### PR TITLE
fix: fixed tests for pretty printer, refactored test functions & methods

### DIFF
--- a/rholang/src/rust/interpreter/compiler/rholang_ast.rs
+++ b/rholang/src/rust/interpreter/compiler/rholang_ast.rs
@@ -696,6 +696,10 @@ impl<'ast> ASTBuilder<'ast> {
         self.arena.alloc(Proc::VarRef(var_ref))
     }
 
+    pub fn alloc_var_from_str(&'ast self, name: &'ast str, pos: SourcePosition) -> &'ast Proc<'ast> {
+        self.alloc_var(Id { name, pos })
+    }
+
     pub fn alloc_par(&'ast self, left: AnnProc<'ast>, right: AnnProc<'ast>) -> &'ast Proc<'ast> {
         self.arena.alloc(Proc::Par { left, right })
     }

--- a/rholang/src/rust/interpreter/pretty_printer.rs
+++ b/rholang/src/rust/interpreter/pretty_printer.rs
@@ -1100,177 +1100,197 @@ impl PrettyPrinter {
 // rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
 #[cfg(test)]
 mod tests {
-    use crate::rust::interpreter::compiler::normalize::{normalize_match_proc, ProcVisitOutputs};
-    use crate::rust::interpreter::compiler::normalizer::ground_normalize_matcher::normalize_ground;
-    use crate::rust::interpreter::compiler::rholang_ast::{Collection, Eval, KeyValuePair, Proc};
-    use crate::rust::interpreter::errors::InterpreterError;
+    use crate::rust::interpreter::compiler::rholang_ast::{
+        ASTBuilder, AnnProc, KeyValuePair, Name, Proc, Var, Id, ProcRemainder
+    };
+    use crate::rust::interpreter::compiler::source_position::SourcePosition;
+    use crate::rust::interpreter::test_utils::utils::{
+        defaults, test, test_normalize_match_proc
+    };
     use crate::rust::interpreter::pretty_printer::PrettyPrinter;
-    use crate::rust::interpreter::test_utils::utils::collection_proc_visit_inputs_and_env;
-    use pretty_assertions;
+    use pretty_assertions::assert_eq;
+
+    // Custom test function for ground expressions
+    fn test_ground_expression(proc: &Proc, expected: &str) {
+        test_normalize_match_proc(
+            proc,
+            defaults(),
+            test("should pretty print correctly", |actual_par, free_map| {
+                let mut printer = PrettyPrinter::new();
+                let printed = printer.build_string_from_message(actual_par);
+                assert_eq!(printed, expected);
+                assert!(free_map.is_empty(), "Expected free map to be empty");
+            })
+        );
+    }
+
+    // Helper function to test collections with PrettyPrinter
+    fn test_pretty_print(name: &str, proc: &Proc, bound_shift: i32, expected: &str) {
+        test_normalize_match_proc(
+            proc,
+            defaults(),
+            test(name,|actual_par, _| {
+                let mut printer = PrettyPrinter::create(0, bound_shift);
+                let printed = printer.build_string_from_message(actual_par);
+                assert_eq!(printed, expected);
+            })
+        );
+    }
+
+    // Helper functions to reduce duplication
+    fn create_id(name: &str, pos: SourcePosition) -> Id {
+        Id {
+            name,
+            pos
+        }
+    }
+
+    fn create_remainder(name: &str, pos: SourcePosition) -> ProcRemainder {
+        ProcRemainder {
+            var: Var::new_id(name, pos),
+            pos,
+        }
+    }
 
     //ground tests
     #[test]
     fn bool_true_should_print_as_true() {
-        let proc = Proc::new_proc_bool(true);
-        let expr = normalize_ground(&proc).unwrap();
-        let mut printer = PrettyPrinter::new();
-
-        assert_eq!(printer.build_string_from_expr(&expr), "true");
+        test_ground_expression(&Proc::BoolLiteral(true), "true");
     }
 
     #[test]
     fn bool_false_should_print_as_false() {
-        let proc = Proc::new_proc_bool(false);
-        let expr = normalize_ground(&proc).unwrap();
-        let mut printer = PrettyPrinter::new();
-
-        assert_eq!(printer.build_string_from_expr(&expr), "false");
+        test_ground_expression(&Proc::BoolLiteral(false), "false");
     }
 
     #[test]
     fn ground_int_should_print_as_string_int() {
-        let proc = Proc::new_proc_int(7);
-        let expr = normalize_ground(&proc).unwrap();
-        let mut printer = PrettyPrinter::new();
-
-        assert_eq!(printer.build_string_from_expr(&expr), "7".to_string());
+        test_ground_expression(&Proc::LongLiteral(7), "7");
     }
 
     #[test]
     fn ground_string_should_print_as_string() {
-        let proc = Proc::new_proc_string("String".to_string());
-        let expr = normalize_ground(&proc).unwrap();
-        let target: String = "\"String\"".to_string();
-        let mut printer = PrettyPrinter::new();
-
-        assert_eq!(printer.build_string_from_expr(&expr), target);
+        test_ground_expression(&Proc::StringLiteral("String"), "\"String\"");
     }
 
     #[test]
     fn ground_uri_should_print_with_back_ticks() {
-        let proc = Proc::new_proc_uri("Uri".to_string());
-        let expr = normalize_ground(&proc).unwrap();
-        let target: String = "`Uri`".to_string();
-        let mut printer = PrettyPrinter::new();
-
-        assert_eq!(printer.build_string_from_expr(&expr), target);
+        let ast_builder = ASTBuilder::with_capacity(64);
+        let uri = "Uri".into();
+        let uri_literal = ast_builder.alloc_uri_literal(uri);
+        test_ground_expression(uri_literal, "`Uri`");
     }
 
     //collections tests
     #[test]
     fn list_should_print() {
-        let (inputs, env) = collection_proc_visit_inputs_and_env();
-        let proc = Proc::Collection(Collection::List {
-            elements: vec![
-                Proc::new_proc_var("P"),
-                Eval::new_eval_name_var("x"),
-                Proc::new_proc_int(7),
-            ],
-            cont: Some(Box::new(Proc::new_proc_var("ignored"))),
-            line_num: 0,
-            col_num: 0,
-        });
+        let ast_builder = ASTBuilder::with_capacity(64);
+        let pos = SourcePosition::default();
 
-        let mut printer = PrettyPrinter::create(0, 2);
-        let normalizer_result: Result<ProcVisitOutputs, InterpreterError> =
-            normalize_match_proc(&proc, inputs.clone(), &env);
-        let normalizer_result_as_par = &normalizer_result.unwrap().par;
-        let result = printer.build_string_from_message(normalizer_result_as_par);
+        let p_var = ast_builder.alloc_var(create_id("P", pos));
+        let x_name = Name::ProcVar(Var::new_id("x", pos));
+        let x_eval = ast_builder.alloc_eval(x_name.annotated(pos));
+        let int_proc = ast_builder.alloc_long_literal(7);
 
-        assert_eq!(result, "[x0, x1, 7...free0]");
+        // Create elements and remainder
+        let elements = vec![
+            AnnProc { proc: p_var, pos },
+            AnnProc { proc: x_eval, pos },
+            AnnProc { proc: int_proc, pos },
+        ];
+        let remainder = create_remainder("ignored", pos);
+
+        let list_proc = ast_builder.alloc_list_with_remainder(elements, remainder);
+        test_pretty_print("list should print", list_proc, 2, "[x0, x1, 7...free0]");
     }
 
     #[test]
     fn set_should_print() {
-        let (inputs, env) = collection_proc_visit_inputs_and_env();
-        let proc = Proc::Collection(Collection::Set {
-            elements: vec![
-                Proc::new_proc_var("P"),
-                Eval::new_eval_name_var("x"),
-                Proc::new_proc_int(7),
-            ],
-            cont: Some(Box::new(Proc::new_proc_var("ignored"))),
-            line_num: 0,
-            col_num: 0,
-        });
+        let ast_builder = ASTBuilder::with_capacity(64);
+        let pos = SourcePosition::default();
 
-        let mut printer = PrettyPrinter::create(0, 2);
-        let normalizer_result: Result<ProcVisitOutputs, InterpreterError> =
-            normalize_match_proc(&proc, inputs.clone(), &env);
-        let normalizer_result_as_par = &normalizer_result.unwrap().par;
-        let result = printer.build_string_from_message(normalizer_result_as_par);
+        let p_var = ast_builder.alloc_var(create_id("P", pos));
+        let x_name = Name::ProcVar(Var::new_id("x", pos));
+        let x_eval = ast_builder.alloc_eval(x_name.annotated(pos));
+        let int_proc = ast_builder.alloc_long_literal(7);
 
-        assert_eq!(result, "Set(7, x1, x0...free0)");
+        // Create elements and remainder
+        let elements = vec![
+            AnnProc { proc: p_var, pos },
+            AnnProc { proc: x_eval, pos },
+            AnnProc { proc: int_proc, pos },
+        ];
+        let remainder = create_remainder("ignored", pos);
+
+        let set_proc = ast_builder.alloc_set_with_remainder(elements, remainder);
+        test_pretty_print("set should print", set_proc, 2, "Set(7, x1, x0...free0)");
     }
 
     #[test]
     fn map_should_print() {
-        let (inputs, env) = collection_proc_visit_inputs_and_env();
-        let proc = Proc::Collection(Collection::Map {
-            pairs: vec![
-                KeyValuePair {
-                    key: Proc::new_proc_int(7),
-                    value: Proc::new_proc_string("Seven".to_string()),
-                    line_num: 0,
-                    col_num: 0,
-                },
-                KeyValuePair {
-                    key: Proc::new_proc_var("P"),
-                    value: Eval::new_eval_name_var("x"),
-                    line_num: 0,
-                    col_num: 0,
-                },
-            ],
-            cont: Some(Box::new(Proc::new_proc_var("ignored"))),
-            line_num: 0,
-            col_num: 0,
-        });
+        let ast_builder = ASTBuilder::with_capacity(64);
+        let pos = SourcePosition::default();
 
-        let mut printer = PrettyPrinter::create(0, 2);
-        let normalizer_result: Result<ProcVisitOutputs, InterpreterError> =
-            normalize_match_proc(&proc, inputs.clone(), &env);
-        let normalizer_result_as_par = &normalizer_result.unwrap().par;
-        let result = printer.build_string_from_message(normalizer_result_as_par);
+        let p_var = ast_builder.alloc_var(create_id("P", pos));
+        let x_name = Name::ProcVar(Var::new_id("x", pos));
+        let x_eval = ast_builder.alloc_eval(x_name.annotated(pos));
+        let int_proc = ast_builder.alloc_long_literal(7);
+        let string_proc = ast_builder.alloc_string_literal("Seven");
 
-        assert_eq!(result, "{7 : \"Seven\", x0 : x1...free0}");
+        let pairs = vec![
+            KeyValuePair {
+                key: AnnProc { proc: int_proc, pos },
+                value: AnnProc { proc: string_proc, pos },
+            },
+            KeyValuePair {
+                key: AnnProc { proc: p_var, pos },
+                value: AnnProc { proc: x_eval, pos },
+            },
+        ];
+        let remainder = create_remainder("ignored", pos);
+
+        let map_proc = ast_builder.alloc_map_with_remainder(pairs, remainder);
+        test_pretty_print("map should print", map_proc, 2, "{7 : \"Seven\", x0 : x1...free0}");
     }
 
     #[test]
     fn map_should_print_commas_correctly() {
-        let (inputs, env) = collection_proc_visit_inputs_and_env();
-        let proc = Proc::Collection(Collection::Map {
-            pairs: vec![
-                KeyValuePair {
-                    key: Proc::new_proc_string("c".to_string()),
-                    value: Proc::new_proc_int(3),
-                    line_num: 0,
-                    col_num: 0,
-                },
-                KeyValuePair {
-                    key: Proc::new_proc_string("b".to_string()),
-                    value: Proc::new_proc_int(2),
-                    line_num: 0,
-                    col_num: 0,
-                },
-                KeyValuePair {
-                    key: Proc::new_proc_string("a".to_string()),
-                    value: Proc::new_proc_int(1),
-                    line_num: 0,
-                    col_num: 0,
-                },
-            ],
-            cont: None,
-            line_num: 0,
-            col_num: 0,
-        });
+        let ast_builder = ASTBuilder::with_capacity(64);
+        let pos = SourcePosition::default();
 
-        let mut printer = PrettyPrinter::new();
-        let normalizer_result: Result<ProcVisitOutputs, InterpreterError> =
-            normalize_match_proc(&proc, inputs.clone(), &env);
-        let normalizer_result_as_par = &normalizer_result.unwrap().par;
-        let result = printer.build_string_from_message(normalizer_result_as_par);
+        let a_proc = ast_builder.alloc_string_literal("a");
+        let b_proc = ast_builder.alloc_string_literal("b");
+        let c_proc = ast_builder.alloc_string_literal("c");
 
-        let target = r#"{"a" : 1, "b" : 2, "c" : 3}"#;
-        assert_eq!(result, target);
+        let one_proc = ast_builder.alloc_long_literal(1);
+        let two_proc = ast_builder.alloc_long_literal(2);
+        let three_proc = ast_builder.alloc_long_literal(3);
+
+        let pairs = vec![
+            KeyValuePair {
+                key: AnnProc { proc: c_proc, pos },
+                value: AnnProc { proc: three_proc, pos },
+            },
+            KeyValuePair {
+                key: AnnProc { proc: b_proc, pos },
+                value: AnnProc { proc: two_proc, pos },
+            },
+            KeyValuePair {
+                key: AnnProc { proc: a_proc, pos },
+                value: AnnProc { proc: one_proc, pos },
+            },
+        ];
+
+
+        let map_proc = ast_builder.alloc_map(pairs);
+        test_normalize_match_proc(
+            map_proc,
+            defaults(),
+            test("should print commas correctly", |actual_par, _| {
+                let mut printer = PrettyPrinter::new();
+                let printed = printer.build_string_from_message(actual_par);
+                assert_eq!(printed, r#"{"a" : 1, "b" : 2, "c" : 3}"#);
+            })
+        );
     }
 }

--- a/rholang/src/rust/interpreter/sorter.rs
+++ b/rholang/src/rust/interpreter/sorter.rs
@@ -9,8 +9,8 @@ impl<'a> ParSorter<'a> {
         ParSorter(par)
     }
 
-    pub fn into_score_tree<'b, Builder: ScoreBuilder>(
-        sorted_par: &'b Sorted<Par>,
+    pub fn convert_to_score_tree<Builder: ScoreBuilder>(
+        sorted_par: &Sorted<Par>,
         score: &mut Builder,
     ) {
         let mut holes = Vec::with_capacity(10);
@@ -25,14 +25,14 @@ impl<'a> ParSorter<'a> {
             match holes.pop() {
                 Some(hole) => {
                     score.focus(hole.location);
-                    Self::into_score_tree_inner(hole.par, score, &mut holes);
+                    Self::process_score_tree_node(hole.par, score, &mut holes);
                 }
                 None => break,
             }
         }
     }
 
-    fn into_score_tree_inner<'b, B: ScoreBuilder>(
+    fn process_score_tree_node<'b, B: ScoreBuilder>(
         par: &'b Par,
         score: &mut B,
         holes: &mut Vec<Hole<'b>>,
@@ -693,7 +693,7 @@ impl<'a> SortMatcher for ExprSorter<'a> {
 
                 body.ps.iter().for_each(|(k, v)| {
                     k.graft_into(score);
-                    ParSorter::into_score_tree(v, score)
+                    ParSorter::convert_to_score_tree(v, score)
                 });
                 remainder_score(body.remainder, -1, score);
                 score.leaf_bool(body.connective_used);


### PR DESCRIPTION
Key changes:

- Fixed non-working tests in `pretty_printer.rs`
- Performed full refactoring of tests, removed deprecated dependencies and functions
- Switched to using test_normalize_match_proc function for ground expressions
- I wrote some helper functions to avoid bloating test cases
- Added new function `alloc_var_from_str` to `rholang_ast`