### PR TITLE
Refactored and fixed normalize tests

### DIFF
--- a/rholang/src/rust/interpreter/compiler/normalizer/collection_normalize_matcher.rs
+++ b/rholang/src/rust/interpreter/compiler/normalizer/collection_normalize_matcher.rs
@@ -182,6 +182,7 @@ mod tests {
     use bitvec::vec::BitVec;
     use bitvec::{bitvec, order::Lsb0};
     use pretty_assertions::assert_eq;
+    use crate::assert_matches;
 
     #[test]
     fn list_should_delegate() {

--- a/rholang/src/rust/interpreter/compiler/normalizer/name_normalize_matcher.rs
+++ b/rholang/src/rust/interpreter/compiler/normalizer/name_normalize_matcher.rs
@@ -78,6 +78,7 @@ mod tests {
     };
     use bitvec::{bitvec, order::Lsb0};
     use pretty_assertions::assert_eq;
+    use crate::assert_matches;
 
     #[test]
     fn name_wildcard_should_add_a_wildcard_count_to_known_free() {

--- a/rholang/src/rust/interpreter/compiler/normalizer/processes/p_match_normalizer.rs
+++ b/rholang/src/rust/interpreter/compiler/normalizer/processes/p_match_normalizer.rs
@@ -92,9 +92,11 @@ mod tests {
         },
         normal_forms::{EListBody, Expr, Match, MatchCase, Par, Receive, ReceiveBind, Send},
         test_utils::utils::*,
+        test_utils::utils::assert_matches
     };
     use bitvec::{bitvec, order::Lsb0, vec::BitVec};
     use pretty_assertions::assert_eq;
+    use crate::assert_matches;
 
     #[test]
     fn p_match_should_handle_a_match_inside_a_for_comprehension() {

--- a/rholang/src/rust/interpreter/compiler/normalizer/processes/p_send_normalizer.rs
+++ b/rholang/src/rust/interpreter/compiler/normalizer/processes/p_send_normalizer.rs
@@ -80,6 +80,7 @@ mod tests {
     use super::{Proc, SourcePosition};
     use bitvec::{bitvec, order::Lsb0};
     use pretty_assertions::assert_eq;
+    use crate::assert_matches;
 
     #[test]
     fn p_send_should_handle_a_basic_send() {

--- a/rholang/src/rust/interpreter/test_utils/utils.rs
+++ b/rholang/src/rust/interpreter/test_utils/utils.rs
@@ -106,3 +106,27 @@ pub(crate) fn assert_equal_normalized(lhs: &str, rhs: &str) {
     })
     .expect("Normalization expected not to fail");
 }
+
+#[macro_export]
+macro_rules! assert_matches {
+    ($expression:expr, $pattern:pat => $assertions:block) => {
+        match $expression {
+            $pattern => $assertions,
+            other => panic!(
+                "assertion failed: `{:?}` does not match pattern `{}`",
+                other,
+                stringify!($pattern)
+            ),
+        }
+    };
+}
+
+pub fn assert_matches<T, F>(result: Result<T, InterpreterError>, matcher: F)
+where
+    F: FnOnce(InterpreterError),
+{
+    match result {
+        Ok(_) => panic!("Expected an error, but got Ok"),
+        Err(e) => matcher(e),
+    }
+}


### PR DESCRIPTION
Key changes:

- Fixed non-working tests in `normalize.rs`
- Performed full refactoring of tests, removed deprecated dependencies and functions
- Added `BinaryOp` enum with `binary_op_to_expr_constructor` function to simplify future development, remove repetition and unify binary operations in one place
- Reimplemented `assert_matches`, made two variants - through macro and as a function. This fixed a problem with some tests not only in `normalizer`, but also in many others that had a dependency on `assert_matches` rule.