### PR TITLE
Adds a new internal API for the LSP-based language server

### DIFF
--- a/node/src/main/protobuf/lsp.proto
+++ b/node/src/main/protobuf/lsp.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+package lsp;
+
+// If you are building for other languages "scalapb.proto"
+// can be manually obtained here:
+// https://raw.githubusercontent.com/scalapb/ScalaPB/master/protobuf/scalapb/scalapb.proto
+// make a scalapb directory in this file's location and place it inside
+
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+    package_name: "coop.rchain.node.model"
+};
+
+service Lsp {
+    rpc Validate (ValidateRequest) returns (ValidateResponse) {}
+}
+
+message ValidateRequest {
+    string text = 1;
+}
+
+message ValidateResponse {
+    string message = 1;
+}

--- a/node/src/main/scala/coop/rchain/node/api/LspService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/LspService.scala
@@ -1,0 +1,41 @@
+package coop.rchain.node.api
+
+import cats.effect.Sync
+import cats.syntax.all._
+import coop.rchain.models.Par
+import coop.rchain.monix.Monixable
+import coop.rchain.node.model.lsp.{LspGrpcMonix, ValidateRequest, ValidateResponse}
+import coop.rchain.rholang.interpreter.compiler.Compiler
+import coop.rchain.rholang.interpreter.errors.InterpreterError
+import coop.rchain.rholang.interpreter.RhoRuntime
+import coop.rchain.shared.syntax._
+import monix.eval.Task
+import monix.execution.Scheduler
+
+object LspService {
+
+  def apply[F[_]: Monixable: Sync](worker: Scheduler): LspGrpcMonix.Lsp =
+    new LspGrpcMonix.Lsp {
+      def validate(source: String): F[ValidateResponse] =
+        Sync[F]
+          .attempt(
+            Compiler[F]
+              .sourceToADT(source, Map.empty[String, Par])
+          )
+          .flatMap {
+            case Left(er) =>
+              er match {
+                case _: InterpreterError => Sync[F].delay(s"Error: ${er.toString}")
+                case th: Throwable       => Sync[F].delay(s"Error: $th")
+              }
+            case Right(_) => Sync[F].delay("")
+          }
+          .map(ValidateResponse(_))
+
+      private def defer[A](task: F[A]): Task[A] =
+        task.toTask.executeOn(worker)
+
+      def validate(request: ValidateRequest): Task[ValidateResponse] =
+        defer(validate(request.text))
+    }
+}

--- a/node/src/main/scala/coop/rchain/node/api/package.scala
+++ b/node/src/main/scala/coop/rchain/node/api/package.scala
@@ -6,6 +6,7 @@ import cats.effect.{Concurrent, Sync}
 import coop.rchain.casper.protocol.deploy.v1.DeployServiceV1GrpcMonix
 import coop.rchain.casper.protocol.propose.v1.ProposeServiceV1GrpcMonix
 import coop.rchain.grpc.{GrpcServer, Server}
+import coop.rchain.node.model.lsp._
 import coop.rchain.node.model.repl._
 import coop.rchain.shared._
 import io.grpc.netty.NettyServerBuilder
@@ -23,6 +24,7 @@ package object api {
       replGrpcService: ReplGrpcMonix.Repl,
       deployGrpcService: DeployServiceV1GrpcMonix.DeployService,
       proposeGrpcService: ProposeServiceV1GrpcMonix.ProposeService,
+      lspGrpcService: LspGrpcMonix.Lsp,
       maxMessageSize: Int,
       keepAliveTime: FiniteDuration,
       keepAliveTimeout: FiniteDuration,
@@ -46,6 +48,9 @@ package object api {
         .addService(
           DeployServiceV1GrpcMonix
             .bindService(deployGrpcService, grpcExecutor)
+        )
+        .addService(
+          LspGrpcMonix.bindService(lspGrpcService, grpcExecutor)
         )
         .keepAliveTime(keepAliveTime.length, keepAliveTime.unit)
         .keepAliveTimeout(keepAliveTimeout.length, keepAliveTimeout.unit)

--- a/node/src/main/scala/coop/rchain/node/runtime/APIServers.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/APIServers.scala
@@ -13,7 +13,8 @@ import coop.rchain.comm.discovery.NodeDiscovery
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.monix.Monixable
-import coop.rchain.node.api.{DeployGrpcServiceV1, ProposeGrpcServiceV1, ReplGrpcService}
+import coop.rchain.node.api.{DeployGrpcServiceV1, LspService, ProposeGrpcServiceV1, ReplGrpcService}
+import coop.rchain.node.model.lsp.LspGrpcMonix
 import coop.rchain.node.model.repl.ReplGrpcMonix
 import coop.rchain.rholang.interpreter.RhoRuntime
 import coop.rchain.shared.Log
@@ -22,7 +23,8 @@ import monix.execution.Scheduler
 final case class APIServers(
     repl: ReplGrpcMonix.Repl,
     propose: ProposeServiceV1GrpcMonix.ProposeService,
-    deploy: DeployServiceV1GrpcMonix.DeployService
+    deploy: DeployServiceV1GrpcMonix.DeployService,
+    lsp: LspGrpcMonix.Lsp
 )
 
 object APIServers {
@@ -64,6 +66,7 @@ object APIServers {
         isNodeReadOnly
       )
     val propose = ProposeGrpcServiceV1(triggerProposeFOpt, proposerStateRefOpt)
-    APIServers(repl, propose, deploy)
+    val lsp     = LspService(mainScheduler)
+    APIServers(repl, propose, deploy, lsp)
   }
 }

--- a/node/src/main/scala/coop/rchain/node/runtime/ServersInstances.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/ServersInstances.scala
@@ -125,6 +125,7 @@ object ServersInstances {
           apiServers.repl,
           apiServers.deploy,
           apiServers.propose,
+          apiServers.lsp,
           nodeConf.apiServer.grpcMaxRecvMessageSize.toInt,
           nodeConf.apiServer.keepAliveTime,
           nodeConf.apiServer.keepAliveTimeout,


### PR DESCRIPTION
## Overview
The prototype validated Rholang code by evaluating it with the internal Repl API. This behavior, for validation, is less than ideal since any non-problematic code was evaluated within an RSpace context. It is not desirable to insert new records into RSpace each time a document is successfully validated, and it does not make sense to extend the Repl API with LSP-specific methods, so this PR adds a new LSP-specific API. The first method it supports is `validate` but many more will be added and `validate` will be improved.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
