### PR TITLE
Updates the Validate LSP API method to return sequences of diagnostics

### DIFF
--- a/node/src/main/protobuf/lsp.proto
+++ b/node/src/main/protobuf/lsp.proto
@@ -20,6 +20,37 @@ message ValidateRequest {
     string text = 1;
 }
 
+message Position {
+    uint64 line = 1;
+    uint64 column = 2;
+}
+
+message Range {
+    Position start = 1;
+    Position end = 2;
+}
+
+enum DiagnosticSeverity {
+    ERROR = 0;
+    WARNING = 1;
+    INFORMATION = 2;
+    HINT = 3;
+}
+
+message Diagnostic {
+    Range range = 1;
+    DiagnosticSeverity severity = 2;
+    string source = 3;
+    string message = 4;
+}
+
+message DiagnosticList {
+    repeated Diagnostic diagnostics = 1;
+}
+
 message ValidateResponse {
-    string message = 1;
+    oneof result {
+        DiagnosticList success = 1;
+        string error = 2;
+    }
 }

--- a/node/src/main/scala/coop/rchain/node/api/LspService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/LspService.scala
@@ -1,21 +1,87 @@
 package coop.rchain.node.api
 
+import java.io.{PrintWriter, StringWriter}
+import scala.util.matching.Regex
 import cats.effect.Sync
 import cats.syntax.all._
 import coop.rchain.models.Par
 import coop.rchain.monix.Monixable
-import coop.rchain.node.model.lsp.{LspGrpcMonix, ValidateRequest, ValidateResponse}
-import coop.rchain.rholang.interpreter.compiler.Compiler
-import coop.rchain.rholang.interpreter.errors.InterpreterError
+import coop.rchain.node.model.lsp.{
+  Diagnostic,
+  DiagnosticList,
+  DiagnosticSeverity,
+  LspGrpcMonix,
+  Position,
+  Range,
+  ValidateRequest,
+  ValidateResponse
+}
+import coop.rchain.rholang.interpreter.compiler.{Compiler, SourcePosition}
+import coop.rchain.rholang.interpreter.errors.{
+  InterpreterError,
+  LexerError,
+  ReceiveOnSameChannelsError,
+  SyntaxError,
+  UnboundVariableRef,
+  UnexpectedNameContext,
+  UnexpectedProcContext,
+  UnexpectedReuseOfNameContextFree,
+  UnexpectedReuseOfProcContextFree
+}
 import coop.rchain.rholang.interpreter.RhoRuntime
 import coop.rchain.shared.syntax._
 import monix.eval.Task
 import monix.execution.Scheduler
 
 object LspService {
+  val SOURCE: String         = "rholang"
+  val RE_SYNTAX_ERROR: Regex = """syntax error\([^)]*\): .* at (\d+):(\d+)-(\d+):(\d+)""".r
+  val RE_LEXER_ERROR: Regex  = """.* at (\d+):(\d+)\(\d+\)""".r
 
   def apply[F[_]: Monixable: Sync](worker: Scheduler): LspGrpcMonix.Lsp =
     new LspGrpcMonix.Lsp {
+      def validation(
+          startLine: Int,
+          startColumn: Int,
+          endLine: Int,
+          endColumn: Int,
+          message: String
+      ): Seq[Diagnostic] =
+        Seq(
+          Diagnostic(
+            range = Some(
+              Range(
+                start = Some(
+                  Position(
+                    line = startLine.toLong - 1L,
+                    column = startColumn.toLong - 1L
+                  )
+                ),
+                end = Some(
+                  Position(
+                    line = endLine.toLong - 1L,
+                    column = endColumn.toLong - 1L
+                  )
+                )
+              )
+            ),
+            severity = DiagnosticSeverity.ERROR,
+            source = SOURCE,
+            message = message
+          )
+        )
+
+      def default_validation(source: String, message: String): Seq[Diagnostic] = {
+        val (lastLine, lastColumn) = source.foldLeft((0, 0)) {
+          case ((line, column), char) =>
+            char match {
+              case '\n' => (line + 1, 0)
+              case _    => (line, column + 1)
+            }
+        }
+        validation(0, 0, lastLine, lastColumn, message)
+      }
+
       def validate(source: String): F[ValidateResponse] =
         Sync[F]
           .attempt(
@@ -25,12 +91,91 @@ object LspService {
           .flatMap {
             case Left(er) =>
               er match {
-                case _: InterpreterError => Sync[F].delay(s"Error: ${er.toString}")
-                case th: Throwable       => Sync[F].delay(s"Error: $th")
+                case ie: InterpreterError =>
+                  Sync[F].delay(
+                    ValidateResponse(
+                      result = ValidateResponse.Result.Success(
+                        DiagnosticList(
+                          diagnostics = ie match {
+                            case UnboundVariableRef(varName, line, column) =>
+                              validation(line, column, line, column + varName.length, er.getMessage)
+                            case UnexpectedNameContext(
+                                varName,
+                                _,
+                                SourcePosition(line, column)
+                                ) =>
+                              validation(line, column, line, column + varName.length, er.getMessage)
+                            case UnexpectedReuseOfNameContextFree(
+                                varName,
+                                _,
+                                SourcePosition(line, column)
+                                ) =>
+                              validation(line, column, line, column + varName.length, er.getMessage)
+                            case UnexpectedProcContext(
+                                varName,
+                                _,
+                                SourcePosition(line, column)
+                                ) =>
+                              validation(line, column, line, column + varName.length, er.getMessage)
+                            case UnexpectedReuseOfProcContextFree(
+                                varName,
+                                _,
+                                SourcePosition(line, column)
+                                ) =>
+                              validation(line, column, line, column + varName.length, er.getMessage)
+                            case ReceiveOnSameChannelsError(line, column) =>
+                              validation(line, column, line, column, er.getMessage)
+                            case SyntaxError(message) =>
+                              message match {
+                                case RE_SYNTAX_ERROR(startLine, startColumn, endLine, endColumn) =>
+                                  validation(
+                                    Integer.parseInt(startLine),
+                                    Integer.parseInt(startColumn),
+                                    Integer.parseInt(endLine),
+                                    Integer.parseInt(endColumn),
+                                    er.getMessage
+                                  )
+                                case _ => default_validation(source, er.getMessage)
+                              }
+                            case LexerError(message) =>
+                              message match {
+                                case RE_LEXER_ERROR(lineStr, columnStr) => {
+                                  val line   = Integer.parseInt(lineStr)
+                                  val column = Integer.parseInt(columnStr)
+                                  validation(line, column, line, column, er.getMessage)
+                                }
+                                case _ => default_validation(source, er.getMessage)
+                              }
+                            case _ => default_validation(source, er.getMessage)
+                          }
+                        )
+                      )
+                    )
+                  )
+                case th: Throwable =>
+                  Sync[F].delay(
+                    ValidateResponse(
+                      result = ValidateResponse.Result.Error(
+                        {
+                          val sw = new StringWriter();
+                          th.printStackTrace(new PrintWriter(sw));
+                          s"${th.getMessage()}\n$sw"
+                        }
+                      )
+                    )
+                  )
               }
-            case Right(_) => Sync[F].delay("")
+            case Right(_) =>
+              Sync[F].delay(
+                ValidateResponse(
+                  result = ValidateResponse.Result.Success(
+                    DiagnosticList(
+                      diagnostics = Seq()
+                    )
+                  )
+                )
+              )
           }
-          .map(ValidateResponse(_))
 
       private def defer[A](task: F[A]): Task[A] =
         task.toTask.executeOn(worker)


### PR DESCRIPTION
## Overview

Returns additional diagnostic information from the Validate LSP API method to reduce the likelihood of breaking how the messages are parsed by the language server while transforming them into diagnostics for the client.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
