### PR TITLE
Cherry-picks LSP API changes from main

### DIFF
--- a/node/src/main/protobuf/lsp.proto
+++ b/node/src/main/protobuf/lsp.proto
@@ -1,0 +1,56 @@
+syntax = "proto3";
+package lsp;
+
+// If you are building for other languages "scalapb.proto"
+// can be manually obtained here:
+// https://raw.githubusercontent.com/scalapb/ScalaPB/master/protobuf/scalapb/scalapb.proto
+// make a scalapb directory in this file's location and place it inside
+
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+    package_name: "coop.rchain.node.model"
+};
+
+service Lsp {
+    rpc Validate (ValidateRequest) returns (ValidateResponse) {}
+}
+
+message ValidateRequest {
+    string text = 1;
+}
+
+message Position {
+    uint64 line = 1;
+    uint64 column = 2;
+}
+
+message Range {
+    Position start = 1;
+    Position end = 2;
+}
+
+enum DiagnosticSeverity {
+    ERROR = 0;
+    WARNING = 1;
+    INFORMATION = 2;
+    HINT = 3;
+}
+
+message Diagnostic {
+    Range range = 1;
+    DiagnosticSeverity severity = 2;
+    string source = 3;
+    string message = 4;
+}
+
+message DiagnosticList {
+    repeated Diagnostic diagnostics = 1;
+}
+
+message ValidateResponse {
+    oneof result {
+        DiagnosticList success = 1;
+        string error = 2;
+    }
+}

--- a/node/src/main/scala/coop/rchain/node/api/LspService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/LspService.scala
@@ -1,0 +1,186 @@
+package coop.rchain.node.api
+
+import java.io.{PrintWriter, StringWriter}
+import scala.util.matching.Regex
+import cats.effect.Sync
+import cats.syntax.all._
+import coop.rchain.models.Par
+import coop.rchain.monix.Monixable
+import coop.rchain.node.model.lsp.{
+  Diagnostic,
+  DiagnosticList,
+  DiagnosticSeverity,
+  LspGrpcMonix,
+  Position,
+  Range,
+  ValidateRequest,
+  ValidateResponse
+}
+import coop.rchain.rholang.interpreter.compiler.{Compiler, SourcePosition}
+import coop.rchain.rholang.interpreter.errors.{
+  InterpreterError,
+  LexerError,
+  ReceiveOnSameChannelsError,
+  SyntaxError,
+  UnboundVariableRef,
+  UnexpectedNameContext,
+  UnexpectedProcContext,
+  UnexpectedReuseOfNameContextFree,
+  UnexpectedReuseOfProcContextFree
+}
+import coop.rchain.rholang.interpreter.RhoRuntime
+import coop.rchain.shared.syntax._
+import monix.eval.Task
+import monix.execution.Scheduler
+
+object LspService {
+  val SOURCE: String         = "rholang"
+  val RE_SYNTAX_ERROR: Regex = """syntax error\([^)]*\): .* at (\d+):(\d+)-(\d+):(\d+)""".r
+  val RE_LEXER_ERROR: Regex  = """.* at (\d+):(\d+)\(\d+\)""".r
+
+  def apply[F[_]: Monixable: Sync](worker: Scheduler): LspGrpcMonix.Lsp =
+    new LspGrpcMonix.Lsp {
+      def validation(
+          startLine: Int,
+          startColumn: Int,
+          endLine: Int,
+          endColumn: Int,
+          message: String
+      ): Seq[Diagnostic] =
+        Seq(
+          Diagnostic(
+            range = Some(
+              Range(
+                start = Some(
+                  Position(
+                    line = startLine.toLong - 1L,
+                    column = startColumn.toLong - 1L
+                  )
+                ),
+                end = Some(
+                  Position(
+                    line = endLine.toLong - 1L,
+                    column = endColumn.toLong - 1L
+                  )
+                )
+              )
+            ),
+            severity = DiagnosticSeverity.ERROR,
+            source = SOURCE,
+            message = message
+          )
+        )
+
+      def default_validation(source: String, message: String): Seq[Diagnostic] = {
+        val (lastLine, lastColumn) = source.foldLeft((0, 0)) {
+          case ((line, column), char) =>
+            char match {
+              case '\n' => (line + 1, 0)
+              case _    => (line, column + 1)
+            }
+        }
+        validation(0, 0, lastLine, lastColumn, message)
+      }
+
+      def validate(source: String): F[ValidateResponse] =
+        Sync[F]
+          .attempt(
+            Compiler[F]
+              .sourceToADT(source, Map.empty[String, Par])
+          )
+          .flatMap {
+            case Left(er) =>
+              er match {
+                case ie: InterpreterError =>
+                  Sync[F].delay(
+                    ValidateResponse(
+                      result = ValidateResponse.Result.Success(
+                        DiagnosticList(
+                          diagnostics = ie match {
+                            case UnboundVariableRef(varName, line, column) =>
+                              validation(line, column, line, column + varName.length, er.getMessage)
+                            case UnexpectedNameContext(
+                                varName,
+                                _,
+                                SourcePosition(line, column)
+                                ) =>
+                              validation(line, column, line, column + varName.length, er.getMessage)
+                            case UnexpectedReuseOfNameContextFree(
+                                varName,
+                                _,
+                                SourcePosition(line, column)
+                                ) =>
+                              validation(line, column, line, column + varName.length, er.getMessage)
+                            case UnexpectedProcContext(
+                                varName,
+                                _,
+                                SourcePosition(line, column)
+                                ) =>
+                              validation(line, column, line, column + varName.length, er.getMessage)
+                            case UnexpectedReuseOfProcContextFree(
+                                varName,
+                                _,
+                                SourcePosition(line, column)
+                                ) =>
+                              validation(line, column, line, column + varName.length, er.getMessage)
+                            case ReceiveOnSameChannelsError(line, column) =>
+                              validation(line, column, line, column, er.getMessage)
+                            case SyntaxError(message) =>
+                              message match {
+                                case RE_SYNTAX_ERROR(startLine, startColumn, endLine, endColumn) =>
+                                  validation(
+                                    Integer.parseInt(startLine),
+                                    Integer.parseInt(startColumn),
+                                    Integer.parseInt(endLine),
+                                    Integer.parseInt(endColumn),
+                                    er.getMessage
+                                  )
+                                case _ => default_validation(source, er.getMessage)
+                              }
+                            case LexerError(message) =>
+                              message match {
+                                case RE_LEXER_ERROR(lineStr, columnStr) => {
+                                  val line   = Integer.parseInt(lineStr)
+                                  val column = Integer.parseInt(columnStr)
+                                  validation(line, column, line, column, er.getMessage)
+                                }
+                                case _ => default_validation(source, er.getMessage)
+                              }
+                            case _ => default_validation(source, er.getMessage)
+                          }
+                        )
+                      )
+                    )
+                  )
+                case th: Throwable =>
+                  Sync[F].delay(
+                    ValidateResponse(
+                      result = ValidateResponse.Result.Error(
+                        {
+                          val sw = new StringWriter();
+                          th.printStackTrace(new PrintWriter(sw));
+                          s"${th.getMessage()}\n$sw"
+                        }
+                      )
+                    )
+                  )
+              }
+            case Right(_) =>
+              Sync[F].delay(
+                ValidateResponse(
+                  result = ValidateResponse.Result.Success(
+                    DiagnosticList(
+                      diagnostics = Seq()
+                    )
+                  )
+                )
+              )
+          }
+
+      private def defer[A](task: F[A]): Task[A] =
+        task.toTask.executeOn(worker)
+
+      def validate(request: ValidateRequest): Task[ValidateResponse] =
+        defer(validate(request.text))
+    }
+}

--- a/node/src/main/scala/coop/rchain/node/api/package.scala
+++ b/node/src/main/scala/coop/rchain/node/api/package.scala
@@ -6,6 +6,7 @@ import cats.effect.{Concurrent, Sync}
 import coop.rchain.casper.protocol.deploy.v1.DeployServiceV1GrpcMonix
 import coop.rchain.casper.protocol.propose.v1.ProposeServiceV1GrpcMonix
 import coop.rchain.grpc.{GrpcServer, Server}
+import coop.rchain.node.model.lsp._
 import coop.rchain.node.model.repl._
 import coop.rchain.shared._
 import io.grpc.netty.NettyServerBuilder
@@ -23,6 +24,7 @@ package object api {
       replGrpcService: ReplGrpcMonix.Repl,
       deployGrpcService: DeployServiceV1GrpcMonix.DeployService,
       proposeGrpcService: ProposeServiceV1GrpcMonix.ProposeService,
+      lspGrpcService: LspGrpcMonix.Lsp,
       maxMessageSize: Int,
       keepAliveTime: FiniteDuration,
       keepAliveTimeout: FiniteDuration,
@@ -46,6 +48,9 @@ package object api {
         .addService(
           DeployServiceV1GrpcMonix
             .bindService(deployGrpcService, grpcExecutor)
+        )
+        .addService(
+          LspGrpcMonix.bindService(lspGrpcService, grpcExecutor)
         )
         .keepAliveTime(keepAliveTime.length, keepAliveTime.unit)
         .keepAliveTimeout(keepAliveTimeout.length, keepAliveTimeout.unit)

--- a/node/src/main/scala/coop/rchain/node/runtime/APIServers.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/APIServers.scala
@@ -13,7 +13,8 @@ import coop.rchain.comm.discovery.NodeDiscovery
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.monix.Monixable
-import coop.rchain.node.api.{DeployGrpcServiceV1, ProposeGrpcServiceV1, ReplGrpcService}
+import coop.rchain.node.api.{DeployGrpcServiceV1, LspService, ProposeGrpcServiceV1, ReplGrpcService}
+import coop.rchain.node.model.lsp.LspGrpcMonix
 import coop.rchain.node.model.repl.ReplGrpcMonix
 import coop.rchain.rholang.interpreter.RhoRuntime
 import coop.rchain.shared.Log
@@ -22,7 +23,8 @@ import monix.execution.Scheduler
 final case class APIServers(
     repl: ReplGrpcMonix.Repl,
     propose: ProposeServiceV1GrpcMonix.ProposeService,
-    deploy: DeployServiceV1GrpcMonix.DeployService
+    deploy: DeployServiceV1GrpcMonix.DeployService,
+    lsp: LspGrpcMonix.Lsp
 )
 
 object APIServers {
@@ -64,6 +66,7 @@ object APIServers {
         isNodeReadOnly
       )
     val propose = ProposeGrpcServiceV1(triggerProposeFOpt, proposerStateRefOpt)
-    APIServers(repl, propose, deploy)
+    val lsp     = LspService(mainScheduler)
+    APIServers(repl, propose, deploy, lsp)
   }
 }

--- a/node/src/main/scala/coop/rchain/node/runtime/ServersInstances.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/ServersInstances.scala
@@ -125,6 +125,7 @@ object ServersInstances {
           apiServers.repl,
           apiServers.deploy,
           apiServers.propose,
+          apiServers.lsp,
           nodeConf.apiServer.grpcMaxRecvMessageSize.toInt,
           nodeConf.apiServer.keepAliveTime,
           nodeConf.apiServer.keepAliveTimeout,


### PR DESCRIPTION
Adds the new LSP API from main for the language server. Presently, the API supports validating Rholang documents and returning diagnostics but it will support many more methods in the near future.
