### PR TITLE
Protect internal depth state of TreeHashMap so clients cannot break a THM instance's invariants

### DIFF
--- a/casper/src/main/resources/Registry.rho
+++ b/casper/src/main/resources/Registry.rho
@@ -56,7 +56,7 @@ in {
 
   new MakeNode, ByteArrayToNybbleList,
       TreeHashMapSetter, TreeHashMapGetter, TreeHashMapContains, TreeHashMapUpdater,
-      powersCh, storeToken, nodeGet in {
+      powersCh, storeToken, nodeGet, depthP in {
     match [1,2,4,8,16,32,64,128,256,512,1024,2048,4096,8192,16384,32768,65536] {
       powers => {
         contract MakeNode(@initVal, @node) = {
@@ -80,8 +80,14 @@ in {
         contract TreeHashMap(@"init", @depth, ret) = {
           new map in {
             MakeNode!(0, (*map, [])) |
-            @(*map, "depth")!!(depth) |
+            @(*map, *depthP)!!(depth) |
             ret!(*map)
+          }
+        } |
+
+        contract TreeHashMap(@"depth", @map, ret) = {
+          for(@depth <- @(map, *depthP)) {
+            ret!(depth)
           }
         } |
 
@@ -113,7 +119,7 @@ in {
             // Hash the key to get a 256-bit array
             keccak256Hash!(key.toByteArray(), *hashCh) |
             for (@hash <- hashCh) {
-              for (@depth <<- @(map, "depth")) {
+              for (@depth <<- @(map, *depthP)) {
                 // Get the bit list
                 ByteArrayToNybbleList!(hash, 0, depth, [], *nybListCh) |
                 for (@nybList <- nybListCh) {
@@ -133,7 +139,7 @@ in {
             // Hash the key to get a 256-bit array
             keccak256Hash!(key.toByteArray(), *hashCh) |
             for (@hash <- hashCh) {
-              for(@depth <<- @(map, "depth")) {
+              for(@depth <<- @(map, *depthP)) {
                 // Get the bit list
                 ByteArrayToNybbleList!(hash, 0, depth, [], *nybListCh) |
                 for (@nybList <- nybListCh) {
@@ -221,7 +227,7 @@ in {
             // Hash the key to get a 256-bit array
             keccak256Hash!(key.toByteArray(), *hashCh) |
             for (@hash <- hashCh) {
-              for (@depth <<- @(map, "depth")) {
+              for (@depth <<- @(map, *depthP)) {
                 // Get the bit list
                 ByteArrayToNybbleList!(hash, 0, depth, [], *nybListCh) |
                 for (@nybList <- nybListCh) {
@@ -256,7 +262,7 @@ in {
             // Hash the key to get a 256-bit array
             keccak256Hash!(key.toByteArray(), *hashCh) |
             for (@hash <- hashCh) {
-              for (@depth <<- @(map, "depth")) {
+              for (@depth <<- @(map, *depthP)) {
                 // Get the bit list
                 ByteArrayToNybbleList!(hash, 0, depth, [], *nybListCh) |
                 for (@nybList <- nybListCh) {
@@ -316,7 +322,7 @@ in {
             // Hash the key to get a 256-bit array
             keccak256Hash!(key.toByteArray(), *hashCh) |
             for (@hash <- hashCh) {
-              for (@depth <<- @(map, "depth")) {
+              for (@depth <<- @(map, *depthP)) {
                 // Get the bit list
                 ByteArrayToNybbleList!(hash, 0, depth, [], *nybListCh) |
                 for (@nybList <- nybListCh) {

--- a/casper/src/test/resources/TreeHashMapTest.rho
+++ b/casper/src/test/resources/TreeHashMapTest.rho
@@ -10,7 +10,8 @@ new
   test_contains_after_set,
   test_get_after_set_to_nil,
   test_contains_after_set_to_nil,
-  test_contention
+  test_contention,
+  test_depth_matches_init
 in {
   rl!(`rho:id:zphjgsfy13h1k85isc8rtwtgt3t9zzt5pjd5ihykfmyapfc4wt3x5h`, *RhoSpecCh) |
   for(@(_, RhoSpec) <- RhoSpecCh) {
@@ -25,7 +26,8 @@ in {
         ("Contains after set returns true", *test_contains_after_set),
         ("Get after set to Nil returns Nil", *test_get_after_set_to_nil),
         ("Contains after set to Nil returns true", *test_contains_after_set_to_nil),
-        ("Works under contention", *test_contention)
+        ("Works under contention", *test_contention),
+        ("Depth matches init", *test_depth_matches_init)
       ])
   } |
 
@@ -213,6 +215,19 @@ in {
             }
           } |
           tryIt!(0, true)
+        }
+      } |
+
+      contract test_depth_matches_init(rhoSpec, _, ackCh) = {
+        new ret, ch in {
+          TreeHashMap!("init", 3, *ret) |
+          for (@thm <- ret) {
+            TreeHashMap!("depth", thm, *ch) |
+            rhoSpec!("assertMany",
+              [
+                ((3, "== <-", *ch), "Depth returns same value provided to init")
+              ], *ackCh)
+          }
         }
       }
     }


### PR DESCRIPTION
## Overview

The previous implementation of TreeHashMap (THM) stored the `depth` parameter on `@(*map, "depth")` by saying `@(*map, "depth")!!(depth)`.  Any client of a THM instance `map` (i.e. one who has the channel `map` in scope) could cause a race condition by saying `@(*map, "depth")!!(wrongDepth)`.

If a process creates its own THM and breaks it, we don't care.  If a process receives a THM from some other process and breaks it, we don't care.  But if two processes Alice and Bob receive the same THM t from a single source and Alice breaks t causing Bob to malfunction, we do care.

This change makes THM instances protect their depth invariant.

### Notes

I did a quick review of all uses of THM in system contracts, and none of them expose the THM directly to clients, so I don't think there's a security issue.

