### PR TITLE
Merging logic fix

### DIFF
--- a/casper/tests/merging/merge_number_channel_spec.rs
+++ b/casper/tests/merging/merge_number_channel_spec.rs
@@ -367,10 +367,7 @@ async fn test_case(
     assert_eq!(RhoNumber::unapply(&res[0]).unwrap(), expected_final_result);
 }
 
-// TODO: Remove ignore once we have a fix for this test
-// This test should be passing. Just commenting out for now.
 #[tokio::test]
-#[ignore]
 async fn multiple_branches_should_reject_deploy_when_mergeable_number_channels_got_negative_number()
 {
     test_case(
@@ -391,8 +388,6 @@ async fn multiple_branches_should_reject_deploy_when_mergeable_number_channels_g
     .await;
 }
 
-// TODO: Remove ignore once we have a fix for this test
-// This test should be passing. Just commenting out for now.
 #[tokio::test]
 async fn multiple_branches_should_reject_deploy_when_mergeable_number_channels_got_overflow() {
     test_case(
@@ -413,8 +408,6 @@ async fn multiple_branches_should_reject_deploy_when_mergeable_number_channels_g
     .await;
 }
 
-// TODO: Remove ignore once we have a fix for this test
-// This test should be passing. Just commenting out for now.
 #[tokio::test]
 async fn multiple_branches_with_normal_rejection_should_choose_from_normal_reject_options() {
     test_case(
@@ -449,10 +442,7 @@ async fn multiple_branches_with_normal_rejection_should_choose_from_normal_rejec
     .await;
 }
 
-// TODO: Remove ignore once we have a fix for this test
-// This test should be passing. Just commenting out for now.
 #[tokio::test]
-#[ignore]
 async fn multiple_branches_should_merge_number_channels() {
     test_case(
         vec![RHO_ST.to_owned()],

--- a/casper/tests/merging/merge_number_channel_spec.rs
+++ b/casper/tests/merging/merge_number_channel_spec.rs
@@ -394,7 +394,6 @@ async fn multiple_branches_should_reject_deploy_when_mergeable_number_channels_g
 // TODO: Remove ignore once we have a fix for this test
 // This test should be passing. Just commenting out for now.
 #[tokio::test]
-#[ignore]
 async fn multiple_branches_should_reject_deploy_when_mergeable_number_channels_got_overflow() {
     test_case(
         vec![RHO_ST.to_owned(), rho_change(10)],

--- a/casper/tests/merging/merge_number_channel_spec.rs
+++ b/casper/tests/merging/merge_number_channel_spec.rs
@@ -416,7 +416,6 @@ async fn multiple_branches_should_reject_deploy_when_mergeable_number_channels_g
 // TODO: Remove ignore once we have a fix for this test
 // This test should be passing. Just commenting out for now.
 #[tokio::test]
-#[ignore]
 async fn multiple_branches_with_normal_rejection_should_choose_from_normal_reject_options() {
     test_case(
         vec![RHO_ST.to_owned(), rho_change(100)],

--- a/rholang/src/rust/interpreter/merging/rholang_merging_logic.rs
+++ b/rholang/src/rust/interpreter/merging/rholang_merging_logic.rs
@@ -65,7 +65,7 @@ impl RholangMergingLogic {
 
                 for (ch, end_val) in end_val_map {
                     if let Some(prev_val) = state.get(&ch) {
-                        let diff = end_val - prev_val;
+                        let diff = end_val.wrapping_sub(*prev_val);
                         diffs.insert(ch.clone(), diff);
                         state.insert(ch, end_val);
                     }

--- a/rholang/src/rust/interpreter/rho_runtime.rs
+++ b/rholang/src/rust/interpreter/rho_runtime.rs
@@ -102,7 +102,7 @@ pub trait RhoRuntime: HasCost {
         initial_phlo: Cost,
         normalizer_env: HashMap<String, Par>,
     ) -> Result<EvaluateResult, InterpreterError> {
-        let rand = Blake2b512Random::create_from_bytes(&[0; 128]);
+        let rand = Blake2b512Random::create_from_length(128);
         let checkpoint = self.create_soft_checkpoint();
         match self
             .evaluate(term, initial_phlo, normalizer_env, rand)

--- a/rspace++/src/rspace/history/history_repository_impl.rs
+++ b/rspace++/src/rspace/history/history_repository_impl.rs
@@ -17,9 +17,7 @@ use crate::rspace::hot_store_trie_action::{
     HotStoreTrieAction, TrieDeleteAction, TrieDeleteConsume, TrieDeleteJoins, TrieDeleteProduce,
     TrieInsertAction, TrieInsertConsume, TrieInsertJoins, TrieInsertProduce,
 };
-use crate::rspace::serializers::serializers::{
-    encode_binary, encode_continuations, encode_datums, encode_joins,
-};
+use crate::rspace::serializers::serializers::{encode_continuations, encode_datums, encode_joins};
 use crate::rspace::state::rspace_exporter::RSpaceExporter;
 use crate::rspace::state::rspace_importer::RSpaceImporter;
 use log::debug;
@@ -148,7 +146,7 @@ where
                 )
             }
             HotStoreTrieAction::TrieInsertAction(TrieInsertAction::TrieInsertBinaryProduce(i)) => {
-                let data = encode_binary(&i.data);
+                let data = bincode::serialize(&i.data).expect("Failed to serialize Vec<Vec<u8>>");
                 let data_leaf = DataLeaf { bytes: data };
                 let data_leaf_encoded = bincode::serialize(&data_leaf)
                     .expect("History Repository Impl: Unable to serialize DataLeaf");
@@ -163,7 +161,8 @@ where
                 )
             }
             HotStoreTrieAction::TrieInsertAction(TrieInsertAction::TrieInsertBinaryConsume(i)) => {
-                let data = encode_binary(&i.continuations);
+                let data =
+                    bincode::serialize(&i.continuations).expect("Failed to serialize Vec<Vec<u8>>");
                 let continuations_leaf = ContinuationsLeaf { bytes: data };
                 let continuations_leaf_encoded = bincode::serialize(&continuations_leaf)
                     .expect("History Repository Impl: Unable to serialize ContinuationsLeaf");
@@ -181,7 +180,7 @@ where
                 )
             }
             HotStoreTrieAction::TrieInsertAction(TrieInsertAction::TrieInsertBinaryJoins(i)) => {
-                let data = encode_binary(&i.joins);
+                let data = bincode::serialize(&i.joins).expect("Failed to serialize Vec<Vec<u8>>");
                 let joins_leaf = JoinsLeaf { bytes: data };
                 let joins_leaf_encoded = bincode::serialize(&joins_leaf)
                     .expect("History Repository Impl: Unable to serialize JoinsLeaf");


### PR DESCRIPTION
All 4 test cases in `merge_number_channel_spec.rs` were failing due to various porting bugs.

`multiple_branches_should_reject_deploy_when_mergeable_number_channels_got_overflow`:
- Updated `rholang_merging_logic.rs` to use `wrapping_sub`

`multiple_branches_with_normal_rejection_should_choose_from_normal_reject_options`:
- Updated `rho_runtime.rs` to use correct creation method for `Blake2b512Random`

`multiple_branches_should_reject_deploy_when_mergeable_number_channels_got_negative_number`,
`multiple_branches_should_merge_number_channels`:
- Updated `conflict_set_merger.rs` to make branch processing deterministic using collection order
- Updated `deploy_chain_index.rs` to provide deterministic ordering across all nodes for consensus safety

All 4 test cases in merge_number_channel_spec.rs now pass consistently.