### PR TITLE
Add BlockApproverProtocol implementation in Rust

### DIFF
--- a/casper/src/rust/engine/block_approver_protocol.rs
+++ b/casper/src/rust/engine/block_approver_protocol.rs
@@ -159,7 +159,8 @@ impl<T: TransportLayer + Send + Sync + 'static> BlockApproverProtocol<T> {
         };
 
         // Expected blessed contracts
-        let genesis_blessed_contracts = crate::rust::genesis::genesis::Genesis::default_blessed_terms(
+        let genesis_blessed_contracts = crate::rust::genesis::genesis::Genesis::default_blessed_terms_with_timestamp(
+            self.deploy_timestamp,
             &pos_params,
             &self.vaults,
             i64::MAX,

--- a/casper/src/rust/engine/block_approver_protocol.rs
+++ b/casper/src/rust/engine/block_approver_protocol.rs
@@ -98,10 +98,7 @@ impl<T: TransportLayer + Send + Sync + 'static> BlockApproverProtocol<T> {
 
     /// Corresponds to Scala `BlockApproverProtocol.getBlockApproval` / `getApproval` –
     /// signs candidate ApprovedBlockCandidate and creates `BlockApproval`.
-    fn get_block_approval(
-        &self,
-        candidate: &ApprovedBlockCandidate,
-    ) -> BlockApproval {
+    fn get_block_approval(&self, candidate: &ApprovedBlockCandidate) -> BlockApproval {
         let sig_data = Blake2b256::hash(candidate.clone().to_proto().encode_to_vec());
         let sig = self.validator_id.signature(&sig_data);
         BlockApproval {
@@ -161,18 +158,22 @@ impl<T: TransportLayer + Send + Sync + 'static> BlockApproverProtocol<T> {
         };
 
         // Expected blessed contracts
-        let genesis_blessed_contracts = crate::rust::genesis::genesis::Genesis::default_blessed_terms_with_timestamp(
-            self.deploy_timestamp,
-            &pos_params,
-            &self.vaults,
-            i64::MAX,
-            shard_id,
-        );
+        let genesis_blessed_contracts =
+            crate::rust::genesis::genesis::Genesis::default_blessed_terms_with_timestamp(
+                self.deploy_timestamp,
+                &pos_params,
+                &self.vaults,
+                i64::MAX,
+                shard_id,
+            );
 
         let block_deploys: &Vec<ProcessedDeploy> = &block.body.deploys;
 
         if block_deploys.len() != genesis_blessed_contracts.len() {
-            return Err("Mismatch between number of candidate deploys and expected number of deploys.".to_string());
+            return Err(
+                "Mismatch between number of candidate deploys and expected number of deploys."
+                    .to_string(),
+            );
         }
 
         // Check deploys equality (order matters)
@@ -259,15 +260,12 @@ impl<T: TransportLayer + Send + Sync + 'static> BlockApproverProtocol<T> {
                     packet,
                 };
 
-                self.transport
-                    .stream(peer, &blob)
-                    .await
-                    .map_err(|e| {
-                        CasperError::RuntimeError(format!(
-                            "Failed to stream BlockApproval to peer: {}",
-                            e
-                        ))
-                    })?;
+                self.transport.stream(peer, &blob).await.map_err(|e| {
+                    CasperError::RuntimeError(format!(
+                        "Failed to stream BlockApproval to peer: {}",
+                        e
+                    ))
+                })?;
 
                 info!(
                     "Approved genesis block candidate from {}. Approval sent in response.",
@@ -284,4 +282,4 @@ impl<T: TransportLayer + Send + Sync + 'static> BlockApproverProtocol<T> {
 
         Ok(())
     }
-} 
+}

--- a/casper/src/rust/engine/block_approver_protocol.rs
+++ b/casper/src/rust/engine/block_approver_protocol.rs
@@ -65,9 +65,11 @@ impl<T: TransportLayer + Send + Sync + 'static> BlockApproverProtocol<T> {
         conf: Arc<RPConf>,
     ) -> Result<Self, CasperError> {
         if bonds.len() <= required_sigs as usize {
-            return Err(CasperError::RuntimeError(
-                "Required sigs must be smaller than the number of bonded validators".to_string(),
-            ));
+            return Err(CasperError::RuntimeError(format!(
+                "Required sigs ({}) must be smaller than the number of bonded validators ({})",
+                required_sigs,
+                bonds.len()
+            )));
         }
 
         let bonds_bytes: HashMap<Bytes, i64> = bonds

--- a/casper/src/rust/engine/block_approver_protocol.rs
+++ b/casper/src/rust/engine/block_approver_protocol.rs
@@ -1,0 +1,284 @@
+// See casper/src/main/scala/coop/rchain/casper/engine/BlockApproverProtocol.scala
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use comm::rust::peer_node::PeerNode;
+use comm::rust::rp::rp_conf::RPConf;
+use comm::rust::transport::transport_layer::{Blob, TransportLayer};
+use crypto::rust::hash::blake2b256::Blake2b256;
+use log::{info, warn};
+use models::rust::casper::protocol::casper_message::{
+    ApprovedBlockCandidate, BlockApproval, ProcessedDeploy, ProcessedSystemDeploy, UnapprovedBlock,
+};
+use models::rust::casper::protocol::packet_type_tag::ToPacket;
+use prost::bytes::Bytes;
+use prost::Message;
+
+use crate::rust::errors::CasperError;
+use crate::rust::genesis::contracts::{
+    proof_of_stake::ProofOfStake, validator::Validator, vault::Vault,
+};
+use crate::rust::util::rholang::runtime_manager::RuntimeManager;
+use crate::rust::validator_identity::ValidatorIdentity;
+
+/// Rust port of `coop.rchain.casper.engine.BlockApproverProtocol` from Scala.
+/// The field layout and logic mirror the original as closely as possible.
+#[derive(Clone)]
+pub struct BlockApproverProtocol<T: TransportLayer + Send + Sync + 'static> {
+    // Configuration / static data
+    validator_id: ValidatorIdentity,
+    deploy_timestamp: i64,
+    vaults: Vec<Vault>,
+    bonds: HashMap<crypto::rust::public_key::PublicKey, i64>,
+    bonds_bytes: HashMap<Bytes, i64>, // helper map keyed by raw bytes
+    minimum_bond: i64,
+    maximum_bond: i64,
+    epoch_length: i32,
+    quarantine_length: i32,
+    number_of_active_validators: i32,
+    required_sigs: i32,
+    pos_multi_sig_public_keys: Vec<String>,
+    pos_multi_sig_quorum: i32,
+
+    // Infrastructure
+    transport: Arc<T>,
+    conf: Arc<RPConf>,
+}
+
+impl<T: TransportLayer + Send + Sync + 'static> BlockApproverProtocol<T> {
+    /// Corresponds to Scala `BlockApproverProtocol.of` – constructor with basic validation.
+    pub fn new(
+        validator_id: ValidatorIdentity,
+        deploy_timestamp: i64,
+        vaults: Vec<Vault>,
+        bonds: HashMap<crypto::rust::public_key::PublicKey, i64>,
+        minimum_bond: i64,
+        maximum_bond: i64,
+        epoch_length: i32,
+        quarantine_length: i32,
+        number_of_active_validators: i32,
+        required_sigs: i32,
+        pos_multi_sig_public_keys: Vec<String>,
+        pos_multi_sig_quorum: i32,
+        transport: Arc<T>,
+        conf: Arc<RPConf>,
+    ) -> Result<Self, CasperError> {
+        if bonds.len() <= required_sigs as usize {
+            return Err(CasperError::RuntimeError(
+                "Required sigs must be smaller than the number of bonded validators".to_string(),
+            ));
+        }
+
+        let bonds_bytes: HashMap<Bytes, i64> = bonds
+            .iter()
+            .map(|(pk, stake)| (pk.bytes.clone(), *stake))
+            .collect();
+
+        Ok(Self {
+            validator_id,
+            deploy_timestamp,
+            vaults,
+            bonds,
+            bonds_bytes,
+            minimum_bond,
+            maximum_bond,
+            epoch_length,
+            quarantine_length,
+            number_of_active_validators,
+            required_sigs,
+            pos_multi_sig_public_keys,
+            pos_multi_sig_quorum,
+            transport,
+            conf,
+        })
+    }
+
+    /// Corresponds to Scala `BlockApproverProtocol.getBlockApproval` / `getApproval` –
+    /// signs candidate ApprovedBlockCandidate and creates `BlockApproval`.
+    fn get_block_approval(
+        &self,
+        candidate: &ApprovedBlockCandidate,
+    ) -> BlockApproval {
+        let sig_data = Blake2b256::hash(candidate.clone().to_proto().encode_to_vec());
+        let sig = self.validator_id.signature(&sig_data);
+        BlockApproval {
+            candidate: candidate.clone(),
+            sig,
+        }
+    }
+
+    /// Corresponds to Scala `BlockApproverProtocol.validateCandidate` –
+    /// performs full validation of the candidate genesis block.
+    async fn validate_candidate(
+        &self,
+        runtime_manager: &mut RuntimeManager,
+        candidate: &ApprovedBlockCandidate,
+        shard_id: &str,
+    ) -> Result<(), String> {
+        // Basic checks – required sigs, absence of system deploys, bonds equality
+        if candidate.required_sigs != self.required_sigs {
+            return Err("Candidate didn't have required signatures number.".to_string());
+        }
+
+        let block = &candidate.block;
+        if !block.body.system_deploys.is_empty() {
+            return Err("Candidate must not contain system deploys.".to_string());
+        }
+
+        let block_bonds: HashMap<Bytes, i64> = block
+            .body
+            .state
+            .bonds
+            .iter()
+            .map(|b| (b.validator.clone(), b.stake))
+            .collect();
+
+        if block_bonds != self.bonds_bytes {
+            return Err("Block bonds don't match expected.".to_string());
+        }
+
+        // Prepare PoS params
+        let validators: Vec<Validator> = block_bonds
+            .iter()
+            .map(|(pk_bytes, stake)| Validator {
+                pk: crypto::rust::public_key::PublicKey::new(pk_bytes.clone()),
+                stake: *stake,
+            })
+            .collect();
+
+        let pos_params = ProofOfStake {
+            minimum_bond: self.minimum_bond,
+            maximum_bond: self.maximum_bond,
+            validators,
+            epoch_length: self.epoch_length,
+            quarantine_length: self.quarantine_length,
+            number_of_active_validators: self.number_of_active_validators,
+            pos_multi_sig_public_keys: self.pos_multi_sig_public_keys.clone(),
+            pos_multi_sig_quorum: self.pos_multi_sig_quorum,
+        };
+
+        // Expected blessed contracts
+        let genesis_blessed_contracts = crate::rust::genesis::genesis::Genesis::default_blessed_terms(
+            &pos_params,
+            &self.vaults,
+            i64::MAX,
+            shard_id,
+        );
+
+        let block_deploys: &Vec<ProcessedDeploy> = &block.body.deploys;
+
+        if block_deploys.len() != genesis_blessed_contracts.len() {
+            return Err("Mismatch between number of candidate deploys and expected number of deploys.".to_string());
+        }
+
+        // Check deploys equality (order matters)
+        let wrong_deploys: Vec<String> = block_deploys
+            .iter()
+            .zip(genesis_blessed_contracts.iter())
+            .filter(|(candidate_deploy, expected_contract)| {
+                candidate_deploy.deploy.data.term != expected_contract.data.term
+            })
+            .map(|(candidate_deploy, _)| {
+                let term = &candidate_deploy.deploy.data.term;
+                term.chars().take(100).collect::<String>()
+            })
+            .take(5)
+            .collect();
+
+        if !wrong_deploys.is_empty() {
+            return Err(format!(
+                "Genesis candidate deploys do not match expected blessed contracts.\nBad contracts (5 first):\n{}",
+                wrong_deploys.join("\n")
+            ));
+        }
+
+        // State hash checks
+        let empty_state_hash = RuntimeManager::empty_state_hash_fixed();
+        let state_hash = runtime_manager
+            .replay_compute_state(
+                &empty_state_hash,
+                block_deploys.clone(),
+                Vec::<ProcessedSystemDeploy>::new(),
+                &rholang::rust::interpreter::system_processes::BlockData::from_block(block),
+                None,
+                true,
+            )
+            .await
+            .map_err(|e| format!("Failed status during replay: {:?}.", e))?;
+
+        if state_hash != block.body.state.post_state_hash {
+            return Err("Tuplespace hash mismatch.".to_string());
+        }
+
+        // Bonds computed from tuplespace
+        let tuplespace_bonds = runtime_manager
+            .compute_bonds(&block.body.state.post_state_hash)
+            .await
+            .map_err(|e| format!("{:?}", e))?;
+
+        let tuplespace_bonds_map: HashMap<Bytes, i64> = tuplespace_bonds
+            .into_iter()
+            .map(|b| (b.validator, b.stake))
+            .collect();
+
+        if tuplespace_bonds_map != self.bonds_bytes {
+            return Err("Tuplespace bonds don't match expected ones.".to_string());
+        }
+
+        Ok(())
+    }
+
+    /// Corresponds to Scala `BlockApproverProtocol.unapprovedBlockPacketHandler` –
+    /// verifies candidate message from peer and streams approval if valid.
+    pub async fn unapproved_block_packet_handler(
+        &self,
+        runtime_manager: &mut RuntimeManager,
+        peer: &PeerNode,
+        unapproved_block: UnapprovedBlock,
+        shard_id: &str,
+    ) -> Result<(), CasperError> {
+        let candidate = unapproved_block.candidate.clone();
+        info!(
+            "Received expected genesis block candidate from {}. Verifying...",
+            peer.endpoint.host
+        );
+
+        match self
+            .validate_candidate(runtime_manager, &candidate, shard_id)
+            .await
+        {
+            Ok(_) => {
+                let approval = self.get_block_approval(&candidate);
+                let packet = approval.to_proto().mk_packet();
+                let blob = Blob {
+                    sender: self.conf.local.clone(),
+                    packet,
+                };
+
+                self.transport
+                    .stream(peer, &blob)
+                    .await
+                    .map_err(|e| {
+                        CasperError::RuntimeError(format!(
+                            "Failed to stream BlockApproval to peer: {}",
+                            e
+                        ))
+                    })?;
+
+                info!(
+                    "Approved genesis block candidate from {}. Approval sent in response.",
+                    peer.endpoint.host
+                );
+            }
+            Err(err_msg) => {
+                warn!(
+                    "Received unexpected genesis block candidate from {} because: {}",
+                    peer.endpoint.host, err_msg
+                );
+            }
+        }
+
+        Ok(())
+    }
+} 

--- a/casper/src/rust/engine/mod.rs
+++ b/casper/src/rust/engine/mod.rs
@@ -4,3 +4,4 @@ pub mod engine;
 pub mod initializing;
 pub mod lfs_block_requester;
 pub mod lfs_tuple_space_requester;
+pub mod block_approver_protocol;

--- a/casper/src/rust/engine/mod.rs
+++ b/casper/src/rust/engine/mod.rs
@@ -1,7 +1,7 @@
 pub mod approve_block_protocol;
+pub mod block_approver_protocol;
 pub mod block_retriever;
 pub mod engine;
 pub mod initializing;
 pub mod lfs_block_requester;
 pub mod lfs_tuple_space_requester;
-pub mod block_approver_protocol;

--- a/casper/src/rust/genesis/genesis.rs
+++ b/casper/src/rust/genesis/genesis.rs
@@ -50,14 +50,14 @@ impl Genesis {
         }])
     }
 
-    pub fn default_blessed_terms(
+    pub fn default_blessed_terms_with_timestamp(
+        timestamp: i64,
         pos_params: &ProofOfStake,
         vaults: &Vec<Vault>,
         supply: i64,
         shard_id: &str,
     ) -> Vec<Signed<DeployData>> {
         // Splits initial vaults creation in multiple deploys (batches)
-        const BASE_TIMESTAMP: i64 = 1565818101792;
         const BATCH_SIZE: usize = 100;
 
         // Early return for empty vaults to avoid unnecessary processing
@@ -70,14 +70,14 @@ impl Genesis {
 
         for (idx, chunk) in vaults.chunks(BATCH_SIZE).enumerate() {
             let is_last_batch = idx == batch_count - 1;
-            let timestamp = BASE_TIMESTAMP + idx as i64;
+            let deploy_timestamp = timestamp + idx as i64;
 
             let batch_vaults = chunk.to_vec();
 
             let deploy = standard_deploys::rev_generator(
                 batch_vaults,
                 supply,
-                timestamp,
+                deploy_timestamp,
                 is_last_batch,
                 shard_id,
             );
@@ -110,6 +110,17 @@ impl Genesis {
         all_deploys.push(pos_generator);
 
         all_deploys
+    }
+
+    pub fn default_blessed_terms(
+        pos_params: &ProofOfStake,
+        vaults: &Vec<Vault>,
+        supply: i64,
+        shard_id: &str,
+    ) -> Vec<Signed<DeployData>> {
+        // Use hardcoded timestamp for backwards compatibility
+        const BASE_TIMESTAMP: i64 = 1565818101792;
+        Self::default_blessed_terms_with_timestamp(BASE_TIMESTAMP, pos_params, vaults, supply, shard_id)
     }
 
     pub async fn create_genesis_block(

--- a/casper/tests/engine/approve_block_protocol_test.rs
+++ b/casper/tests/engine/approve_block_protocol_test.rs
@@ -22,9 +22,7 @@ use crypto::rust::{
     signatures::{secp256k1::Secp256k1, signatures_alg::SignaturesAlg},
 };
 use models::casper::Signature as ProtoSignature;
-use models::rust::casper::protocol::casper_message::{
-    ApprovedBlockCandidate, BlockApproval,
-};
+use models::rust::casper::protocol::casper_message::{ApprovedBlockCandidate, BlockApproval};
 use prost::{bytes, Message};
 use shared::rust::shared::f1r3fly_event::F1r3flyEvent;
 use shared::rust::shared::f1r3fly_events::F1r3flyEvents;
@@ -203,7 +201,8 @@ async fn should_add_valid_signatures_to_state() {
         Duration::from_millis(100),
         Duration::from_millis(1),
         key_pairs,
-    ).await;
+    )
+    .await;
     let approval = create_approval(&fixture.candidate, &key_pair.0, &key_pair.1);
 
     let protocol = fixture.protocol.clone();
@@ -236,7 +235,8 @@ async fn should_not_change_signatures_on_duplicate_approval() {
         Duration::from_millis(100),
         Duration::from_millis(1),
         key_pairs,
-    ).await;
+    )
+    .await;
     let approval1 = create_approval(&fixture.candidate, &key_pair.0, &key_pair.1);
     let approval2 = create_approval(&fixture.candidate, &key_pair.0, &key_pair.1);
 
@@ -280,7 +280,8 @@ async fn should_not_add_invalid_signatures() {
         Duration::from_millis(100),
         Duration::from_millis(1),
         key_pairs,
-    ).await;
+    )
+    .await;
     let invalid_approval = create_invalid_approval(&fixture.candidate);
 
     let protocol = fixture.protocol.clone();
@@ -309,7 +310,8 @@ async fn should_create_approved_block_when_enough_signatures_collected() {
         Duration::from_millis(30),
         Duration::from_millis(1),
         key_pairs.clone(),
-    ).await;
+    )
+    .await;
 
     let protocol = fixture.protocol.clone();
     let protocol_clone = fixture.protocol.clone();
@@ -344,7 +346,8 @@ async fn should_continue_collecting_if_not_enough_signatures() {
         Duration::from_millis(30),
         Duration::from_millis(1),
         key_pairs.clone(),
-    ).await;
+    )
+    .await;
 
     let protocol = fixture.protocol.clone();
     let protocol_clone = fixture.protocol.clone();
@@ -386,7 +389,8 @@ async fn should_skip_duration_when_required_signatures_is_zero() {
         Duration::from_millis(30),
         Duration::from_millis(1),
         key_pairs,
-    ).await;
+    )
+    .await;
 
     let start = std::time::Instant::now();
     let result = timeout(Duration::from_millis(100), fixture.protocol.run()).await;
@@ -411,7 +415,8 @@ async fn should_not_accept_approval_from_untrusted_validator() {
         Duration::from_millis(100),
         Duration::from_millis(1),
         key_pairs,
-    ).await;
+    )
+    .await;
     let approval = create_approval(
         &fixture.candidate,
         &untrusted_key_pair.0,
@@ -444,7 +449,8 @@ async fn should_send_unapproved_block_message_to_peers_at_every_interval() {
         Duration::from_millis(100),
         Duration::from_millis(5),
         key_pairs,
-    ).await;
+    )
+    .await;
 
     let protocol = fixture.protocol.clone();
     let protocol_clone = fixture.protocol.clone();
@@ -499,7 +505,8 @@ async fn should_send_approved_block_message_to_peers_once_approved_block_is_crea
         Duration::from_millis(2),
         Duration::from_millis(1),
         key_pairs,
-    ).await;
+    )
+    .await;
 
     let protocol = fixture.protocol.clone();
     let protocol_clone = fixture.protocol.clone();

--- a/casper/tests/engine/approve_block_protocol_test.rs
+++ b/casper/tests/engine/approve_block_protocol_test.rs
@@ -22,7 +22,9 @@ use crypto::rust::{
     signatures::{secp256k1::Secp256k1, signatures_alg::SignaturesAlg},
 };
 use models::casper::Signature as ProtoSignature;
-use models::rust::casper::protocol::casper_message::{ApprovedBlockCandidate, BlockApproval};
+use models::rust::casper::protocol::casper_message::{
+    ApprovedBlockCandidate, BlockApproval,
+};
 use prost::{bytes, Message};
 use shared::rust::shared::f1r3fly_event::F1r3flyEvent;
 use shared::rust::shared::f1r3fly_events::F1r3flyEvents;
@@ -201,8 +203,7 @@ async fn should_add_valid_signatures_to_state() {
         Duration::from_millis(100),
         Duration::from_millis(1),
         key_pairs,
-    )
-    .await;
+    ).await;
     let approval = create_approval(&fixture.candidate, &key_pair.0, &key_pair.1);
 
     let protocol = fixture.protocol.clone();
@@ -235,8 +236,7 @@ async fn should_not_change_signatures_on_duplicate_approval() {
         Duration::from_millis(100),
         Duration::from_millis(1),
         key_pairs,
-    )
-    .await;
+    ).await;
     let approval1 = create_approval(&fixture.candidate, &key_pair.0, &key_pair.1);
     let approval2 = create_approval(&fixture.candidate, &key_pair.0, &key_pair.1);
 
@@ -280,8 +280,7 @@ async fn should_not_add_invalid_signatures() {
         Duration::from_millis(100),
         Duration::from_millis(1),
         key_pairs,
-    )
-    .await;
+    ).await;
     let invalid_approval = create_invalid_approval(&fixture.candidate);
 
     let protocol = fixture.protocol.clone();
@@ -310,8 +309,7 @@ async fn should_create_approved_block_when_enough_signatures_collected() {
         Duration::from_millis(30),
         Duration::from_millis(1),
         key_pairs.clone(),
-    )
-    .await;
+    ).await;
 
     let protocol = fixture.protocol.clone();
     let protocol_clone = fixture.protocol.clone();
@@ -346,8 +344,7 @@ async fn should_continue_collecting_if_not_enough_signatures() {
         Duration::from_millis(30),
         Duration::from_millis(1),
         key_pairs.clone(),
-    )
-    .await;
+    ).await;
 
     let protocol = fixture.protocol.clone();
     let protocol_clone = fixture.protocol.clone();
@@ -389,8 +386,7 @@ async fn should_skip_duration_when_required_signatures_is_zero() {
         Duration::from_millis(30),
         Duration::from_millis(1),
         key_pairs,
-    )
-    .await;
+    ).await;
 
     let start = std::time::Instant::now();
     let result = timeout(Duration::from_millis(100), fixture.protocol.run()).await;
@@ -415,8 +411,7 @@ async fn should_not_accept_approval_from_untrusted_validator() {
         Duration::from_millis(100),
         Duration::from_millis(1),
         key_pairs,
-    )
-    .await;
+    ).await;
     let approval = create_approval(
         &fixture.candidate,
         &untrusted_key_pair.0,
@@ -449,8 +444,7 @@ async fn should_send_unapproved_block_message_to_peers_at_every_interval() {
         Duration::from_millis(100),
         Duration::from_millis(5),
         key_pairs,
-    )
-    .await;
+    ).await;
 
     let protocol = fixture.protocol.clone();
     let protocol_clone = fixture.protocol.clone();
@@ -505,8 +499,7 @@ async fn should_send_approved_block_message_to_peers_once_approved_block_is_crea
         Duration::from_millis(2),
         Duration::from_millis(1),
         key_pairs,
-    )
-    .await;
+    ).await;
 
     let protocol = fixture.protocol.clone();
     let protocol_clone = fixture.protocol.clone();

--- a/casper/tests/util/genesis_builder.rs
+++ b/casper/tests/util/genesis_builder.rs
@@ -97,14 +97,11 @@ impl GenesisBuilder {
     /// but using a simplified approach for testing to avoid heavy infrastructure
     pub fn build_test_genesis(validator_key_pairs: Vec<(PrivateKey, PublicKey)>) -> BlockMessage {
         // Extract validator public keys (equivalent to validatorKeyPairs.map(_._2))
-        let validator_pks: Vec<PublicKey> = validator_key_pairs
-            .iter()
-            .map(|(_, pk)| pk.clone())
-            .collect();
-
+        let validator_pks: Vec<PublicKey> = validator_key_pairs.iter().map(|(_, pk)| pk.clone()).collect();
+        
         // Create bonds using GenesisBuilder.createBonds logic (equivalent to createBonds(validatorKeyPairs.map(_._2)))
         let bonds_map = Self::create_bonds(validator_pks);
-
+        
         // Convert to the Bond format used in genesis block
         let bonds: Vec<Bond> = bonds_map
             .into_iter()

--- a/casper/tests/util/genesis_builder.rs
+++ b/casper/tests/util/genesis_builder.rs
@@ -97,11 +97,14 @@ impl GenesisBuilder {
     /// but using a simplified approach for testing to avoid heavy infrastructure
     pub fn build_test_genesis(validator_key_pairs: Vec<(PrivateKey, PublicKey)>) -> BlockMessage {
         // Extract validator public keys (equivalent to validatorKeyPairs.map(_._2))
-        let validator_pks: Vec<PublicKey> = validator_key_pairs.iter().map(|(_, pk)| pk.clone()).collect();
-        
+        let validator_pks: Vec<PublicKey> = validator_key_pairs
+            .iter()
+            .map(|(_, pk)| pk.clone())
+            .collect();
+
         // Create bonds using GenesisBuilder.createBonds logic (equivalent to createBonds(validatorKeyPairs.map(_._2)))
         let bonds_map = Self::create_bonds(validator_pks);
-        
+
         // Convert to the Bond format used in genesis block
         let bonds: Vec<Bond> = bonds_map
             .into_iter()


### PR DESCRIPTION
# Overview

Introduced the BlockApproverProtocol module, porting the logic from Scala to Rust.

# Test
No test or usages of this class for now