### PR TITLE
Add ApprovedBlockReceived to F1r3flyEvent list and enhance LFS block requester

### DIFF
--- a/casper/src/rust/engine/initializing.rs
+++ b/casper/src/rust/engine/initializing.rs
@@ -86,9 +86,8 @@ impl<T: TransportLayer + Sync> Initializing<T> {
         );
 
         let block_request_stream = lfs_block_requester::stream(
-            approved_block.clone(),
-            // TODO: just use self.block_message_queue instead of clone?
-            self.block_message_queue.clone(),
+            &approved_block,
+            &self.block_message_queue,
             response_message_rx,
             min_block_number_for_deploy_lifespan,
             Duration::from_secs(30),
@@ -104,7 +103,7 @@ impl<T: TransportLayer + Sync> Initializing<T> {
             TupleSpaceRequester::new(&self.transport_layer, &self.rp_conf_ask);
 
         let tuple_space_stream = lfs_tuple_space_requester::stream(
-            approved_block,
+            &approved_block,
             tuple_space_rx,
             Duration::from_secs(120),
             tuple_space_requester,

--- a/casper/src/rust/engine/lfs_tuple_space_requester.rs
+++ b/casper/src/rust/engine/lfs_tuple_space_requester.rs
@@ -489,7 +489,7 @@ impl<T: TupleSpaceRequesterOps, R: RSpaceImporter + Clone + 'static>
 /// # Returns
 /// fs2.Stream processing all tuple space state (Scala: F[Stream[F, ST[StatePartPath]]])
 pub async fn stream<T: TupleSpaceRequesterOps, R: RSpaceImporter + Clone + 'static>(
-    approved_block: ApprovedBlock,
+    approved_block: &ApprovedBlock,
     mut tuple_space_message_receiver: mpsc::UnboundedReceiver<StoreItemsMessage>,
     request_timeout: Duration,
     request_ops: T,

--- a/casper/tests/engine/lfs_block_requester_effects_spec.rs
+++ b/casper/tests/engine/lfs_block_requester_effects_spec.rs
@@ -328,9 +328,10 @@ where
         // Create mock operations implementation
         let mut mock_ops = MockBlockRequesterOps::new(test_state, request_tx, save_tx);
 
+        let empty_queue = std::collections::VecDeque::new();
         let lfs_stream = casper::rust::engine::lfs_block_requester::stream(
-            approved_block,
-            std::collections::VecDeque::new(),
+            &approved_block,
+            &empty_queue,
             response_rx,
             0,
             request_timeout,

--- a/casper/tests/engine/lfs_state_requester_effects_spec.rs
+++ b/casper/tests/engine/lfs_state_requester_effects_spec.rs
@@ -478,7 +478,7 @@ where
     // Create the actual LFS tuple space requester stream
     // Scala equivalent: processingStream <- LfsTupleSpaceRequester.stream(...)
     let stream_result = lfs_tuple_space_requester::stream(
-        approved_block,
+        &approved_block,
         store_items_rx,
         request_timeout,
         mock_ops,

--- a/shared/src/rust/shared/f1r3fly_event.rs
+++ b/shared/src/rust/shared/f1r3fly_event.rs
@@ -8,6 +8,7 @@ pub enum F1r3flyEvent {
     SentUnapprovedBlock(String),
     SentApprovedBlock(String),
     BlockApprovalReceived(BlockApprovalReceived),
+    ApprovedBlockReceived(ApprovedBlockReceived),
 }
 
 #[derive(Debug, Clone)]
@@ -39,6 +40,11 @@ pub struct BlockFinalised {
 pub struct BlockApprovalReceived {
     pub block_hash: String,
     pub sender: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ApprovedBlockReceived {
+    pub block_hash: String,
 }
 
 impl F1r3flyEvent {
@@ -80,5 +86,9 @@ impl F1r3flyEvent {
 
     pub fn block_finalised(block_hash: String) -> Self {
         Self::BlockFinalised(BlockFinalised { block_hash })
+    }
+
+    pub fn approved_block_received(block_hash: String) -> Self {
+        Self::ApprovedBlockReceived(ApprovedBlockReceived { block_hash })
     }
 }


### PR DESCRIPTION
# Overview
This is pre-porting part for initializing.rs:
- Add f1r3fly_event.rs with blockchain event definitions
- Enhance lfs_block_requester.rs with create_stream_with_processor function
- Update lfs_tuple_space_requester.rs function signature for reference parameter

# Test
No unit tests yet.