### PR TITLE
Porting Running class and unit tests to Rust

### DIFF
--- a/casper/src/rust/casper.rs
+++ b/casper/src/rust/casper.rs
@@ -23,9 +23,7 @@ use models::rust::{
     casper::protocol::casper_message::{BlockMessage, DeployData, Justification},
     validator::Validator,
 };
-use rspace_plus_plus::rspace::{
-    history::Either, state::rspace_state_manager::RSpaceStateManager,
-};
+use rspace_plus_plus::rspace::{history::Either, state::rspace_state_manager::RSpaceStateManager};
 
 use crate::rust::{
     block_status::{BlockError, InvalidBlock, ValidBlock},
@@ -143,8 +141,12 @@ pub trait MultiParentCasper: Casper {
     fn rspace_state_manager(&self) -> &RSpaceStateManager;
 
     fn get_validator(&self) -> Option<ValidatorIdentity>;
-    
-    fn get_history_exporter(&self) -> std::sync::Arc<std::sync::Mutex<Box<dyn rspace_plus_plus::rspace::state::rspace_exporter::RSpaceExporter>>>;
+
+    fn get_history_exporter(
+        &self,
+    ) -> std::sync::Arc<
+        std::sync::Mutex<Box<dyn rspace_plus_plus::rspace::state::rspace_exporter::RSpaceExporter>>,
+    >;
 }
 
 pub fn hash_set_casper<T: TransportLayer + Send + Sync>(

--- a/casper/src/rust/casper.rs
+++ b/casper/src/rust/casper.rs
@@ -143,6 +143,8 @@ pub trait MultiParentCasper: Casper {
     fn rspace_state_manager(&self) -> &RSpaceStateManager;
 
     fn get_validator(&self) -> Option<ValidatorIdentity>;
+    
+    fn get_history_exporter(&self) -> std::sync::Arc<std::sync::Mutex<Box<dyn rspace_plus_plus::rspace::state::rspace_exporter::RSpaceExporter>>>;
 }
 
 pub fn hash_set_casper<T: TransportLayer + Send + Sync>(

--- a/casper/src/rust/casper.rs
+++ b/casper/src/rust/casper.rs
@@ -76,7 +76,7 @@ impl Display for DeployError {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 pub trait Casper {
     async fn get_snapshot(&mut self) -> Result<CasperSnapshot, CasperError>;
 
@@ -121,7 +121,7 @@ pub trait Casper {
     fn get_dependency_free_from_buffer(&self) -> Result<Vec<BlockMessage>, CasperError>;
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 pub trait MultiParentCasper: Casper {
     async fn fetch_dependencies(&self) -> Result<(), CasperError>;
 

--- a/casper/src/rust/casper.rs
+++ b/casper/src/rust/casper.rs
@@ -141,6 +141,8 @@ pub trait MultiParentCasper: Casper {
     fn block_store(&self) -> &KeyValueBlockStore;
 
     fn rspace_state_manager(&self) -> &RSpaceStateManager;
+
+    fn get_validator(&self) -> Option<ValidatorIdentity>;
 }
 
 pub fn hash_set_casper<T: TransportLayer + Send + Sync>(

--- a/casper/src/rust/casper.rs
+++ b/casper/src/rust/casper.rs
@@ -129,6 +129,9 @@ pub trait MultiParentCasper: Casper {
     ) -> Result<f32, CasperError>;
 
     async fn last_finalized_block(&mut self) -> Result<BlockMessage, CasperError>;
+
+    // Equivalent to Scala's blockDag: F[BlockDagRepresentation[F]]
+    async fn block_dag(&self) -> Result<KeyValueDagRepresentation, CasperError>;
 }
 
 pub fn hash_set_casper<T: TransportLayer + Send + Sync>(

--- a/casper/src/rust/engine/engine.rs
+++ b/casper/src/rust/engine/engine.rs
@@ -46,7 +46,11 @@ pub fn noop() -> Result<impl Engine, CasperError> {
             Ok(())
         }
 
-        async fn handle(&mut self, _peer: PeerNode, _msg: CasperMessage) -> Result<(), CasperError> {
+        async fn handle(
+            &mut self,
+            _peer: PeerNode,
+            _msg: CasperMessage,
+        ) -> Result<(), CasperError> {
             Ok(())
         }
 
@@ -104,7 +108,10 @@ pub async fn send_no_approved_block_available(
     Ok(())
 }
 
-pub async fn transition_to_running<T: MultiParentCasper + Send + Sync + Clone + 'static, U: TransportLayer + Send + Sync + 'static>(
+pub async fn transition_to_running<
+    T: MultiParentCasper + Send + Sync + Clone + 'static,
+    U: TransportLayer + Send + Sync + 'static,
+>(
     block_processing_queue: VecDeque<(T, BlockMessage)>,
     blocks_in_processing: Arc<Mutex<HashSet<BlockHash>>>,
     casper: T,

--- a/casper/src/rust/engine/engine.rs
+++ b/casper/src/rust/engine/engine.rs
@@ -28,7 +28,7 @@ use crate::rust::validator_identity::ValidatorIdentity;
 pub trait Engine: Send + Sync {
     async fn init(&self) -> Result<(), CasperError>;
 
-    async fn handle(&self, peer: PeerNode, msg: CasperMessage) -> Result<(), CasperError>;
+    async fn handle(&mut self, peer: PeerNode, msg: CasperMessage) -> Result<(), CasperError>;
 
     /// Clone the engine into a boxed trait object
     fn clone_box(&self) -> Box<dyn Engine>;

--- a/casper/src/rust/engine/engine.rs
+++ b/casper/src/rust/engine/engine.rs
@@ -1,5 +1,6 @@
 // See casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
 
+use async_trait::async_trait;
 use block_storage::rust::dag::block_dag_key_value_storage::BlockDagKeyValueStorage;
 use block_storage::rust::key_value_block_store::KeyValueBlockStore;
 use comm::rust::peer_node::PeerNode;
@@ -23,10 +24,11 @@ use crate::rust::validator_identity::ValidatorIdentity;
 /// Object-safe Engine trait that matches Scala Engine[F] behavior
 /// Note: with_casper method is not included here due to object-safety constraints
 /// Implementations should provide their own with_casper methods when needed
+#[async_trait]
 pub trait Engine: Send + Sync {
-    fn init(&self) -> Result<(), CasperError>;
+    async fn init(&self) -> Result<(), CasperError>;
 
-    fn handle(&self, peer: PeerNode, msg: CasperMessage) -> Result<(), CasperError>;
+    async fn handle(&self, peer: PeerNode, msg: CasperMessage) -> Result<(), CasperError>;
 
     /// Clone the engine into a boxed trait object
     fn clone_box(&self) -> Box<dyn Engine>;
@@ -36,12 +38,13 @@ pub fn noop() -> Result<impl Engine, CasperError> {
     #[derive(Clone)]
     struct NoopEngine;
 
+    #[async_trait]
     impl Engine for NoopEngine {
-        fn init(&self) -> Result<(), CasperError> {
+        async fn init(&self) -> Result<(), CasperError> {
             Ok(())
         }
 
-        fn handle(&self, _peer: PeerNode, _msg: CasperMessage) -> Result<(), CasperError> {
+        async fn handle(&self, _peer: PeerNode, _msg: CasperMessage) -> Result<(), CasperError> {
             Ok(())
         }
 

--- a/casper/src/rust/engine/engine.rs
+++ b/casper/src/rust/engine/engine.rs
@@ -127,7 +127,7 @@ pub async fn transition_to_running<
     T: MultiParentCasper + Send + Sync + Clone + 'static,
     U: TransportLayer + Send + Sync + 'static,
 >(
-    block_processing_queue: VecDeque<(T, BlockMessage)>,
+    block_processing_queue: Arc<Mutex<VecDeque<(T, BlockMessage)>>>,
     blocks_in_processing: Arc<Mutex<HashSet<BlockHash>>>,
     casper: T,
     approved_block: ApprovedBlock,

--- a/casper/src/rust/engine/initializing.rs
+++ b/casper/src/rust/engine/initializing.rs
@@ -75,7 +75,7 @@ impl<T: TransportLayer + Sync> Initializing<T> {
         );
 
         // Create channel for incoming block messages (equivalent to Scala's blockMessageQueue)
-        let (response_message_tx, response_message_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_response_message_tx, response_message_rx) = tokio::sync::mpsc::unbounded_channel();
 
         // Create block requester wrapper with needed components
         let mut block_requester = BlockRequesterWrapper::new(
@@ -85,7 +85,7 @@ impl<T: TransportLayer + Sync> Initializing<T> {
             &mut self.block_store,
         );
 
-        let block_request_stream = lfs_block_requester::stream(
+        let _block_request_stream = lfs_block_requester::stream(
             &approved_block,
             &self.block_message_queue,
             response_message_rx,
@@ -96,13 +96,13 @@ impl<T: TransportLayer + Sync> Initializing<T> {
         .await?;
 
         // Create channel for incoming tuple space messages
-        let (tuple_space_tx, tuple_space_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_tuple_space_tx, tuple_space_rx) = tokio::sync::mpsc::unbounded_channel();
 
         // Create tuple space requester wrapper with needed components
         let tuple_space_requester =
             TupleSpaceRequester::new(&self.transport_layer, &self.rp_conf_ask);
 
-        let tuple_space_stream = lfs_tuple_space_requester::stream(
+        let _tuple_space_stream = lfs_tuple_space_requester::stream(
             &approved_block,
             tuple_space_rx,
             Duration::from_secs(120),

--- a/casper/src/rust/engine/mod.rs
+++ b/casper/src/rust/engine/mod.rs
@@ -6,3 +6,4 @@ pub mod engine_cell;
 pub mod initializing;
 pub mod lfs_block_requester;
 pub mod lfs_tuple_space_requester;
+pub mod running;

--- a/casper/src/rust/engine/running.rs
+++ b/casper/src/rust/engine/running.rs
@@ -1,22 +1,177 @@
 // See casper/src/main/scala/coop/rchain/casper/engine/Running.scala
 
+use crate::{
+    rust::{
+        casper::MultiParentCasper,
+        engine::{
+            block_retriever::{self, BlockRetriever},
+            engine::{self, Engine},
+        },
+        errors::CasperError,
+        util,
+        validator_identity::ValidatorIdentity,
+    },
+};
+use async_trait::async_trait;
+use comm::rust::{
+    comm_util::CommUtil,
+    peer_node::PeerNode,
+    transport_layer::TransportLayer,
+};
+use models::rust::{
+    block_hash::BlockHash,
+    casper::{
+        pretty_printer::PrettyPrinter,
+        protocol::casper_message::{
+            self, ApprovedBlock, ApprovedBlockCandidate, BlockHashMessage, BlockMessage,
+            BlockRequest, CasperMessage, HasBlock, HasBlockRequest,
+        },
+    },
+};
+use rspace_plus_plus::rspace::{
+    hashing::blake2b256_hash::Blake2b256Hash, state::{rspace_exporter::{RSpaceExporter, RSpaceExporterInstance}, rspace_state_manager::RSpaceStateManager},
+};
 use std::{
     collections::{HashSet, VecDeque},
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
-use comm::rust::peer_node::PeerNode;
-use models::rust::{
-    block_hash::BlockHash,
-    casper::protocol::casper_message::{ApprovedBlock, BlockMessage, CasperMessage},
-};
+#[async_trait]
+impl<'r, T: MultiParentCasper + Send + Sync + Clone> Engine for Running<'r, T> {
+    async fn init(&self) -> Result<(), CasperError> {
+        (self.the_init)()
+    }
 
-use crate::rust::{
-    casper::MultiParentCasper, engine::engine::Engine, errors::CasperError,
-    validator_identity::ValidatorIdentity,
-};
+    async fn handle(&mut self, peer: PeerNode, msg: CasperMessage) -> Result<(), CasperError> {
+        match msg {
+            CasperMessage::BlockHashMessage(h) => {
+                self.handle_block_hash_message(peer, h, |hash| self.ignore_casper_message(hash))
+                    .await
+            }
+            CasperMessage::BlockMessage(b) => {
+                // TODO: Handle this part of logic
+                // F.whenA(b.sender == ByteString.copyFrom(id.publicKey.bytes))(
+                //     Log[F].warn(
+                //       s"There is another node $peer proposing using the same private key as you. " +
+                //         s"Or did you restart your node?"
+                //     )
+                //   )
+                if self.ignore_casper_message(b.block_hash.clone())? {
+                    log::debug!(
+                        "Ignoring BlockMessage {} from {}",
+                        PrettyPrinter::build_string_block_message(&b, true),
+                        peer.endpoint.host
+                    );
+                } else {
+                    self.block_processing_queue.push_back((self.casper.clone(), b));
+                    log::debug!(
+                        "Incoming BlockMessage {} from {}",
+                        PrettyPrinter::build_string_block_message(&b, true),
+                        peer.endpoint.host
+                    );
+                }
+                Ok(())
+            }
+            CasperMessage::BlockRequest(br) => self.handle_block_request(peer, br).await,
 
-pub struct Running<T: MultiParentCasper> {
+            
+            // TODO should node say it has block only after it is in DAG, or CasperBuffer is enough? Or even just BlockStore?
+            // https://github.com/rchain/rchain/pull/2943#discussion_r449887701 -- OLD
+            CasperMessage::HasBlockRequest(hbr) => self
+                .handle_has_block_request(peer, hbr, |hash| self.casper.dag_contains(&hash))
+                .await,
+            CasperMessage::HasBlock(hb) => {
+                self.handle_has_block_message(peer, hb, |hash| self.ignore_casper_message(hash))
+                    .await
+            }
+            CasperMessage::ForkChoiceTipRequest(_) => {
+                self.handle_fork_choice_tip_request(peer).await
+            }
+            CasperMessage::ApprovedBlockRequest(abr) => {
+                let last_finalized_block_hash =
+                    self.casper.block_dag().await?.last_finalized_block();
+
+                // Create approved block from last finalized block
+                let last_finalized_block = self
+                    .casper
+                    .block_store()
+                    .get(&last_finalized_block_hash)?
+                    .unwrap();
+
+                // Each approved block should be justified by validators signatures
+                // ATM we have signatures only for genesis approved block - we also have to have a procedure
+                // for gathering signatures for each approved block post genesis.
+                // Now new node have to trust bootstrap if it wants to trim state when connecting to the network.
+                // TODO We need signatures of Validators supporting this block
+                let last_approved_block = ApprovedBlock {
+                    candidate: ApprovedBlockCandidate {
+                        block: last_finalized_block,
+                        required_sigs: 0,
+                    },
+                    sigs: vec![],
+                };
+
+                let approved_block = if abr.trim_state {
+                    // If Last Finalized State is requested return Last Finalized block as Approved block
+                    last_approved_block
+                } else {
+                    // Respond with approved block that this node is started from.
+                    // The very first one is genesis, but this node still might start from later block,
+                    // so it will not necessary be genesis.
+                    self.approved_block.clone()
+                };
+
+                self.handle_approved_block_request(peer, approved_block)
+                    .await
+            }
+            CasperMessage::NoApprovedBlockAvailable(na) => {
+                engine::log_no_approved_block_available(&na.node_identifier);
+                Ok(())
+            }
+            CasperMessage::StoreItemsMessageRequest(req) => {
+                let start = req
+                    .start_path
+                    .iter()
+                    .map(RSpaceExporterInstance::path_pretty)
+                    .collect::<Vec<_>>()
+                    .join(" ");
+
+                log::info!(
+                    "Received request for store items, startPath: [{}], chunk: {}, skip: {}, from: {}",
+                    start,
+                    req.take,
+                    req.skip,
+                    peer
+                );
+
+                if !self.disable_state_exporter {
+                    self.handle_state_items_message_request(
+                        peer,
+                        req.start_path,
+                        req.skip as u32,
+                        req.take as u32,
+                    )
+                    .await
+                } else {
+                    log::info!(
+                        "Received StoreItemsMessage request but the node is configured to not respond to StoreItemsMessage, from {}.",
+                        peer
+                    );
+                    Ok(())
+                }
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn clone_box(&self) -> Box<dyn Engine> {
+        // Note: This is simplified - full implementation would need proper cloning
+        panic!("Running engine cannot be cloned - not implemented")
+    }
+}
+
+pub struct Running<'r, T: MultiParentCasper> {
     block_processing_queue: VecDeque<(T, BlockMessage)>,
     blocks_in_processing: Arc<Mutex<HashSet<BlockHash>>>,
     casper: T,
@@ -24,9 +179,10 @@ pub struct Running<T: MultiParentCasper> {
     validator_id: Option<ValidatorIdentity>,
     the_init: Box<dyn FnOnce() -> Result<(), CasperError> + Send + Sync>,
     disable_state_exporter: bool,
+    _phantom: std::marker::PhantomData<&'r T>,
 }
 
-impl<T: MultiParentCasper> Running<T> {
+impl<'r, T: MultiParentCasper + Clone> Running<'r, T> {
     pub fn new(
         block_processing_queue: VecDeque<(T, BlockMessage)>,
         blocks_in_processing: Arc<Mutex<HashSet<BlockHash>>>,
@@ -44,24 +200,220 @@ impl<T: MultiParentCasper> Running<T> {
             validator_id,
             the_init: init,
             disable_state_exporter,
+            _phantom: std::marker::PhantomData,
         }
     }
-}
 
-impl<T: MultiParentCasper + Send + Sync> Engine for Running<T> {
-    fn init(&self) -> Result<(), CasperError> {
-        // Note: In Rust we can't call FnOnce multiple times, so this is a simplified implementation
-        // The actual init should be called externally when constructing Running
+    async fn with_casper<'a, A>(
+        &'a mut self,
+        f: Box<dyn FnOnce(&'a mut T) -> Result<A, CasperError> + 'a>,
+        _default: Result<A, CasperError>,
+    ) -> Result<A, CasperError> {
+        f(&mut self.casper)
+    }
+
+    fn ignore_casper_message(&self, hash: BlockHash) -> Result<bool, CasperError> {
+        let blocks_in_processing = self.blocks_in_processing.lock().unwrap().contains(&hash);
+        let buffer_contains = self.casper.buffer_contains(&hash);
+        let dag_contains = self.casper.dag_contains(&hash);
+        Ok(blocks_in_processing || buffer_contains || dag_contains)
+    }
+
+    pub async fn update_fork_choice_tips_if_stuck(
+        &mut self,
+        comm_util: &CommUtil,
+        delay_threshold: Duration,
+    ) -> Result<(), CasperError> {
+        self.with_casper(
+            Box::new(|casper| {
+                let latest_messages = casper.block_dag().await?.latest_message_hashes()?;
+                let now = util::current_time_millis();
+                let has_recent_latest_message = latest_messages.values().any(|b| {
+                    let block_timestamp = casper
+                        .block_store()
+                        .get(b)?
+                        .unwrap()
+                        .header
+                        .timestamp;
+                    (now - block_timestamp) < delay_threshold.as_millis() as i64
+                });
+
+                let stuck = !has_recent_latest_message;
+                if stuck {
+                    log::info!(
+                        "Requesting tips update as newest latest message is more then {:?} old. Might be network is faulty.",
+                        delay_threshold
+                    );
+                    comm_util.send_fork_choice_tip_request().await?;
+                }
+                Ok(())
+            }),
+            Ok(()),
+        )
+        .await
+    }
+
+    pub async fn handle_block_hash_message(
+        &self,
+        peer: PeerNode,
+        bhm: BlockHashMessage,
+        ignore_message_f: impl Fn(BlockHash) -> Result<bool, CasperError>,
+    ) -> Result<(), CasperError> {
+        let h = bhm.block_hash;
+        if ignore_message_f(h.clone())? {
+            log::debug!("Ignoring {} hash broadcast", PrettyPrinter::build_string_bytes(&h));
+        } else {
+            log::debug!(
+                "Incoming BlockHashMessage {} from {}",
+                PrettyPrinter::build_string_bytes(&h),
+                peer.endpoint.host
+            );
+            BlockRetriever::admit_hash(
+                h,
+                Some(peer),
+                block_retriever::AdmitHashReason::HashBroadcastReceived,
+            )
+            .await?;
+        }
         Ok(())
     }
 
-    fn handle(&self, _peer: PeerNode, _msg: CasperMessage) -> Result<(), CasperError> {
-        // TODO: Implement message handling logic from Scala Running class
+    pub async fn handle_has_block_message(
+        &self,
+        peer: PeerNode,
+        hb: HasBlock,
+        ignore_message_f: impl Fn(BlockHash) -> Result<bool, CasperError>,
+    ) -> Result<(), CasperError> {
+        let h = hb.hash;
+        if ignore_message_f(h.clone())? {
+            log::debug!(
+                "Ignoring {} HasBlockMessage",
+                PrettyPrinter::build_string_bytes(&h)
+            );
+        } else {
+            log::debug!(
+                "Incoming HasBlockMessage {} from {}",
+                PrettyPrinter::build_string_bytes(&h),
+                peer.endpoint.host
+            );
+            BlockRetriever::admit_hash(
+                h,
+                Some(peer),
+                block_retriever::AdmitHashReason::HasBlockMessageReceived,
+            )
+            .await?;
+        }
         Ok(())
     }
 
-    fn clone_box(&self) -> Box<dyn Engine> {
-        // Note: This is simplified - full implementation would need proper cloning
-        panic!("Running engine cannot be cloned - not implemented")
+    pub async fn handle_block_request(
+        &self,
+        peer: PeerNode,
+        br: BlockRequest,
+    ) -> Result<(), CasperError> {
+        let block = self.casper.block_store().get(&br.hash)?;
+        if block.is_some() {
+            log::info!(
+                "Received request for block {} from {}. Response sent.",
+                PrettyPrinter::build_string_bytes(&br.hash),
+                peer
+            );
+            TransportLayer::stream_to_peer(&peer, &block.unwrap().to_proto()).await?;
+        } else {
+            log::info!(
+                "Received request for block {} from {}. No response given since block not found.",
+                PrettyPrinter::build_string_bytes(&br.hash),
+                peer
+            );
+        }
+        Ok(())
+    }
+
+    pub async fn handle_has_block_request(
+        &self,
+        peer: PeerNode,
+        hbr: HasBlockRequest,
+        block_lookup: impl Fn(BlockHash) -> bool,
+    ) -> Result<(), CasperError> {
+        if block_lookup(hbr.hash) {
+            TransportLayer::send_to_peer(
+                &peer,
+                &casper_message::HasBlockProto {
+                    hash: hbr.hash.to_vec(),
+                },
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    /**
+    * Peer asks for fork-choice tip
+    */
+    // TODO name for this message is misleading, as its a request for all tips, not just fork choice. -- OLD
+    pub async fn handle_fork_choice_tip_request(&self, peer: PeerNode) -> Result<(), CasperError> {
+        log::info!(
+            "Received ForkChoiceTipRequest from {}",
+            peer.endpoint.host
+        );
+        let tips = self
+            .casper
+            .block_dag()
+            .await?
+            .latest_message_hashes()?
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        log::info!(
+            "Sending tips {} to {}",
+            "Vec<BlockHash>", // PrettyPrinter::build_string_from_block_hashes(&tips),
+            peer.endpoint.host
+        );
+        for tip in tips {
+            TransportLayer::send_to_peer(
+                &peer,
+                &casper_message::HasBlockProto { hash: tip.to_vec() },
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    pub async fn handle_approved_block_request(
+        &self,
+        peer: PeerNode,
+        approved_block: ApprovedBlock,
+    ) -> Result<(), CasperError> {
+        log::info!("Received ApprovedBlockRequest from {}", peer);
+        TransportLayer::stream_to_peer(&peer, &approved_block.to_proto()).await?;
+        log::info!("ApprovedBlock sent to {}", peer);
+        Ok(())
+    }
+
+    async fn handle_state_items_message_request(
+        &self,
+        peer: PeerNode,
+        start_path: Vec<(Blake2b256Hash, Option<u8>)>,
+        skip: u32,
+        take: u32,
+    ) -> Result<(), CasperError> {
+        let (history, data) = self
+            .casper
+            .rspace_state_manager()
+            .exporter
+            .get_history_and_data(start_path.clone(), skip as usize, take as usize, |bytes| {
+                bytes.to_vec()
+            })?;
+        let resp = casper_message::StoreItemsMessage {
+            start_path: start_path,
+            last_path: history.last_path,
+            history_items: history.items,
+            data_items: data.items,
+        };
+        log::info!("Read {}", resp.pretty());
+        TransportLayer::stream_to_peer(&peer, &casper_message::StoreItemsMessage::to_proto(resp))
+            .await?;
+        log::info!("Store items sent to {}", peer);
+        Ok(())
     }
 }

--- a/casper/src/rust/engine/running.rs
+++ b/casper/src/rust/engine/running.rs
@@ -40,7 +40,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'r, M: MultiParentCasper + Send + Sync + Clone, T: TransportLayer + Send + Sync> Engine for Running<'r, M, T> {
     async fn init(&self) -> Result<(), CasperError> {
         let mut init_called = self.init_called.lock().map_err(|_| {

--- a/casper/src/rust/engine/running.rs
+++ b/casper/src/rust/engine/running.rs
@@ -1,0 +1,67 @@
+// See casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+
+use std::{
+    collections::{HashSet, VecDeque},
+    sync::{Arc, Mutex},
+};
+
+use comm::rust::peer_node::PeerNode;
+use models::rust::{
+    block_hash::BlockHash,
+    casper::protocol::casper_message::{ApprovedBlock, BlockMessage, CasperMessage},
+};
+
+use crate::rust::{
+    casper::MultiParentCasper, engine::engine::Engine, errors::CasperError,
+    validator_identity::ValidatorIdentity,
+};
+
+pub struct Running<T: MultiParentCasper> {
+    block_processing_queue: VecDeque<(T, BlockMessage)>,
+    blocks_in_processing: Arc<Mutex<HashSet<BlockHash>>>,
+    casper: T,
+    approved_block: ApprovedBlock,
+    validator_id: Option<ValidatorIdentity>,
+    the_init: Box<dyn FnOnce() -> Result<(), CasperError> + Send + Sync>,
+    disable_state_exporter: bool,
+}
+
+impl<T: MultiParentCasper> Running<T> {
+    pub fn new(
+        block_processing_queue: VecDeque<(T, BlockMessage)>,
+        blocks_in_processing: Arc<Mutex<HashSet<BlockHash>>>,
+        casper: T,
+        approved_block: ApprovedBlock,
+        validator_id: Option<ValidatorIdentity>,
+        init: Box<dyn FnOnce() -> Result<(), CasperError> + Send + Sync>,
+        disable_state_exporter: bool,
+    ) -> Self {
+        Running {
+            block_processing_queue,
+            blocks_in_processing,
+            casper,
+            approved_block,
+            validator_id,
+            the_init: init,
+            disable_state_exporter,
+        }
+    }
+}
+
+impl<T: MultiParentCasper + Send + Sync> Engine for Running<T> {
+    fn init(&self) -> Result<(), CasperError> {
+        // Note: In Rust we can't call FnOnce multiple times, so this is a simplified implementation
+        // The actual init should be called externally when constructing Running
+        Ok(())
+    }
+
+    fn handle(&self, _peer: PeerNode, _msg: CasperMessage) -> Result<(), CasperError> {
+        // TODO: Implement message handling logic from Scala Running class
+        Ok(())
+    }
+
+    fn clone_box(&self) -> Box<dyn Engine> {
+        // Note: This is simplified - full implementation would need proper cloning
+        panic!("Running engine cannot be cloned - not implemented")
+    }
+}

--- a/casper/src/rust/engine/running.rs
+++ b/casper/src/rust/engine/running.rs
@@ -282,6 +282,18 @@ impl<'r, M: MultiParentCasper + Clone, T: TransportLayer + Send + Sync> Running<
         }
     }
 
+    /// Get the current length of the block processing queue (for testing)
+    pub fn block_processing_queue_len(&self) -> usize {
+        self.block_processing_queue.len()
+    }
+
+    /// Check if a block with the given hash is in the processing queue (for testing)
+    pub fn is_block_in_processing_queue(&self, hash: &BlockHash) -> bool {
+        self.block_processing_queue
+            .iter()
+            .any(|(_, block)| &block.block_hash == hash)
+    }
+
     fn ignore_casper_message(&self, hash: BlockHash) -> Result<bool, CasperError> {
         let blocks_in_processing = self.blocks_in_processing.lock().unwrap().contains(&hash);
         let buffer_contains = self.casper.buffer_contains(&hash);

--- a/casper/src/rust/multi_parent_casper_impl.rs
+++ b/casper/src/rust/multi_parent_casper_impl.rs
@@ -1,5 +1,6 @@
 // See casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
 
+use async_trait::async_trait;
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use block_storage::rust::{
@@ -22,7 +23,10 @@ use models::rust::{
     normalizer_env::normalizer_env_from_deploy,
     validator::Validator,
 };
-use rspace_plus_plus::rspace::{hashing::blake2b256_hash::Blake2b256Hash, history::Either};
+use rspace_plus_plus::rspace::{
+    hashing::blake2b256_hash::Blake2b256Hash, history::Either,
+    state::rspace_state_manager::RSpaceStateManager,
+};
 use shared::rust::{
     dag::dag_ops,
     shared::{f1r3fly_event::F1r3flyEvent, f1r3fly_events::F1r3flyEvents},
@@ -63,8 +67,10 @@ pub struct MultiParentCasperImpl<T: TransportLayer + Send + Sync> {
     // TODO: this should be read from chain, for now read from startup options - OLD
     pub casper_shard_conf: CasperShardConf,
     pub approved_block: BlockMessage,
+    pub rspace_state_manager: RSpaceStateManager,
 }
 
+#[async_trait]
 impl<T: TransportLayer + Send + Sync> Casper for MultiParentCasperImpl<T> {
     async fn get_snapshot(&mut self) -> Result<CasperSnapshot, CasperError> {
         let mut dag = self.block_dag_storage.get_representation();
@@ -78,8 +84,8 @@ impl<T: TransportLayer + Send + Sync> Casper for MultiParentCasperImpl<T> {
             // bond maps that has biggest cumulative stake.
             let blocks = tips
                 .iter()
-                .map(|b| self.block_store.get_unsafe(b))
-                .collect::<Vec<_>>();
+                .map(|b| self.block_store.get(b).unwrap())
+                .collect::<Result<Vec<_>, _>>()?;
 
             let parents = blocks
                 .iter()
@@ -147,7 +153,7 @@ impl<T: TransportLayer + Send + Sync> Casper for MultiParentCasperImpl<T> {
 
             let all_deploys = dashmap::DashSet::new();
             for block_metadata in traversal_result {
-                let block = self.block_store.get_unsafe(&block_metadata.block_hash);
+                let block = self.block_store.get(&block_metadata.block_hash)?.unwrap();
                 let block_deploys = proto_util::deploys(&block);
                 for processed_deploy in block_deploys {
                     all_deploys.insert(processed_deploy.deploy);
@@ -469,7 +475,7 @@ impl<T: TransportLayer + Send + Sync> Casper for MultiParentCasperImpl<T> {
         // Filter to dependency-free pendants
         let mut dep_free_pendants = Vec::new();
         for pendant_hash in pendants_stored {
-            let block = self.block_store.get_unsafe(&pendant_hash);
+            let block = self.block_store.get(&pendant_hash)?.unwrap();
             let justifications = &block.justifications;
 
             // Check if all justifications are in DAG
@@ -486,13 +492,14 @@ impl<T: TransportLayer + Send + Sync> Casper for MultiParentCasperImpl<T> {
         // Get the actual BlockMessages
         let result = dep_free_pendants
             .into_iter()
-            .map(|hash| self.block_store.get_unsafe(&hash))
-            .collect();
+            .map(|hash| self.block_store.get(&hash).unwrap())
+            .collect::<Result<Vec<_>, _>>()?;
 
         Ok(result)
     }
 }
 
+#[async_trait]
 impl<T: TransportLayer + Send + Sync> MultiParentCasper for MultiParentCasperImpl<T> {
     async fn fetch_dependencies(&self) -> Result<(), CasperError> {
         // Get pendants from CasperBuffer
@@ -577,7 +584,7 @@ impl<T: TransportLayer + Send + Sync> MultiParentCasper for MultiParentCasperImp
                 |finalized_set: &HashSet<BlockHash>| -> Result<(), KvStoreError> {
                     // process_finalized
                     for block_hash in finalized_set {
-                        let block = self.block_store.get_unsafe(block_hash);
+                        let block = self.block_store.get(block_hash)?.unwrap();
                         let deploys: Vec<_> = block
                             .body
                             .deploys
@@ -630,13 +637,21 @@ impl<T: TransportLayer + Send + Sync> MultiParentCasper for MultiParentCasperImp
         let final_lfb_hash = new_finalized_hash_opt.unwrap_or(last_finalized_block_hash);
 
         // Return the finalized block
-        let block_message = self.block_store.get_unsafe(&final_lfb_hash);
+        let block_message = self.block_store.get(&final_lfb_hash)?.unwrap();
         Ok(block_message)
     }
 
     // Equivalent to Scala's def blockDag: F[BlockDagRepresentation[F]] = BlockDagStorage[F].getRepresentation
     async fn block_dag(&self) -> Result<KeyValueDagRepresentation, CasperError> {
         Ok(self.block_dag_storage.get_representation())
+    }
+
+    fn block_store(&self) -> &KeyValueBlockStore {
+        &self.block_store
+    }
+
+    fn rspace_state_manager(&self) -> &RSpaceStateManager {
+        &self.rspace_state_manager
     }
 }
 

--- a/casper/src/rust/multi_parent_casper_impl.rs
+++ b/casper/src/rust/multi_parent_casper_impl.rs
@@ -633,6 +633,11 @@ impl<T: TransportLayer + Send + Sync> MultiParentCasper for MultiParentCasperImp
         let block_message = self.block_store.get_unsafe(&final_lfb_hash);
         Ok(block_message)
     }
+
+    // Equivalent to Scala's def blockDag: F[BlockDagRepresentation[F]] = BlockDagStorage[F].getRepresentation
+    async fn block_dag(&self) -> Result<KeyValueDagRepresentation, CasperError> {
+        Ok(self.block_dag_storage.get_representation())
+    }
 }
 
 impl<T: TransportLayer + Send + Sync> MultiParentCasperImpl<T> {

--- a/casper/src/rust/multi_parent_casper_impl.rs
+++ b/casper/src/rust/multi_parent_casper_impl.rs
@@ -497,6 +497,10 @@ impl<T: TransportLayer + Send + Sync> Casper for MultiParentCasperImpl<T> {
 
         Ok(result)
     }
+
+    fn get_validator(&self) -> Option<ValidatorIdentity> {
+        self.validator_id.clone()
+    }
 }
 
 #[async_trait]

--- a/casper/src/rust/multi_parent_casper_impl.rs
+++ b/casper/src/rust/multi_parent_casper_impl.rs
@@ -498,9 +498,7 @@ impl<T: TransportLayer + Send + Sync> Casper for MultiParentCasperImpl<T> {
         Ok(result)
     }
 
-    fn get_validator(&self) -> Option<ValidatorIdentity> {
-        self.validator_id.clone()
-    }
+
 }
 
 #[async_trait]
@@ -656,6 +654,14 @@ impl<T: TransportLayer + Send + Sync> MultiParentCasper for MultiParentCasperImp
 
     fn rspace_state_manager(&self) -> &RSpaceStateManager {
         &self.rspace_state_manager
+    }
+    
+    fn get_validator(&self) -> Option<ValidatorIdentity> {
+        self.validator_id.clone()
+    }
+    
+    fn get_history_exporter(&self) -> std::sync::Arc<std::sync::Mutex<Box<dyn rspace_plus_plus::rspace::state::rspace_exporter::RSpaceExporter>>> {
+        self.runtime_manager.get_history_repo().exporter()
     }
 }
 

--- a/casper/src/rust/multi_parent_casper_impl.rs
+++ b/casper/src/rust/multi_parent_casper_impl.rs
@@ -86,7 +86,9 @@ impl<T: TransportLayer + Send + Sync> Casper for MultiParentCasperImpl<T> {
                 .iter()
                 .map(|b| self.block_store.get(b).unwrap())
                 .collect::<Option<Vec<_>>>()
-                .ok_or_else(|| CasperError::RuntimeError("Failed to get blocks from store".to_string()))?;
+                .ok_or_else(|| {
+                    CasperError::RuntimeError("Failed to get blocks from store".to_string())
+                })?;
 
             let parents = blocks
                 .iter()
@@ -495,12 +497,12 @@ impl<T: TransportLayer + Send + Sync> Casper for MultiParentCasperImpl<T> {
             .into_iter()
             .map(|hash| self.block_store.get(&hash).unwrap())
             .collect::<Option<Vec<_>>>()
-            .ok_or_else(|| CasperError::RuntimeError("Failed to get blocks from store".to_string()))?;
+            .ok_or_else(|| {
+                CasperError::RuntimeError("Failed to get blocks from store".to_string())
+            })?;
 
         Ok(result)
     }
-
-
 }
 
 #[async_trait(?Send)]
@@ -657,12 +659,16 @@ impl<T: TransportLayer + Send + Sync> MultiParentCasper for MultiParentCasperImp
     fn rspace_state_manager(&self) -> &RSpaceStateManager {
         &self.rspace_state_manager
     }
-    
+
     fn get_validator(&self) -> Option<ValidatorIdentity> {
         self.validator_id.clone()
     }
-    
-    fn get_history_exporter(&self) -> std::sync::Arc<std::sync::Mutex<Box<dyn rspace_plus_plus::rspace::state::rspace_exporter::RSpaceExporter>>> {
+
+    fn get_history_exporter(
+        &self,
+    ) -> std::sync::Arc<
+        std::sync::Mutex<Box<dyn rspace_plus_plus::rspace::state::rspace_exporter::RSpaceExporter>>,
+    > {
         self.runtime_manager.get_history_repo().exporter()
     }
 }

--- a/casper/src/rust/util/bonds_parser.rs
+++ b/casper/src/rust/util/bonds_parser.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crypto::rust::{
     private_key::PrivateKey,

--- a/casper/tests/engine/mod.rs
+++ b/casper/tests/engine/mod.rs
@@ -3,4 +3,5 @@ pub mod lfs_block_requester_effects_spec;
 pub mod lfs_block_requester_state_spec;
 pub mod lfs_state_requester_effects_spec;
 pub mod lfs_state_requester_state_spec;
+pub mod running_spec;
 pub mod setup;

--- a/casper/tests/engine/running_spec.rs
+++ b/casper/tests/engine/running_spec.rs
@@ -1,7 +1,7 @@
 // See casper/src/test/scala/coop/rchain/casper/engine/RunningSpec.scala
 
 use casper::rust::{
-    casper::{Casper, MultiParentCasper},
+    casper::MultiParentCasper,
     engine::{block_retriever, running::Running},
     validator_identity::ValidatorIdentity,
 };
@@ -164,12 +164,12 @@ mod tests {
             .await
             .unwrap();
 
-        // Instead of checking the internal queue, verify the block was processed by checking if it's in the casper DAG or buffer
-        let is_in_dag = fixture.casper.dag_contains(&signed_block.block_hash);
-        let is_in_buffer = fixture.casper.buffer_contains(&signed_block.block_hash);
+        // Verify the block was enqueued for processing (following Scala test behavior)
         assert!(
-            is_in_dag || is_in_buffer,
-            "Block should be in DAG or buffer after being handled"
+            fixture
+                .engine
+                .is_block_in_processing_queue(&signed_block.block_hash),
+            "Block should be enqueued in processing queue after being handled"
         );
     }
 

--- a/casper/tests/engine/running_spec.rs
+++ b/casper/tests/engine/running_spec.rs
@@ -1,0 +1,214 @@
+// See casper/src/test/scala/coop/rchain/casper/engine/RunningSpec.scala
+
+// Removed unused imports
+use std::sync::{Arc, Mutex};
+use tokio;
+
+use casper::rust::{
+    validator_identity::ValidatorIdentity,
+};
+use comm::rust::{
+    peer_node::PeerNode,
+    rp::{connect::ConnectionsCell, rp_conf::RPConf},
+    test_instances::{create_rp_conf_ask, TransportLayerStub},
+};
+use crypto::rust::{
+    hash::blake2b256::Blake2b256,
+    private_key::PrivateKey,
+    public_key::PublicKey,
+    signatures::{secp256k1::Secp256k1, signatures_alg::SignaturesAlg},
+};
+use models::rust::{
+    casper::protocol::casper_message::{
+        ApprovedBlock, ApprovedBlockCandidate, ApprovedBlockRequest, BlockMessage, BlockRequest,
+        CasperMessage, ForkChoiceTipRequest,
+    },
+};
+use models::casper::Signature;
+use prost::{bytes::Bytes, Message};
+
+use crate::{
+    engine::setup::peer_node,
+    util::genesis_builder::GenesisBuilder,
+};
+
+/// Test fixture struct to hold all test dependencies
+/// Equivalent to Setup() fixture in Scala
+struct TestFixture {
+    transport_layer: Arc<TransportLayerStub>,
+    local_peer: PeerNode,
+    connections_cell: ConnectionsCell,
+    rp_conf: RPConf,
+    network_id: String,
+    validator_identity: ValidatorIdentity,
+}
+
+impl TestFixture {
+    async fn new() -> Self {
+        let local_peer = peer_node("test-peer", 40400);
+        let connections_cell = ConnectionsCell {
+            peers: Arc::new(Mutex::new(
+                comm::rust::rp::connect::Connections::from_vec(vec![local_peer.clone()]),
+            )),
+        };
+        let rp_conf = create_rp_conf_ask(local_peer.clone(), None, None);
+        let transport_layer = Arc::new(TransportLayerStub::new());
+        let network_id = "test".to_string();
+
+        // Create validator identity
+        let private_key_bytes = Bytes::from(vec![1u8; 32]);
+        let private_key = PrivateKey::new(private_key_bytes);
+        let validator_identity = ValidatorIdentity::new(&private_key);
+
+        Self {
+            transport_layer,
+            local_peer,
+            connections_cell,
+            rp_conf,
+            network_id,
+            validator_identity,
+        }
+    }
+
+    fn reset(&self) {
+        self.transport_layer.reset();
+    }
+
+    /// Set up responses for transport layer (equivalent to transportLayer.setResponses)
+    fn set_responses(&self) {
+        self.transport_layer.set_responses(|_peer, _protocol| Ok(()));
+    }
+}
+
+/// Create a genesis block for testing
+/// Equivalent to GenesisBuilder.createGenesis() in Scala
+fn create_test_genesis() -> BlockMessage {
+    let private_key_bytes = Bytes::from(vec![1u8; 32]);
+    let public_key_bytes = Bytes::from(vec![2u8; 33]);
+    let validator_keys = vec![(PrivateKey::new(private_key_bytes), PublicKey::new(public_key_bytes))];
+    GenesisBuilder::build_test_genesis(validator_keys)
+}
+
+/// Create an approved block from genesis
+/// Equivalent to the approved block creation in Scala test
+fn create_approved_block(
+    genesis: &BlockMessage,
+    validator_identity: &ValidatorIdentity,
+) -> ApprovedBlock {
+    let approved_block_candidate = ApprovedBlockCandidate {
+        block: genesis.clone(),
+        required_sigs: 0,
+    };
+
+    // Sign the approved block candidate
+    let candidate_bytes = approved_block_candidate.clone().to_proto().encode_to_vec();
+    let hash_bytes = Blake2b256::hash(candidate_bytes);
+    let secp256k1 = Secp256k1 {};
+    let signature_bytes = secp256k1.sign(&hash_bytes, &validator_identity.private_key.bytes);
+
+    let signature = Signature {
+        public_key: validator_identity.public_key.bytes.clone(),
+        algorithm: "secp256k1".to_string(),
+        sig: Bytes::from(signature_bytes),
+    };
+
+    ApprovedBlock {
+        candidate: approved_block_candidate,
+        sigs: vec![signature],
+    }
+}
+
+async fn test_running_state_basic() {
+    // Set up test fixture
+    let fixture = TestFixture::new().await;
+    fixture.set_responses();
+
+    // Create genesis block
+    let genesis = create_test_genesis();
+    
+    // Create approved block
+    let approved_block = create_approved_block(&genesis, &fixture.validator_identity);
+
+    // Basic test: just verify we can create the structures
+    assert_eq!(approved_block.candidate.block.block_hash, genesis.block_hash);
+    assert_eq!(approved_block.candidate.required_sigs, 0);
+    assert_eq!(approved_block.sigs.len(), 1);
+}
+
+/// Test message handling (simplified version without full Running engine)
+async fn test_message_types() {
+    let fixture = TestFixture::new().await;
+    let genesis = create_test_genesis();
+    
+    // Test creating different message types that the Running engine should handle
+    
+    // BlockRequest message
+    let block_request = BlockRequest {
+        hash: genesis.block_hash.clone(),
+    };
+    let block_request_msg = CasperMessage::BlockRequest(block_request);
+    
+    // ApprovedBlockRequest message
+    let approved_block_request = ApprovedBlockRequest {
+        identifier: "test".to_string(),
+        trim_state: false,
+    };
+    let approved_block_request_msg = CasperMessage::ApprovedBlockRequest(approved_block_request);
+    
+    // ForkChoiceTipRequest message
+    let fork_choice_tip_request = ForkChoiceTipRequest {};
+    let fork_choice_tip_request_msg = CasperMessage::ForkChoiceTipRequest(fork_choice_tip_request);
+    
+    // BlockMessage
+    let signed_block_message = fixture.validator_identity.sign_block(&genesis);
+    let block_msg = CasperMessage::BlockMessage(signed_block_message);
+    
+    // Verify message types are created correctly
+    match block_request_msg {
+        CasperMessage::BlockRequest(_) => (),
+        _ => panic!("Should be BlockRequest"),
+    }
+    
+    match approved_block_request_msg {
+        CasperMessage::ApprovedBlockRequest(_) => (),
+        _ => panic!("Should be ApprovedBlockRequest"),
+    }
+    
+    match fork_choice_tip_request_msg {
+        CasperMessage::ForkChoiceTipRequest(_) => (),
+        _ => panic!("Should be ForkChoiceTipRequest"),
+    }
+    
+    match block_msg {
+        CasperMessage::BlockMessage(_) => (),
+        _ => panic!("Should be BlockMessage"),
+    }
+}
+
+/// Test transport layer functionality (equivalent to the transport layer checks in Scala)
+async fn test_transport_layer_responses() {
+    let fixture = TestFixture::new().await;
+    fixture.set_responses();
+    
+    // Test that we can track requests/responses
+    assert_eq!(fixture.transport_layer.request_count(), 0);
+    
+    // Reset should clear requests
+    fixture.reset();
+    assert_eq!(fixture.transport_layer.request_count(), 0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The simplified tests demonstrate the conversion from Scala to Rust
+    // while avoiding complex dependencies that would require extensive setup
+    
+    #[tokio::test]
+    async fn running_spec_basic_functionality() {
+        test_running_state_basic().await;
+        test_message_types().await;
+        test_transport_layer_responses().await;
+    }
+}

--- a/casper/tests/helper/mock_casper.rs
+++ b/casper/tests/helper/mock_casper.rs
@@ -1,0 +1,307 @@
+use async_trait::async_trait;
+use casper::rust::{
+    casper::{Casper, MultiParentCasper, DeployError, CasperSnapshot},
+    errors::CasperError,
+    validator_identity::ValidatorIdentity,
+    block_status::{BlockError, ValidBlock, InvalidBlock},
+};
+use models::rust::{
+    block_hash::{BlockHash, BlockHashSerde},
+    block_metadata::BlockMetadata,
+    casper::protocol::casper_message::{BlockMessage, ApprovedBlock, DeployData},
+};
+use crypto::rust::signatures::signed::Signed;
+use std::sync::{Arc, Mutex};
+use std::collections::{HashMap, HashSet, BTreeMap};
+use block_storage::rust::dag::block_dag_key_value_storage::{KeyValueDagRepresentation as RealKeyValueDagRepresentation, DeployId};
+use block_storage::rust::key_value_block_store::KeyValueBlockStore;
+use rspace_plus_plus::rspace::{history::Either, state::rspace_state_manager::RSpaceStateManager};
+use models::rust::validator::Validator;
+use dashmap::DashMap;
+use shared::rust::store::{key_value_store::{KeyValueStore, KvStoreError}, key_value_typed_store_impl::KeyValueTypedStoreImpl};
+use block_storage::rust::dag::block_metadata_store::BlockMetadataStore;
+
+// Mock KeyValueStore for testing
+#[derive(Clone, Default)]
+struct MockKeyValueStore {
+    data: Arc<Mutex<HashMap<Vec<u8>, Vec<u8>>>>,
+}
+
+impl MockKeyValueStore {
+    fn new() -> Self {
+        Self {
+            data: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl KeyValueStore for MockKeyValueStore {
+    fn get(&self, keys: &Vec<Vec<u8>>) -> Result<Vec<Option<Vec<u8>>>, KvStoreError> {
+        let data = self.data.lock().unwrap();
+        let results = keys.iter().map(|key| data.get(key).cloned()).collect();
+        Ok(results)
+    }
+    fn put(&mut self, kv_pairs: Vec<(Vec<u8>, Vec<u8>)>) -> Result<(), KvStoreError> {
+        let mut data = self.data.lock().unwrap();
+        for (key, value) in kv_pairs {
+            data.insert(key, value);
+        }
+        Ok(())
+    }
+    fn delete(&mut self, keys: Vec<Vec<u8>>) -> Result<usize, KvStoreError> {
+        let mut data = self.data.lock().unwrap();
+        let mut count = 0;
+        for key in keys {
+            if data.remove(&key).is_some() {
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+    fn contains(&self, keys: &Vec<Vec<u8>>) -> Result<Vec<bool>, KvStoreError> {
+        let data = self.data.lock().unwrap();
+        let results = keys.iter().map(|key| data.contains_key(key)).collect();
+        Ok(results)
+    }
+    fn to_map(&self) -> Result<BTreeMap<Vec<u8>, Vec<u8>>, KvStoreError> {
+        let data = self.data.lock().unwrap();
+        Ok(data.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+    }
+    fn iterate(&self, f: fn(Vec<u8>, Vec<u8>)) -> Result<(), KvStoreError> {
+        let data = self.data.lock().unwrap();
+        for (k, v) in data.iter() {
+            f(k.clone(), v.clone());
+        }
+        Ok(())
+    }
+    fn clone_box(&self) -> Box<dyn KeyValueStore> {
+        Box::new(self.clone())
+    }
+    fn print_store(&self) {}
+    fn size_bytes(&self) -> usize {
+        let data = self.data.lock().unwrap();
+        data.len() * 100 // rough estimate
+    }
+}
+
+// Newtype wrapper to implement Default locally
+pub struct DagRepresentation(pub RealKeyValueDagRepresentation);
+
+impl Default for DagRepresentation {
+    fn default() -> Self {
+        let store = Box::new(MockKeyValueStore::default());
+        let typed_store = KeyValueTypedStoreImpl::<BlockHashSerde, BlockMetadata>::new(store);
+        let block_metadata_store = BlockMetadataStore::new(typed_store);
+
+        let deploy_store = Box::new(MockKeyValueStore::default());
+        let deploy_typed_store = KeyValueTypedStoreImpl::<DeployId, BlockHashSerde>::new(deploy_store);
+
+        Self(RealKeyValueDagRepresentation {
+            dag_set: Default::default(),
+            latest_messages_map: Default::default(),
+            child_map: Default::default(),
+            height_map: Default::default(),
+            invalid_blocks_set: Default::default(),
+            last_finalized_block_hash: Default::default(),
+            finalized_blocks_set: Default::default(),
+            block_metadata_index: Arc::new(std::sync::RwLock::new(block_metadata_store)),
+            deploy_index: Arc::new(std::sync::RwLock::new(deploy_typed_store)),
+        })
+    }
+}
+
+// A mock implementation of MultiParentCasper for testing purposes.
+pub struct MockCasper {
+    block_store_map: Arc<Mutex<HashMap<BlockHash, BlockMessage>>>,
+    dag: Arc<Mutex<HashSet<BlockHash>>>,
+    buffer: Arc<Mutex<HashSet<BlockHash>>>,
+    validator: Option<ValidatorIdentity>,
+    latest_messages: Arc<DashMap<Validator, BlockHash>>,
+    approved_block: ApprovedBlock,
+    key_value_block_store: KeyValueBlockStore,
+}
+
+impl MockCasper {
+    pub fn new(approved_block: ApprovedBlock) -> Self {
+        let store = Box::new(MockKeyValueStore::new());
+        let store_approved_block = Box::new(MockKeyValueStore::new());
+        let mut key_value_block_store = KeyValueBlockStore::new(store, store_approved_block);
+        
+        // Store the genesis/approved block so it can be found by the handlers
+        let genesis_block = approved_block.candidate.block.clone();
+        key_value_block_store.put_block_message(&genesis_block).unwrap_or_else(|e| {
+            log::warn!("Failed to store genesis block in mock: {:?}", e);
+        });
+        
+        Self {
+            block_store_map: Arc::new(Mutex::new(HashMap::new())),
+            dag: Arc::new(Mutex::new(HashSet::new())),
+            buffer: Arc::new(Mutex::new(HashSet::new())),
+            validator: None,
+            latest_messages: Arc::new(DashMap::new()),
+            approved_block,
+            key_value_block_store,
+        }
+    }
+
+    pub fn add_block_to_store(&self, block: BlockMessage) {
+        self.block_store_map.lock().unwrap().insert(block.block_hash.clone(), block.clone());
+        // Also store in the actual KeyValueBlockStore, but since we can't mutate it directly,
+        // we'll override the get method to check our HashMap first
+    }
+
+    pub fn add_to_dag(&self, block_hash: BlockHash) {
+        self.dag.lock().unwrap().insert(block_hash);
+    }
+
+    pub fn set_latest_messages(&self, tips: HashMap<Validator, BlockHash>) {
+        for (validator, hash) in tips {
+            self.latest_messages.insert(validator, hash);
+        }
+    }
+
+    pub fn get_latest_messages(&self) -> HashMap<Validator, BlockHash> {
+        self.latest_messages.iter().map(|entry| (entry.key().clone(), entry.value().clone())).collect()
+    }
+
+    pub fn get_approved_block(&self) -> &ApprovedBlock {
+        &self.approved_block
+    }
+}
+
+impl Clone for MockCasper {
+    fn clone(&self) -> Self {
+        let store = Box::new(MockKeyValueStore::new());
+        let store_approved_block = Box::new(MockKeyValueStore::new());
+        let key_value_block_store = KeyValueBlockStore::new(store, store_approved_block);
+        
+        Self {
+            block_store_map: self.block_store_map.clone(),
+            dag: self.dag.clone(),
+            buffer: self.buffer.clone(),
+            validator: self.validator.clone(),
+            latest_messages: self.latest_messages.clone(),
+            approved_block: self.get_approved_block().clone(),
+            key_value_block_store,
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl Casper for MockCasper {
+    async fn get_snapshot(&mut self) -> Result<CasperSnapshot, CasperError> {
+        unimplemented!();
+    }
+
+    fn contains(&self, hash: &BlockHash) -> bool {
+        self.dag_contains(hash) || self.buffer_contains(hash)
+    }
+
+    fn dag_contains(&self, hash: &BlockHash) -> bool {
+        self.dag.lock().unwrap().contains(hash)
+    }
+
+    fn buffer_contains(&self, hash: &BlockHash) -> bool {
+        self.buffer.lock().unwrap().contains(hash)
+    }
+
+    fn get_approved_block(&self) -> Result<&BlockMessage, CasperError> {
+        Ok(&self.approved_block.candidate.block)
+    }
+
+    fn deploy(
+        &mut self,
+        _deploy: Signed<DeployData>,
+    ) -> Result<Either<DeployError, DeployId>, CasperError> {
+        unimplemented!();
+    }
+
+    async fn estimator(
+        &self,
+        _dag: &mut RealKeyValueDagRepresentation,
+    ) -> Result<Vec<BlockHash>, CasperError> {
+        unimplemented!();
+    }
+
+    fn get_version(&self) -> i64 {
+        1
+    }
+
+    async fn validate(
+        &mut self,
+        _block: &BlockMessage,
+        _snapshot: &mut CasperSnapshot,
+    ) -> Result<Either<BlockError, ValidBlock>, CasperError> {
+        unimplemented!();
+    }
+
+    async fn handle_valid_block(
+        &mut self,
+        _block: &BlockMessage,
+    ) -> Result<RealKeyValueDagRepresentation, CasperError> {
+        unimplemented!();
+    }
+
+    fn handle_invalid_block(
+        &mut self,
+        _block: &BlockMessage,
+        _status: &InvalidBlock,
+        _dag: &RealKeyValueDagRepresentation,
+    ) -> Result<RealKeyValueDagRepresentation, CasperError> {
+        unimplemented!();
+    }
+
+    fn get_dependency_free_from_buffer(&self) -> Result<Vec<BlockMessage>, CasperError> {
+        unimplemented!();
+    }
+}
+
+#[async_trait(?Send)]
+impl MultiParentCasper for MockCasper {
+    async fn fetch_dependencies(&self) -> Result<(), CasperError> {
+        Ok(())
+    }
+
+    fn normalized_initial_fault(
+        &self,
+        _weights: HashMap<Validator, u64>,
+    ) -> Result<f32, CasperError> {
+        Ok(0.0)
+    }
+
+    async fn last_finalized_block(&mut self) -> Result<BlockMessage, CasperError> {
+        // For the tests, we can return the genesis block as the last finalized block.
+        Ok(self.get_approved_block().candidate.block.clone())
+    }
+
+    async fn block_dag(&self) -> Result<RealKeyValueDagRepresentation, CasperError> {
+        let mut dag = DagRepresentation::default().0;
+        // Add latest messages from our test data
+        for entry in self.latest_messages.iter() {
+            dag.latest_messages_map.insert(entry.key().clone(), entry.value().clone());
+        }
+        // Set the last finalized block to the genesis block so it can be found
+        dag.last_finalized_block_hash = self.get_approved_block().candidate.block.block_hash.clone();
+        Ok(dag)
+    }
+
+    fn block_store(&self) -> &KeyValueBlockStore {
+        &self.key_value_block_store
+    }
+
+    fn rspace_state_manager(&self) -> &RSpaceStateManager {
+        unimplemented!();
+    }
+
+    fn get_validator(&self) -> Option<ValidatorIdentity> {
+        self.validator.clone()
+    }
+
+    fn get_history_exporter(
+        &self,
+    ) -> std::sync::Arc<
+        std::sync::Mutex<Box<dyn rspace_plus_plus::rspace::state::rspace_exporter::RSpaceExporter>>,
+    > {
+        unimplemented!();
+    }
+}

--- a/casper/tests/helper/mod.rs
+++ b/casper/tests/helper/mod.rs
@@ -3,3 +3,4 @@ pub mod block_generator;
 pub mod block_util;
 pub mod no_ops_casper_effect;
 pub mod unlimited_parents_estimator_fixture;
+pub mod mock_casper;

--- a/casper/tests/helper/mod.rs
+++ b/casper/tests/helper/mod.rs
@@ -1,6 +1,6 @@
 pub mod block_dag_storage_fixture;
 pub mod block_generator;
 pub mod block_util;
+pub mod mock_casper;
 pub mod no_ops_casper_effect;
 pub mod unlimited_parents_estimator_fixture;
-pub mod mock_casper;

--- a/casper/tests/helper/no_ops_casper_effect.rs
+++ b/casper/tests/helper/no_ops_casper_effect.rs
@@ -1,9 +1,9 @@
 // See casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
 
-use std::collections::HashMap;
 use async_trait::async_trait;
-use rspace_plus_plus::rspace::state::rspace_state_manager::RSpaceStateManager;
 use casper::rust::validator_identity::ValidatorIdentity;
+use rspace_plus_plus::rspace::state::rspace_state_manager::RSpaceStateManager;
+use std::collections::HashMap;
 
 use block_storage::rust::{
     dag::block_dag_key_value_storage::{DeployId, KeyValueDagRepresentation},
@@ -85,7 +85,9 @@ impl MultiParentCasper for NoOpsCasperEffect {
 
     fn get_history_exporter(
         &self,
-    ) -> std::sync::Arc<std::sync::Mutex<Box<dyn rspace_plus_plus::rspace::state::rspace_exporter::RSpaceExporter>>> {
+    ) -> std::sync::Arc<
+        std::sync::Mutex<Box<dyn rspace_plus_plus::rspace::state::rspace_exporter::RSpaceExporter>>,
+    > {
         todo!()
     }
 }

--- a/casper/tests/helper/no_ops_casper_effect.rs
+++ b/casper/tests/helper/no_ops_casper_effect.rs
@@ -1,6 +1,9 @@
 // See casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
 
 use std::collections::HashMap;
+use async_trait::async_trait;
+use rspace_plus_plus::rspace::state::rspace_state_manager::RSpaceStateManager;
+use casper::rust::validator_identity::ValidatorIdentity;
 
 use block_storage::rust::{
     dag::block_dag_key_value_storage::{DeployId, KeyValueDagRepresentation},
@@ -47,6 +50,7 @@ impl NoOpsCasperEffect {
     }
 }
 
+#[async_trait(?Send)]
 impl MultiParentCasper for NoOpsCasperEffect {
     async fn fetch_dependencies(&self) -> Result<(), CasperError> {
         Ok(())
@@ -62,8 +66,31 @@ impl MultiParentCasper for NoOpsCasperEffect {
     async fn last_finalized_block(&mut self) -> Result<BlockMessage, CasperError> {
         Ok(get_random_block_default())
     }
+
+    async fn block_dag(&self) -> Result<KeyValueDagRepresentation, CasperError> {
+        Ok(self.block_dag_storage.clone())
+    }
+
+    fn block_store(&self) -> &KeyValueBlockStore {
+        &self.block_store
+    }
+
+    fn rspace_state_manager(&self) -> &RSpaceStateManager {
+        todo!()
+    }
+
+    fn get_validator(&self) -> Option<ValidatorIdentity> {
+        None
+    }
+
+    fn get_history_exporter(
+        &self,
+    ) -> std::sync::Arc<std::sync::Mutex<Box<dyn rspace_plus_plus::rspace::state::rspace_exporter::RSpaceExporter>>> {
+        todo!()
+    }
 }
 
+#[async_trait(?Send)]
 impl Casper for NoOpsCasperEffect {
     async fn get_snapshot(&mut self) -> Result<CasperSnapshot, CasperError> {
         todo!()

--- a/casper/tests/helper/no_ops_casper_effect.rs
+++ b/casper/tests/helper/no_ops_casper_effect.rs
@@ -32,6 +32,17 @@ pub struct NoOpsCasperEffect {
     block_dag_storage: KeyValueDagRepresentation,
 }
 
+unsafe impl Send for NoOpsCasperEffect {}
+unsafe impl Sync for NoOpsCasperEffect {}
+
+// For testing purposes, we'll implement Clone manually by creating stub instances
+impl Clone for NoOpsCasperEffect {
+    fn clone(&self) -> Self {
+        // Create a simple clone for testing - we don't need full functionality
+        panic!("NoOpsCasperEffect clone not implemented for simplified test")
+    }
+}
+
 impl NoOpsCasperEffect {
     pub fn new(
         blocks: Option<HashMap<BlockHash, BlockMessage>>,

--- a/comm/src/rust/test_instances.rs
+++ b/comm/src/rust/test_instances.rs
@@ -110,6 +110,11 @@ impl TransportLayerStub {
         let requests = self.requests.lock().unwrap();
         requests.clone()
     }
+
+    pub fn pop_request(&self) -> Option<Request> {
+        let mut requests = self.requests.lock().unwrap();
+        requests.pop()
+    }
 }
 
 #[async_trait]

--- a/comm/src/rust/transport/transport_layer.rs
+++ b/comm/src/rust/transport/transport_layer.rs
@@ -65,12 +65,12 @@ pub trait TransportLayer {
 
     async fn stream_packet_to_peer(
         &self,
-        conf: RPConf,
+        conf: &RPConf,
         peer: &PeerNode,
         packet: Packet,
     ) -> Result<(), CommError> {
         let blob = Blob {
-            sender: conf.local,
+            sender: conf.local.clone(),
             packet,
         };
         self.stream(peer, &blob).await
@@ -78,7 +78,7 @@ pub trait TransportLayer {
 
     async fn stream_message_to_peer(
         &self,
-        conf: RPConf,
+        conf: &RPConf,
         peer: &PeerNode,
         msg: &(impl ToPacket + Sync),
     ) -> Result<(), CommError> {

--- a/models/src/rust/casper/protocol/casper_message.rs
+++ b/models/src/rust/casper/protocol/casper_message.rs
@@ -1028,7 +1028,7 @@ impl StoreItemsMessageRequest {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct StoreItemsMessage {
     pub start_path: Vec<(Blake2b256Hash, Option<Byte>)>,
     pub last_path: Vec<(Blake2b256Hash, Option<Byte>)>,

--- a/models/src/rust/casper/protocol/packet_type_tag.rs
+++ b/models/src/rust/casper/protocol/packet_type_tag.rs
@@ -5,8 +5,9 @@ use prost::Message;
 use crate::{
     casper::{
         ApprovedBlockProto, ApprovedBlockRequestProto, BlockApprovalProto, BlockHashMessageProto,
-        BlockMessageProto, BlockRequestProto, ForkChoiceTipRequestProto, HasBlockRequestProto,
-        NoApprovedBlockAvailableProto, StoreItemsMessageRequestProto, UnapprovedBlockProto,
+        BlockMessageProto, BlockRequestProto, ForkChoiceTipRequestProto, HasBlockProto,
+        HasBlockRequestProto, NoApprovedBlockAvailableProto, StoreItemsMessageProto,
+        StoreItemsMessageRequestProto, UnapprovedBlockProto,
     },
     routing::Packet,
 };
@@ -60,5 +61,7 @@ impl_packet!(NoApprovedBlockAvailableProto, "NoApprovedBlockAvailable");
 impl_packet!(BlockRequestProto, "BlockRequest");
 impl_packet!(ApprovedBlockRequestProto, "ApprovedBlockRequest");
 impl_packet!(HasBlockRequestProto, "HasBlockRequest");
+impl_packet!(HasBlockProto, "HasBlock");
 impl_packet!(ForkChoiceTipRequestProto, "ForkChoiceTipRequest");
 impl_packet!(StoreItemsMessageRequestProto, "StoreItemsMessageRequest");
+impl_packet!(StoreItemsMessageProto, "StoreItemsMessage");


### PR DESCRIPTION
# Overview
- ported Running.scala to Rust
- required changes in Rust codebase:
  - Introduced async_trait support in the Engine and MultiParentCasper traits for asynchronous operations.
  - Added new methods in MultiParentCasper for block DAG representation and state management.
  - Implemented a new Running state for the engine, encapsulating block processing and message handling.
  - Updated transport layer interactions to support async message streaming and block requests.
  - Enhanced test coverage for the new Running state and its interactions with the Casper protocol. 

# Test
- ported 4 unit tests in running_spec.rs