### PR TITLE
Adds write permission to CI workflow to release artifacts

### DIFF
--- a/.github/workflows/required-workflow.yml
+++ b/.github/workflows/required-workflow.yml
@@ -495,6 +495,8 @@ jobs:
   # GitHub (create) release and packages
   release_packages:
     name: Release Packages
+    permissions:
+      contents: write  # Required for creating/updating releases
     needs:
       - required_scala_unit_tests
       - required_integration_tests


### PR DESCRIPTION
This should fix the following failure encountered while releasing artifacts: https://github.com/F1R3FLY-io/f1r3fly/actions/runs/16659085015/job/47152733986