### PR TITLE
Default Docker build to just build for host architecture, not cross-compile for all possible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,20 @@ docker run -it -p 40400:40400 -p 40401:40401 -p 40402:40402 -p 40403:40403 -p 40
 
 Alternatively, build the Docker image locally after setting up the [development environment](#installation):
 
+**Native Build (Default - Fast)**:
 ```sh
 docker context use default && sbt ";compile ;project node ;Docker/publishLocal ;project rchain"
 ```
 
-This creates the image `f1r3flyindustries/f1r3fly-rust-node:latest`, which you can run as shown above.
+**Cross-Platform Build (Multi-Architecture)**:
+```sh
+CROSS_COMPILE=true docker context use default && sbt ";compile ;project node ;Docker/publishLocal ;project rchain"
+```
+
+- **Native build** compiles Rust libraries for your current architecture only (3-5x faster, ideal for development)
+- **Cross-platform build** compiles for both AMD64 and ARM64 architectures (slower, ideal for production/releases)
+
+Both commands create the image `f1r3flyindustries/f1r3fly-rust-node:latest`, which you can run as shown above.
 
 ### Debian/Ubuntu
 
@@ -182,9 +191,29 @@ Support for macOS native packages may be added in future releases.
 
 Prerequisites: [Environment set up](#installation).
 
-1. `docker context use default && sbt ";compile ;project node ;Docker/publishLocal ;project rchain"` will compile the project and create a docker image. 
-2. `sbt ";compile ;project node ;assembly ;project rchain"` will compile the project and create a fat jar. You can use this to run locally without docker.
-3. `sbt "clean"` will clean the project.
+### Docker Image
+
+**Native Build (Default - Recommended for Development)**:
+```sh
+docker context use default && sbt ";compile ;project node ;Docker/publishLocal ;project rchain"
+```
+
+**Cross-Platform Build (Multi-Architecture for Production)**:
+```sh
+CROSS_COMPILE=true docker context use default && sbt ";compile ;project node ;Docker/publishLocal ;project rchain"
+```
+
+### Fat JAR (Local Development)
+
+```sh
+sbt ";compile ;project node ;assembly ;project rchain"
+```
+
+### Clean
+
+```sh
+sbt "clean"
+```
 
 - It is recommended to have a terminal window open just for `sbt` to run various commands.
 

--- a/scripts/build_rust_libraries_docker_native.sh
+++ b/scripts/build_rust_libraries_docker_native.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -e
+
+# Detect host architecture and OS
+HOST_ARCH=$(uname -m)
+HOST_OS=$(uname -s)
+
+echo "Building Rust libraries for Docker (Linux) on $HOST_OS $HOST_ARCH..."
+
+# Determine Linux target and output directory based on host architecture
+case "$HOST_ARCH" in
+    x86_64|amd64)
+        LINUX_TARGET="x86_64-unknown-linux-gnu"
+        OUTPUT_DIR="rust_libraries/docker/release/amd64"
+        echo "🖥️  Host: x86_64 → Target: x86_64-unknown-linux-gnu → $OUTPUT_DIR"
+        ;;
+    aarch64|arm64)
+        LINUX_TARGET="aarch64-unknown-linux-gnu"
+        OUTPUT_DIR="rust_libraries/docker/release/aarch64"
+        echo "🍎 Host: arm64 → Target: aarch64-unknown-linux-gnu → $OUTPUT_DIR"
+        ;;
+    *)
+        echo "❌ Unsupported architecture: $HOST_ARCH"
+        exit 1
+        ;;
+esac
+
+# Create release directory
+mkdir -p "./$OUTPUT_DIR"
+
+# Determine build command based on host OS
+if [ "$HOST_OS" = "Linux" ]; then
+    echo "🐧 Building natively on Linux"
+    BUILD_CMD="cargo build --release"
+    SOURCE_PATH="./target/release"
+else
+    echo "📱 Cross-compiling to Linux from $HOST_OS using cross"
+    # Check if cross is available
+    if ! command -v cross &> /dev/null; then
+        echo "❌ 'cross' tool not found. Installing..."
+        cargo install cross --git https://github.com/cross-rs/cross 2>/dev/null || {
+            echo "❌ Failed to install cross. Please install it manually:"
+            echo "   cargo install cross --git https://github.com/cross-rs/cross"
+            exit 1
+        }
+    fi
+    # Install target if not already available
+    rustup target add $LINUX_TARGET 2>/dev/null || true
+    BUILD_CMD="cross build --release --target $LINUX_TARGET"
+    SOURCE_PATH="./target/$LINUX_TARGET/release"
+fi
+
+# Build rspace++ library
+echo "Building rspace++ library..."
+cd rspace++/
+$BUILD_CMD -p rspace_plus_plus_rhotypes
+cp "$SOURCE_PATH/librspace_plus_plus_rhotypes.so" "../$OUTPUT_DIR/"
+
+# Build rholang library  
+echo "Building rholang library..."
+cd ../rholang/
+$BUILD_CMD -p rholang
+cp "$SOURCE_PATH/librholang.so" "../$OUTPUT_DIR/"
+
+cd ..
+echo "✅ Native Rust libraries built successfully for Docker ($LINUX_TARGET)"
+echo "📁 Libraries available in: $OUTPUT_DIR/"
+ls -la "$OUTPUT_DIR"/*.so

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -4,6 +4,7 @@
 arch=$(uname -m)
 
 # Set JNA library path based on architecture
+echo "Using Rust libraries for $arch"
 case "$arch" in
   x86_64|amd64)
     JNA_PATH="-Djna.library.path=/opt/docker/rust_libraries/release/amd64/"


### PR DESCRIPTION
Updated Rust build script and SBT Docker build script to default build just for host architecture, not cross compile for all possible architectures.

Added flag `CROSS_COMPILE` which will trigger build for both `arm64` and `amd64`. Not enabled by default.

Updated README with instructions on how to use