### PR TITLE
nazar/fix-readonly

### DIFF
--- a/docker/shard-with-autopropose.yml
+++ b/docker/shard-with-autopropose.yml
@@ -156,6 +156,31 @@ services:
     # ports:
     #   - "8080:8080"
 
+#  # =================================================================
+#  # OBSERVER SERVICE - Read-only node for monitoring shard state
+#  # =================================================================
+#  readonly:
+#    image: f1r3flyindustries/f1r3fly-rust-node:latest
+#    user: root
+#    networks:
+#      - f1r3fly
+#    container_name: $READONLY_HOST
+#    ports:
+#      - "40451:40401"
+#      - "40452:40402"
+#      - "40453:40403"
+#    command:
+#      - run
+#      - --host=$READONLY_HOST
+#      - --bootstrap=rnode://1e780e5dfbe0a3d9470a2b414f502d59402e09c2@$BOOTSTRAP_HOST?protocol=40400&discovery=40404
+#      - --no-upnp
+#      - --allow-private-addresses
+#      - --api-max-blocks-limit=100
+#      - -Dlogback.configurationFile=/var/lib/rnode/logback.xml
+#
+#    volumes:
+#      - ./conf/logback.xml:/var/lib/rnode/logback.xml
+
 networks:
   f1r3fly:
     driver: bridge 

--- a/rholang/src/lib.rs
+++ b/rholang/src/lib.rs
@@ -864,14 +864,37 @@ extern "C" fn reset(
     runtime_ptr: *mut RhoRuntime,
     root_pointer: *const u8,
     root_bytes_len: usize,
-) -> () {
+) -> i32 {
     // println!("\nHit reset");
 
     let root_slice = unsafe { std::slice::from_raw_parts(root_pointer, root_bytes_len) };
     let root = Blake2b256Hash::from_bytes(root_slice.to_vec());
 
-    let runtime = unsafe { (*runtime_ptr).runtime.clone() };
-    runtime.try_lock().unwrap().reset(root);
+    // Access underlying space directly to capture Result and map to error code
+    let runtime_arc = unsafe { (*runtime_ptr).runtime.clone() };
+    let mut runtime = match runtime_arc.try_lock() {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("ERROR: failed to lock runtime in reset: {:?}", e);
+            return 2; // lock error
+        }
+    };
+
+    let mut space_lock = match runtime.reducer.space.try_lock() {
+        Ok(lock) => lock,
+        Err(e) => {
+            eprintln!("ERROR: failed to lock reducer.space in reset: {:?}", e);
+            return 2; // lock error
+        }
+    };
+
+    match space_lock.reset(root) {
+        Ok(_) => 0,
+        Err(e) => {
+            eprintln!("ERROR: reset failed: {:?}", e);
+            1 // generic reset error (e.g. unknown root)
+        }
+    }
 }
 
 #[no_mangle]

--- a/rholang/src/main/scala/coop/rchain/rholang/JNAInterface.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/JNAInterface.scala
@@ -29,7 +29,7 @@ trait JNAInterface extends Library {
       runtime_ptr: Pointer,
       root_pointer: Pointer,
       root_bytes_len: Int
-  ): Unit
+  ): Int
 
   def get_data(
       rspace: Pointer,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RhoRuntime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RhoRuntime.scala
@@ -820,13 +820,11 @@ class RhoRuntimeImpl[F[_]: Sync: Span](
   override def reset(root: Blake2b256Hash): F[Unit] =
     for {
       _ <- Sync[F].delay {
-            // println("\nhit scala reset, root: " + root)
-            val rootBytes = root.bytes.toArray
-
+            val rootBytes  = root.bytes.toArray
             val rootMemory = new Memory(rootBytes.length.toLong)
             rootMemory.write(0, rootBytes, 0, rootBytes.length)
 
-            val _ = RHOLANG_RUST_INSTANCE.reset(
+            val code = RHOLANG_RUST_INSTANCE.reset(
               runtimePtr,
               rootMemory,
               rootBytes.length
@@ -835,6 +833,10 @@ class RhoRuntimeImpl[F[_]: Sync: Span](
             // Not sure if these lines are needed
             // Need to figure out how to deallocate each memory instance
             rootMemory.clear()
+
+            if (code != 0) {
+              throw new RuntimeException(s"Rust RhoRuntime.reset failed, code=$code")
+            }
           }
     } yield ()
 

--- a/rspace++/src/main/scala/JNAInterface.scala
+++ b/rspace++/src/main/scala/JNAInterface.scala
@@ -42,11 +42,11 @@ trait JNAInterface extends Library {
 
   def create_checkpoint(rspace: Pointer): Pointer
 
-  def reset(
+  def reset_rspace(
       rspace: Pointer,
       root_pointer: Pointer,
       root_bytes_len: Int
-  ): Unit
+  ): Int
 
   def get_data(
       rspace: Pointer,


### PR DESCRIPTION
Problem
During LFS import, the wrong root hash was passed to Rust in setRoot. As a result, reset received a non-existent hash and failed on unwrap, crashing the process.

Fix
- Pass the correct root hash to setRoot so Rust recognizes the state.
- Remove panic from reset and return an error code instead. This lets the Scala layer decide how to handle failures (e.g., convert to ReplayFailure/BlockStatus) without crashing the container.

Why error codes
- Scala-side control: errors are handled in JVM land (can be logged, mapped, or retried) instead of causing an uncontrolled abort.
- Resource safety: JNA memory is released before propagating the failure; panic does not guarantee that.

Impact
Prevents process-wide crashes on bad roots; restores stability while preserving correct failure semantics at the Scala level.

In short
Rust panic over FFI => process crash. Returning error codes => safe handoff to Scala with full control over handling.