### PR TITLE
Fix Replay of Non-determinstic System Process in Shard mode

### DIFF
--- a/models/src/main/scala/coop/rchain/casper/protocol/CasperMessage.scala
+++ b/models/src/main/scala/coop/rchain/casper/protocol/CasperMessage.scala
@@ -585,8 +585,8 @@ object Event {
       pe.persistent,
       pe.timesRepeated,
       pe.isDeterministic,
-      Seq.empty
-    ) //pe.outputValue)
+      pe.outputValue.map(_.toByteArray)
+    )
 
   private def toProduceEventProto(pe: ProduceEvent): ProduceEventProto =
     ProduceEventProto(
@@ -595,8 +595,8 @@ object Event {
       pe.persistent,
       pe.timesRepeated,
       pe.isDeterministic,
-      Seq.empty
-    ) //pe.outputValue)
+      pe.outputValue.map(ba => ByteString.copyFrom(ba))
+    )
 
   private def toConsumeEventProto(ce: ConsumeEvent): ConsumeEventProto =
     ConsumeEventProto(ce.channelsHashes, ce.hash, ce.persistent)


### PR DESCRIPTION
# Overview

Fixes replaying Non-Deterministic System Process (like gpt4 call) in Shard mode


# Manual test 
1. Deployed Rholang with GPT call:
```rholang
new gptAnswer,
    gpt4(`rho:ai:gpt4`),
    stdout(`rho:io:stdout`) in {
			
  gpt4!("abc", *gptAnswer) |
  for(@answer <- gptAnswer) {
    stdout!(["GTP4 created a prompt", answer])
  }
}
``
2. Make sure Observer can validate and replay the block
<img width="1914" height="807" alt="Untitled" src="https://github.com/user-attachments/assets/21a9b9ad-3a69-49e8-8477-92d14435ef96" />
