### PR TITLE
fix: return the eval cost in case of InterpreterError

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
@@ -116,7 +116,7 @@ class InterpreterImpl[F[_]: Sync: Span](implicit C: _cost[F], mergeChs: Ref[F, S
 
       // InterpreterError is returned as a result
       case error: InterpreterError =>
-        EvaluateResult(initialCost, Vector(error), Set()).pure[F]
+        EvaluateResult(evalCost, Vector(error), Set()).pure[F]
 
       // Any other error is unexpected and it's fatal, rethrow
       case error: Throwable =>


### PR DESCRIPTION
Fixing the Bug #179 

# Manual test
0. Run a new shard and check balance before deployment <img width="454" height="146" alt="image" src="https://github.com/user-attachments/assets/227e33f0-0890-486f-97cf-03b289a906d1" />
1. Deployment  <img width="935" height="330" alt="image" src="https://github.com/user-attachments/assets/82f5d403-dd1a-4978-bd25-8fcccb8db020" />
2. Confirm the cost in the block <img width="1058" height="208" alt="image" src="https://github.com/user-attachments/assets/3d45f7cd-c9f6-4e33-be05-3632ab907b4a" />
3. Check Refund number in logs <img width="1402" height="604" alt="image" src="https://github.com/user-attachments/assets/41ec5ba2-a3fd-4a59-b28a-ada0979efa7a" />
4. Check balance after  <img width="449" height="140" alt="image" src="https://github.com/user-attachments/assets/63d4bcf8-4a17-4c2d-9aae-a5da71d8758c" />

