### PR TITLE
fix: return the eval cost in case of InterpreterError in Rust

### DIFF
--- a/rholang/src/rust/interpreter/interpreter.rs
+++ b/rholang/src/rust/interpreter/interpreter.rs
@@ -101,6 +101,10 @@ impl InterpreterImpl {
         parsing_cost: Cost,
         error: InterpreterError,
     ) -> Result<EvaluateResult, InterpreterError> {
+        // Calculate the evaluated cost (actual cost consumed so far)
+        let phlos_left = self.c.get();
+        let eval_cost = initial_cost.clone() - phlos_left;
+
         match error {
             // Parsing error consumes only parsing cost
             InterpreterError::ParserError(_) => Ok(EvaluateResult {
@@ -147,9 +151,9 @@ impl InterpreterImpl {
                 mergeable: HashSet::new(),
             }),
 
-            // InterpreterError is returned as a result
+            // InterpreterError is returned as a result with evaluated cost
             _ => Ok(EvaluateResult {
-                cost: initial_cost,
+                cost: eval_cost,
                 errors: vec![error],
                 mergeable: HashSet::new(),
             }),


### PR DESCRIPTION
Porting #185 to Rust version