### PR TITLE
feat: Ported hearbeat proposer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,7 +2492,7 @@ dependencies = [
  "itertools 0.12.1",
  "models",
  "prost 0.14.1",
- "rand 0.8.5",
+ "rand 0.9.2",
  "regex",
  "rholang",
  "rpassword",

--- a/casper/src/rust/blocks/proposer/block_creator.rs
+++ b/casper/src/rust/blocks/proposer/block_creator.rs
@@ -152,6 +152,7 @@ pub async fn create(
     deploy_storage: Arc<Mutex<KeyValueDeployStorage>>,
     runtime_manager: &mut RuntimeManager,
     block_store: &mut KeyValueBlockStore,
+    allow_empty_blocks: bool,
 ) -> Result<BlockCreatorResult, CasperError> {
     let next_seq_num = casper_snapshot
         .max_seq_nums
@@ -191,7 +192,7 @@ pub async fn create(
     // Note: system_deploys always contains CloseBlockDeploy, but that doesn't count
     // as "new deploys" for the purpose of creating a block
     let has_slashing_deploys = !slashing_deploys.is_empty();
-    if all_deploys.is_empty() && !has_slashing_deploys {
+    if !allow_empty_blocks && all_deploys.is_empty() && !has_slashing_deploys {
         return Ok(BlockCreatorResult::NoNewDeploys);
     }
 

--- a/casper/src/rust/blocks/proposer/proposer.rs
+++ b/casper/src/rust/blocks/proposer/proposer.rs
@@ -73,6 +73,7 @@ pub trait BlockCreator {
         casper_snapshot: &CasperSnapshot,
         validator_identity: &ValidatorIdentity,
         dummy_deploy_opt: Option<(PrivateKey, String)>,
+        allow_empty_blocks: bool,
     ) -> Result<BlockCreatorResult, CasperError>;
 }
 
@@ -194,6 +195,7 @@ where
                         casper_snapshot,
                         &self.validator,
                         self.dummy_deploy_opt.clone(),
+                        false,
                     )
                     .await?;
 
@@ -483,6 +485,7 @@ impl BlockCreator for ProductionBlockCreator {
         casper_snapshot: &CasperSnapshot,
         validator_identity: &ValidatorIdentity,
         dummy_deploy_opt: Option<(PrivateKey, String)>,
+        allow_empty_blocks: bool,
     ) -> Result<BlockCreatorResult, CasperError> {
         block_creator::create(
             casper_snapshot,
@@ -491,6 +494,7 @@ impl BlockCreator for ProductionBlockCreator {
             self.deploy_storage.clone(),
             &mut self.runtime_manager,
             &mut self.block_store,
+            allow_empty_blocks,
         )
         .await
     }

--- a/casper/src/rust/casper_conf.rs
+++ b/casper/src/rust/casper_conf.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::{path::PathBuf, time::Duration};
+use tokio::runtime::Handle;
 
 /// Casper configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -55,6 +56,8 @@ pub struct CasperConf {
 
     #[serde(rename = "min-phlo-price")]
     pub min_phlo_price: i64,
+
+    pub heartbeat_conf: HeartbeatConf,
 }
 
 /// Round robin dispatcher configuration
@@ -124,6 +127,15 @@ pub struct GenesisCeremony {
 
     #[serde(rename = "ceremony-master-mode")]
     pub ceremony_master_mode: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HeartbeatConf {
+    pub enabled: bool,
+    #[serde(rename = "check-interval", deserialize_with = "de_duration")]
+    pub check_interval: Duration,
+    #[serde(rename = "max-lfb-age", deserialize_with = "de_duration")]
+    pub max_lfb_age: Duration,
 }
 
 pub fn de_duration<'de, D>(deserializer: D) -> Result<Duration, D::Error>

--- a/casper/tests/add_block/proposer_spec.rs
+++ b/casper/tests/add_block/proposer_spec.rs
@@ -106,6 +106,7 @@ impl BlockCreator for TestBlockCreator {
         _: &CasperSnapshot,
         _: &ValidatorIdentity,
         _: Option<(PrivateKey, String)>,
+        _: bool,
     ) -> Result<BlockCreatorResult, CasperError> {
         use models::rust::block_implicits::get_random_block_default;
         Ok(BlockCreatorResult::Created(get_random_block_default()))

--- a/casper/tests/helper/test_node.rs
+++ b/casper/tests/helper/test_node.rs
@@ -186,6 +186,7 @@ impl TestNode {
             self.deploy_storage.clone(),
             &mut self.runtime_manager.clone(),
             &mut self.block_store.clone(),
+            false,
         )
         .await
     }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -39,10 +39,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"]
 tracing-log = "0.2"
 dashmap = "6.1.0"
 regex = "1.0"
+rand = "0.9.2"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
-rand = "0.8"
 rspace_plus_plus = { path = "../rspace++" }
 # No dependencies yet - empty module
 

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -334,6 +334,19 @@ casper {
   # The minimum Phlogiston price. Value can be configured to provide sufficient transaction fees to cover
   # the cost of the network and equipment
   min-phlo-price = 1
+
+  # Heartbeat configuration for maintaining liveness during periods of no user activity
+  heartbeat {
+    # Enable heartbeat block proposing
+    enabled = false
+
+    # Check interval - how often to check if heartbeat is needed
+    check-interval = 30 seconds
+
+    # Maximum age of last finalized block before triggering heartbeat
+    # If no block has been finalized in this duration, propose an empty block
+    max-lfb-age = 60 seconds
+  }
 }
 
 # Enable/disable Kamon reporters. Kamon is used for metrics collection / aggregation.

--- a/node/src/rust/configuration/commandline/config_mapper.rs
+++ b/node/src/rust/configuration/commandline/config_mapper.rs
@@ -587,6 +587,11 @@ mod tests {
                     ceremony_master_mode: false,
                 },
                 min_phlo_price: 1,
+                heartbeat_conf: casper::rust::casper_conf::HeartbeatConf {
+                    enabled: false,
+                    check_interval: Duration::from_secs(30),
+                    max_lfb_age: Duration::from_secs(60),
+                },
             },
             metrics: crate::rust::configuration::model::Metrics {
                 prometheus: false,

--- a/node/src/rust/instances/heartbeat_proposer.rs
+++ b/node/src/rust/instances/heartbeat_proposer.rs
@@ -1,0 +1,176 @@
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use casper::rust::blocks::proposer::proposer::ProposerResult;
+use casper::rust::casper::{CasperSnapshot, MultiParentCasper};
+use casper::rust::casper_conf::HeartbeatConf;
+use casper::rust::engine::engine_cell::EngineCell;
+use casper::rust::validator_identity::ValidatorIdentity;
+use models::rust::casper::protocol::casper_message::BlockMessage;
+use rand::Rng;
+
+use casper::rust::ProposeFunction;
+
+/// Heartbeat proposer that periodically checks if a block
+/// needs to be proposed to maintain liveness.
+pub struct HeartbeatProposer;
+
+impl HeartbeatProposer {
+    /// Create a heartbeat proposer stream that periodically checks if a block
+    /// needs to be proposed to maintain liveness.
+    ///
+    /// This integrates with the existing propose queue mechanism for thread safety.
+    /// The heartbeat simply calls the same triggerPropose function that user deploys
+    /// and explicit propose calls use, ensuring serialization through ProposerInstance.
+    ///
+    /// To prevent lock-step behavior between validators, the stream waits a random
+    /// amount of time (0 to checkInterval) before starting the periodic checks.
+    ///
+    /// The heartbeat only runs on bonded validators. It checks the active validators
+    /// set before proposing to avoid unnecessary attempts by unbonded nodes.
+    ///
+    /// # Arguments
+    ///
+    /// * `engine_cell` - The EngineCell to read the current Casper instance from
+    /// * `trigger_propose_f` - The propose function that integrates with the propose queue
+    /// * `validator_identity` - The validator identity to check if bonded
+    /// * `config` - Heartbeat configuration (enabled, check_interval, max_lfb_age)
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(JoinHandle)` when the heartbeat is spawned, or `None` when
+    /// disabled or trigger function is not available.
+    pub fn create(
+        engine_cell: Arc<EngineCell>,
+        trigger_propose_f: Option<Arc<ProposeFunction>>, // same queue/function used by user-triggered proposes
+        validator_identity: ValidatorIdentity,
+        config: HeartbeatConf,
+    ) -> Option<tokio::task::JoinHandle<()>> {
+        if !config.enabled {
+            return None;
+        }
+
+        let trigger = match trigger_propose_f {
+            Some(f) => f,
+            None => {
+                tracing::warn!("Heartbeat: trigger_propose function not available, skipping spawn");
+                return None;
+            }
+        };
+
+        let initial_delay = random_initial_delay(config.check_interval);
+        tracing::info!(
+            "Heartbeat: Starting with random initial delay of {}s (check interval: {}s, max LFB age: {}s)",
+            initial_delay.as_secs(),
+            config.check_interval.as_secs(),
+            config.max_lfb_age.as_secs()
+        );
+
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(initial_delay).await;
+
+            let mut ticker = tokio::time::interval(config.check_interval);
+
+            loop {
+                // wait next tick
+                ticker.tick().await;
+
+                tracing::debug!("Heartbeat: Checking if propose is needed");
+                let eng = engine_cell.get().await;
+
+                // Access Casper if available and run the check
+                if let Some(casper) = eng.with_casper() {
+                    let _ =
+                        do_heartbeat_check(casper, &*trigger, &validator_identity, &config).await;
+                } else {
+                    tracing::debug!("Heartbeat: Casper not available yet, skipping check");
+                }
+            }
+        });
+
+        Some(handle)
+    }
+}
+
+fn random_initial_delay(check_interval: Duration) -> Duration {
+    let max_millis = check_interval.as_millis() as u64;
+    let random_millis = rand::rng().random_range(0..=max_millis);
+    Duration::from_millis(random_millis)
+}
+
+async fn do_heartbeat_check(
+    casper: &dyn MultiParentCasper,
+    trigger_propose: &ProposeFunction,
+    validator_identity: &ValidatorIdentity,
+    config: &HeartbeatConf,
+) -> Result<(), casper::rust::errors::CasperError> {
+    let snapshot: CasperSnapshot = casper.get_snapshot().await?;
+
+    let is_bonded = snapshot
+        .on_chain_state
+        .active_validators
+        .contains(&validator_identity.public_key.bytes);
+
+    if !is_bonded {
+        tracing::info!("Heartbeat: Validator is not bonded, skipping heartbeat propose");
+    } else {
+        tracing::debug!("Heartbeat: Validator is bonded, checking LFB age");
+        check_lfb_and_propose(casper, trigger_propose, config).await?;
+    }
+
+    Ok(())
+}
+
+async fn check_lfb_and_propose(
+    casper: &dyn MultiParentCasper,
+    trigger_propose: &ProposeFunction,
+    config: &HeartbeatConf,
+) -> Result<(), casper::rust::errors::CasperError> {
+    let lfb: BlockMessage = casper.last_finalized_block().await?;
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u128)
+        .unwrap_or(0);
+
+    let lfb_timestamp_ms = lfb.header.timestamp as u128;
+
+    let time_since_lfb = now - lfb_timestamp_ms;
+
+    let should_propose = time_since_lfb > config.max_lfb_age.as_millis();
+
+    if should_propose {
+        tracing::info!(
+            "Heartbeat: LFB is {}ms old (threshold: {}ms), triggering propose",
+            time_since_lfb,
+            config.max_lfb_age.as_millis()
+        );
+
+        let result = trigger_propose(casper, false)?;
+        match result {
+            ProposerResult::Empty => {
+                tracing::debug!("Heartbeat: Propose already in progress, will retry next check");
+            }
+            ProposerResult::Failure(status, seq_num) => {
+                tracing::warn!(
+                    "Heartbeat: Propose failed with {} (seqNum {})",
+                    status,
+                    seq_num
+                );
+            }
+            ProposerResult::Success(_, _) => {
+                tracing::info!("Heartbeat: Successfully created block");
+            }
+            ProposerResult::Started(seq_num) => {
+                tracing::info!("Heartbeat: Async propose started (seqNum {})", seq_num);
+            }
+        }
+    } else {
+        tracing::debug!(
+            "Heartbeat: LFB age is {}ms, no action needed",
+            time_since_lfb
+        );
+    }
+
+    Ok(())
+}

--- a/node/src/rust/instances/mod.rs
+++ b/node/src/rust/instances/mod.rs
@@ -1,2 +1,3 @@
 pub mod block_processor_instance;
+pub mod heartbeat_proposer;
 pub mod proposer_instance;

--- a/node/tests/rho_trie_traverser_test.rs
+++ b/node/tests/rho_trie_traverser_test.rs
@@ -21,13 +21,13 @@ async fn traverse_the_tree_hash_map_should_work() {
     let trie_depth = 2;
 
     // Generate random key-value pairs like the original Scala test
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let insert_key_values: Vec<(String, i32, i32)> = (0..=total)
         .map(|i| {
             let key: String = (0..10)
-                .map(|_| rng.sample(rand::distributions::Alphanumeric) as char)
+                .map(|_| rng.sample(rand::distr::Alphanumeric) as char)
                 .collect();
-            let value = rng.gen_range(0..1_000_000);
+            let value = rng.random_range(0..1_000_000);
             (key, value, i)
         })
         .collect();


### PR DESCRIPTION
## Overview
Port Heartbeat Proposer from Scala to Rust

This PR ports the heartbeat proposer functionality from Scala to Rust, enabling validators to automatically propose blocks when the last finalized block (LFB) becomes stale, ensuring liveness during periods of no user activity.

### Summary

The heartbeat proposer is a background task that periodically checks if a block needs to be proposed to maintain network liveness. It integrates with the existing propose queue mechanism.

This PR is a direct port of this [PR](https://github.com/F1R3FLY-io/f1r3node/pull/209)

