### PR TITLE
Fix overflow when `seqNum` exceeds 16-bit unsigned max

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/merging/RholangMergingLogic.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/merging/RholangMergingLogic.scala
@@ -18,7 +18,7 @@ import coop.rchain.rspace.{HotStoreTrieAction, TrieInsertBinaryProduce}
 import coop.rchain.scodec.codecs
 import scodec.Codec
 import scodec.bits.ByteVector
-import scodec.codecs.{bytes, int64, uint16, variableSizeBytes}
+import scodec.codecs.{bytes, int32, int64, uint16, variableSizeBytes}
 
 object RholangMergingLogic {
 
@@ -208,6 +208,7 @@ object RholangMergingLogic {
   val codecByteVectorVar: Codec[ByteVector] = variableSizeBytes(uint16, bytes)
 
   val codecMergeableKey: Codec[(ByteVector, ByteVector, Int)] =
-    (codecByteVectorVar :: codecByteVectorVar :: uint16).as[(ByteVector, ByteVector, Int)]
+    (codecByteVectorVar :: codecByteVectorVar :: int32).as[(ByteVector, ByteVector, Int)]
 
 }
+


### PR DESCRIPTION
## Overview
**Problem**: Node crashed when `seqNum` reached 65536 because it was encoded as uint16 (max value: 65535).

**Solution**: Changed the third element in codecMergeableKey from uint16 to int32 in `RholangMergingLogic.scala`.

Now considered element matches `codecSeqNum` type and the original `seqNum` type across source code.
Validator can now create more than 65535 blocks without crashing.

## Note log:
```
05:33:23.366 [INFO ] [node-runner-34      ] [blocks.proposer.BlockCreator$] - Creating block #196293 (seqNum 65536)
05:33:23.406 [INFO ] [node-runner-33      ] [ain.casper.rholang.RuntimeOps] - PreCharging 04e4d995455227aadaef612d545231475b24b952a0ab75c6d4396e3b06e6909ec70a5f9db353464cd561d9c542a9f5eb138401d4694f409d402f724ac104d61026 for 50000
"hello, world!"
05:33:23.923 [INFO ] [node-runner-33      ] [ain.casper.rholang.RuntimeOps] - Refunding 04e4d995455227aadaef612d545231475b24b952a0ab75c6d4396e3b06e6909ec70a5f9db353464cd561d9c542a9f5eb138401d4694f409d402f724ac104d61026 with 49683
05:33:24.764 [ERROR] [node-runner-31      ] [hain.node.runtime.NodeRuntime] - Caught unhandable error. Exiting. Stacktrace below.
java.lang.Exception: 65536 is greater than maximum value 65535 for 16-bit unsigned integer
	at coop.rchain.shared.AttemptOpsF$.ex(AttemptOpsF.scala:10)
	at coop.rchain.shared.AttemptOpsF$RichAttempt.get(AttemptOpsF.scala:19)
	at coop.rchain.casper.util.rholang.RuntimeManagerOps$.$anonfun$saveMergeableChannels$3(RuntimeManagerSyntax.scala:79)
	at scala.Function1.$anonfun$andThen$1(Function1.scala:57)
	at runToFuture @ coop.rchain.catscontrib.TaskContrib$TaskOps$.unsafeRunSync$extension(taskOps.scala:27)
	at runToFuture @ coop.rchain.catscontrib.TaskContrib$TaskOps$.unsafeRunSync$extension(taskOps.scala:27)
	at runToFuture @ coop.rchain.catscontrib.TaskContrib$TaskOps$.unsafeRunSync$extension(taskOps.scala:27)
	at runToFuture @ coop.rchain.catscontrib.TaskContrib$TaskOps$.unsafeRunSync$extension(taskOps.scala:27)
	at runToFuture @ coop.rchain.catscontrib.TaskContrib$TaskOps$.unsafeRunSync$extension(taskOps.scala:27)
	at runToFuture @ coop.rchain.catscontrib.TaskContrib$TaskOps$.unsafeRunSync$extension(taskOps.scala:27)
	at runToFuture @ coop.rchain.catscontrib.TaskContrib$TaskOps$.unsafeRunSync$extension(taskOps.scala:27)
	at runToFuture @ coop.rchain.catscontrib.TaskContrib$TaskOps$.unsafeRunSync$extension(taskOps.scala:27)
	at runToFuture @ coop.rchain.catscontrib.TaskContrib$TaskOps$.unsafeRunSync$extension(taskOps.scala:27)
	at runToFuture @ coop.rchain.catscontrib.TaskContrib$TaskOps$.unsafeRunSync$extension(taskOps.scala:27)
	at runToFuture @ coop.rchain.catscontrib.TaskContrib$TaskOps$.unsafeRunSync$extension(taskOps.scala:27)
	at runToFuture @ coop.rchain.catscontrib.TaskContrib$TaskOps$.unsafeRunSync$extension(taskOps.scala:27)
	at runToFuture @ coop.rchain.catscontrib.TaskContrib$TaskOps$.unsafeRunSync$extension(taskOps.scala:27)
	at runToFuture @ coop.rchain.catscontrib.TaskContrib$TaskOps$.unsafeRunSync$extension(taskOps.scala:27)
	at runToFuture @ coop.rchain.catscontrib.TaskContrib$TaskOps$.unsafeRunSync$extension(taskOps.scala:27)
	at runToFuture @ coop.rchain.catscontrib.TaskContrib$TaskOps$.unsafeRunSync$extension(taskOps.scala:27)

```
### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
