### PR TITLE
ported engine specs

### DIFF
--- a/casper/src/rust/engine/block_approver_protocol.rs
+++ b/casper/src/rust/engine/block_approver_protocol.rs
@@ -28,18 +28,18 @@ use crate::rust::validator_identity::ValidatorIdentity;
 pub struct BlockApproverProtocol<T: TransportLayer + Send + Sync + 'static> {
     // Configuration / static data
     validator_id: ValidatorIdentity,
-    deploy_timestamp: i64,
-    vaults: Vec<Vault>,
+    pub deploy_timestamp: i64,
+    pub vaults: Vec<Vault>,
     bonds: HashMap<crypto::rust::public_key::PublicKey, i64>,
-    bonds_bytes: HashMap<Bytes, i64>, // helper map keyed by raw bytes
-    minimum_bond: i64,
-    maximum_bond: i64,
-    epoch_length: i32,
-    quarantine_length: i32,
-    number_of_active_validators: u32,
-    required_sigs: i32,
-    pos_multi_sig_public_keys: Vec<String>,
-    pos_multi_sig_quorum: u32,
+    pub bonds_bytes: HashMap<Bytes, i64>, // helper map keyed by raw bytes
+    pub minimum_bond: i64,
+    pub maximum_bond: i64,
+    pub epoch_length: i32,
+    pub quarantine_length: i32,
+    pub number_of_active_validators: u32,
+    pub required_sigs: i32,
+    pub pos_multi_sig_public_keys: Vec<String>,
+    pub pos_multi_sig_quorum: u32,
 
     // Infrastructure
     transport: Arc<T>,
@@ -107,16 +107,44 @@ impl<T: TransportLayer + Send + Sync + 'static> BlockApproverProtocol<T> {
         }
     }
 
+    /// NOTE: Why is this a public static method instead of an instance method?
+    ///
+    /// This design matches the Scala implementation where `validateCandidate` is a static
+    /// method in the companion object
+    ///
+    /// Reasons for static method:
+    /// 1. **Testing flexibility**: Tests need to validate candidates with intentionally
+    ///    wrong parameters (wrong bonds, wrong vaults, wrong genesis params) to verify
+    ///    rejection logic. With an instance method, we'd need to create new protocol
+    ///    instances for each test case, which is cumbersome and verbose.
+    ///
+    /// 2. **Separation of concerns**: Validation is a pure function that doesn't require
+    ///    the protocol's network/transport infrastructure. It only needs validation
+    ///    parameters and a RuntimeManager.
+    ///
+    /// 3. **1:1 Scala port compliance**: Keeping the same API structure as Scala ensures
+    ///    behavioral equivalence and makes cross-referencing easier during porting.
+    ///
     /// Corresponds to Scala `BlockApproverProtocol.validateCandidate` –
     /// performs full validation of the candidate genesis block.
-    async fn validate_candidate(
-        &self,
+    pub async fn validate_candidate(
         runtime_manager: &mut RuntimeManager,
         candidate: &ApprovedBlockCandidate,
+        required_sigs: i32,
+        deploy_timestamp: i64,
+        vaults: &Vec<Vault>,
+        bonds: &HashMap<Bytes, i64>,
+        minimum_bond: i64,
+        maximum_bond: i64,
+        epoch_length: i32,
+        quarantine_length: i32,
+        number_of_active_validators: u32,
         shard_id: &str,
+        pos_multi_sig_public_keys: &[String],
+        pos_multi_sig_quorum: u32,
     ) -> Result<(), String> {
         // Basic checks – required sigs, absence of system deploys, bonds equality
-        if candidate.required_sigs != self.required_sigs {
+        if candidate.required_sigs != required_sigs {
             return Err("Candidate didn't have required signatures number.".to_string());
         }
 
@@ -133,7 +161,7 @@ impl<T: TransportLayer + Send + Sync + 'static> BlockApproverProtocol<T> {
             .map(|b| (b.validator.clone(), b.stake))
             .collect();
 
-        if block_bonds != self.bonds_bytes {
+        if &block_bonds != bonds {
             return Err("Block bonds don't match expected.".to_string());
         }
 
@@ -147,22 +175,22 @@ impl<T: TransportLayer + Send + Sync + 'static> BlockApproverProtocol<T> {
             .collect();
 
         let pos_params = ProofOfStake {
-            minimum_bond: self.minimum_bond,
-            maximum_bond: self.maximum_bond,
+            minimum_bond,
+            maximum_bond,
             validators,
-            epoch_length: self.epoch_length,
-            quarantine_length: self.quarantine_length,
-            number_of_active_validators: self.number_of_active_validators,
-            pos_multi_sig_public_keys: self.pos_multi_sig_public_keys.clone(),
-            pos_multi_sig_quorum: self.pos_multi_sig_quorum,
+            epoch_length,
+            quarantine_length,
+            number_of_active_validators,
+            pos_multi_sig_public_keys: pos_multi_sig_public_keys.to_vec(),
+            pos_multi_sig_quorum,
         };
 
         // Expected blessed contracts
         let genesis_blessed_contracts =
             crate::rust::genesis::genesis::Genesis::default_blessed_terms_with_timestamp(
-                self.deploy_timestamp,
+                deploy_timestamp,
                 &pos_params,
-                &self.vaults,
+                vaults,
                 i64::MAX,
                 shard_id,
             );
@@ -226,11 +254,39 @@ impl<T: TransportLayer + Send + Sync + 'static> BlockApproverProtocol<T> {
             .map(|b| (b.validator, b.stake))
             .collect();
 
-        if tuplespace_bonds_map != self.bonds_bytes {
+        if &tuplespace_bonds_map != bonds {
             return Err("Tuplespace bonds don't match expected ones.".to_string());
         }
 
         Ok(())
+    }
+
+    /// Internal instance method that delegates to the static validate_candidate.
+    /// This provides a convenient API for unapproved_block_packet_handler which
+    /// already has all parameters in self.
+    async fn validate_candidate_internal(
+        &self,
+        runtime_manager: &mut RuntimeManager,
+        candidate: &ApprovedBlockCandidate,
+        shard_id: &str,
+    ) -> Result<(), String> {
+        Self::validate_candidate(
+            runtime_manager,
+            candidate,
+            self.required_sigs,
+            self.deploy_timestamp,
+            &self.vaults,
+            &self.bonds_bytes,
+            self.minimum_bond,
+            self.maximum_bond,
+            self.epoch_length,
+            self.quarantine_length,
+            self.number_of_active_validators,
+            shard_id,
+            &self.pos_multi_sig_public_keys,
+            self.pos_multi_sig_quorum,
+        )
+        .await
     }
 
     /// Corresponds to Scala `BlockApproverProtocol.unapprovedBlockPacketHandler` –
@@ -249,7 +305,7 @@ impl<T: TransportLayer + Send + Sync + 'static> BlockApproverProtocol<T> {
         );
 
         match self
-            .validate_candidate(runtime_manager, &candidate, shard_id)
+            .validate_candidate_internal(runtime_manager, &candidate, shard_id)
             .await
         {
             Ok(_) => {

--- a/casper/src/rust/engine/block_retriever.rs
+++ b/casper/src/rust/engine/block_retriever.rs
@@ -95,6 +95,11 @@ impl<T: TransportLayer + Send + Sync> BlockRetriever<T> {
         }
     }
 
+    /// Get access to the requested_blocks for testing purposes
+    pub fn requested_blocks(&self) -> &RequestedBlocks {
+        &self.requested_blocks
+    }
+
     /// Helper method to add a source peer to an existing request
     fn add_source_peer_to_request(
         init_state: &mut HashMap<BlockHash, RequestState>,

--- a/casper/tests/engine/block_approver_protocol_test.rs
+++ b/casper/tests/engine/block_approver_protocol_test.rs
@@ -1,0 +1,287 @@
+// See casper/src/test/scala/coop/rchain/casper/engine/BlockApproverProtocolTest.scala
+
+use crate::helper::test_node::TestNode;
+use crate::util::comm::transport_layer_test_impl::TransportLayerTestImpl;
+use crate::util::genesis_builder::GenesisBuilder;
+use casper::rust::engine::block_approver_protocol::BlockApproverProtocol;
+use crypto::rust::public_key::PublicKey;
+use models::rust::{
+    block_implicits::get_random_block,
+    casper::protocol::casper_message::{ApprovedBlockCandidate, BlockMessage, UnapprovedBlock},
+};
+use std::collections::HashMap;
+use std::error::Error;
+use std::sync::Arc;
+
+const SHARD_ID: &str = "root-shard";
+
+struct TestContext {
+    protocol: BlockApproverProtocol<TransportLayerTestImpl>,
+    node: TestNode,
+    required_sigs: i32,
+}
+
+impl TestContext {
+    fn create_unapproved(required_sigs: i32, block: &BlockMessage) -> UnapprovedBlock {
+        UnapprovedBlock {
+            candidate: ApprovedBlockCandidate {
+                block: block.clone(),
+                required_sigs,
+            },
+            timestamp: 0,
+            duration: 0,
+        }
+    }
+
+    async fn create_protocol() -> Result<Self, Box<dyn Error>> {
+        let params = GenesisBuilder::build_genesis_parameters_with_defaults(None, None);
+        let genesis_params = params.2.clone();
+
+        let mut genesis_builder = GenesisBuilder::new();
+        let genesis_context = genesis_builder
+            .build_genesis_with_parameters(Some(params))
+            .await?;
+
+        let bonds: HashMap<PublicKey, i64> = genesis_params
+            .proof_of_stake
+            .validators
+            .iter()
+            .map(|v| (v.pk.clone(), v.stake))
+            .collect();
+
+        let required_sigs = (bonds.len() - 1) as i32;
+
+        let mut nodes =
+            TestNode::create_network(genesis_context, 1, None, None, None, None).await?;
+
+        // Note: Using remove(0) instead of referencing nodes[0] because TestNode doesn't implement Clone
+        // and we need an owned value. This is acceptable since networkSize=1 (only one element).
+        let node = nodes.remove(0);
+
+        let protocol = BlockApproverProtocol::new(
+            node.validator_id_opt.clone().unwrap(),
+            genesis_params.timestamp,
+            genesis_params.vaults,
+            bonds,
+            genesis_params.proof_of_stake.minimum_bond,
+            genesis_params.proof_of_stake.maximum_bond,
+            genesis_params.proof_of_stake.epoch_length,
+            genesis_params.proof_of_stake.quarantine_length,
+            genesis_params.proof_of_stake.number_of_active_validators,
+            required_sigs,
+            genesis_params.proof_of_stake.pos_multi_sig_public_keys,
+            genesis_params.proof_of_stake.pos_multi_sig_quorum,
+            node.tle.clone(),
+            Arc::new(node.rp_conf.clone()),
+        )?;
+
+        Ok(Self {
+            protocol,
+            node,
+            required_sigs,
+        })
+    }
+}
+
+#[tokio::test]
+async fn block_approver_protocol_should_respond_to_valid_approved_block_candidates() {
+    // In Rust, we use TestContext struct to hold both protocol and node.
+    let mut ctx = TestContext::create_protocol().await.unwrap();
+
+    let genesis = ctx.node.genesis.clone();
+    let unapproved = TestContext::create_unapproved(ctx.required_sigs, &genesis);
+
+    ctx.protocol
+        .unapproved_block_packet_handler(
+            &mut ctx.node.runtime_manager,
+            &ctx.node.local,
+            unapproved,
+            SHARD_ID,
+        )
+        .await
+        .unwrap();
+
+    // Note: Add log validation when LogStub mechanism from Scala is implemented in Rust
+    // Scala: node.logEff.infos.exists(_.contains("Approval sent in response")) should be(true)
+    // Scala: node.logEff.warns.isEmpty should be(true)
+
+    let queue = ctx
+        .node
+        .tle
+        .test_network()
+        .peer_queue(&ctx.node.local)
+        .unwrap();
+
+    assert_eq!(queue.len(), 1);
+}
+
+#[tokio::test]
+async fn block_approver_protocol_should_log_a_warning_for_invalid_approved_block_candidates() {
+    let mut ctx = TestContext::create_protocol().await.unwrap();
+
+    let different_unapproved1 = TestContext::create_unapproved(
+        ctx.required_sigs / 2, // wrong number of signatures
+        &ctx.node.genesis.clone(),
+    );
+
+    let different_unapproved2 = TestContext::create_unapproved(
+        ctx.required_sigs,
+        &get_random_block(
+            None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        ), // wrong block
+    );
+
+    ctx.protocol
+        .unapproved_block_packet_handler(
+            &mut ctx.node.runtime_manager,
+            &ctx.node.local,
+            different_unapproved1,
+            SHARD_ID,
+        )
+        .await
+        .unwrap();
+
+    ctx.protocol
+        .unapproved_block_packet_handler(
+            &mut ctx.node.runtime_manager,
+            &ctx.node.local,
+            different_unapproved2,
+            SHARD_ID,
+        )
+        .await
+        .unwrap();
+
+    // Note: Add log validation when LogStub mechanism from Scala is implemented in Rust
+    // Scala: node.logEff.warns.count(_.contains("Received unexpected genesis block candidate")) should be(2)
+
+    let queue = ctx
+        .node
+        .tle
+        .test_network()
+        .peer_queue(&ctx.node.local)
+        .unwrap();
+
+    assert!(queue.is_empty());
+}
+
+#[tokio::test]
+async fn block_approver_protocol_should_successfully_validate_correct_candidate() {
+    let mut ctx = TestContext::create_protocol().await.unwrap();
+
+    let unapproved = TestContext::create_unapproved(ctx.required_sigs, &ctx.node.genesis.clone());
+
+    // Scala: BlockApproverProtocol.validateCandidate[Effect](...) - static method call
+    let result = BlockApproverProtocol::<TransportLayerTestImpl>::validate_candidate(
+        &mut ctx.node.runtime_manager,
+        &unapproved.candidate,
+        ctx.protocol.required_sigs,
+        ctx.protocol.deploy_timestamp,
+        &ctx.protocol.vaults,
+        &ctx.protocol.bonds_bytes,
+        ctx.protocol.minimum_bond,
+        ctx.protocol.maximum_bond,
+        ctx.protocol.epoch_length,
+        ctx.protocol.quarantine_length,
+        ctx.protocol.number_of_active_validators,
+        SHARD_ID,
+        &ctx.protocol.pos_multi_sig_public_keys,
+        ctx.protocol.pos_multi_sig_quorum,
+    )
+    .await;
+
+    assert_eq!(result, Ok(()));
+}
+
+#[tokio::test]
+async fn block_approver_protocol_should_reject_candidate_with_incorrect_bonds() {
+    let mut ctx = TestContext::create_protocol().await.unwrap();
+
+    let unapproved = TestContext::create_unapproved(ctx.required_sigs, &ctx.node.genesis.clone());
+
+    // Scala: validateCandidate with bonds = Map.empty (incorrect bonds)
+    let wrong_bonds = HashMap::new();
+
+    let result = BlockApproverProtocol::<TransportLayerTestImpl>::validate_candidate(
+        &mut ctx.node.runtime_manager,
+        &unapproved.candidate,
+        ctx.protocol.required_sigs,
+        ctx.protocol.deploy_timestamp,
+        &ctx.protocol.vaults,
+        &wrong_bonds, // bonds are incorrect (empty)
+        ctx.protocol.minimum_bond,
+        ctx.protocol.maximum_bond,
+        ctx.protocol.epoch_length,
+        ctx.protocol.quarantine_length,
+        ctx.protocol.number_of_active_validators,
+        SHARD_ID,
+        &ctx.protocol.pos_multi_sig_public_keys,
+        ctx.protocol.pos_multi_sig_quorum,
+    )
+    .await;
+
+    assert_eq!(result, Err("Block bonds don't match expected.".to_string()));
+}
+
+#[tokio::test]
+async fn block_approver_protocol_should_reject_candidate_with_incorrect_vaults() {
+    let mut ctx = TestContext::create_protocol().await.unwrap();
+
+    let unapproved = TestContext::create_unapproved(ctx.required_sigs, &ctx.node.genesis.clone());
+
+    // Scala: validateCandidate with vaults = Seq.empty[Vault] (incorrect vaults)
+    let wrong_vaults = vec![];
+
+    let result = BlockApproverProtocol::<TransportLayerTestImpl>::validate_candidate(
+        &mut ctx.node.runtime_manager,
+        &unapproved.candidate,
+        ctx.protocol.required_sigs,
+        ctx.protocol.deploy_timestamp,
+        &wrong_vaults, // vaults are incorrect (empty)
+        &ctx.protocol.bonds_bytes,
+        ctx.protocol.minimum_bond,
+        ctx.protocol.maximum_bond,
+        ctx.protocol.epoch_length,
+        ctx.protocol.quarantine_length,
+        ctx.protocol.number_of_active_validators,
+        SHARD_ID,
+        &ctx.protocol.pos_multi_sig_public_keys,
+        ctx.protocol.pos_multi_sig_quorum,
+    )
+    .await;
+
+    assert_eq!(
+        result,
+        Err(
+            "Mismatch between number of candidate deploys and expected number of deploys."
+                .to_string()
+        )
+    );
+}
+
+#[tokio::test]
+async fn block_approver_protocol_should_reject_candidate_with_incorrect_blessed_contracts() {
+    let mut ctx = TestContext::create_protocol().await.unwrap();
+
+    let unapproved = TestContext::create_unapproved(ctx.required_sigs, &ctx.node.genesis.clone());
+
+    // Scala: validateCandidate with incorrect genesis params (minimumBond + 1, maximumBond - 1, etc.)
+    let result = BlockApproverProtocol::<TransportLayerTestImpl>::validate_candidate(
+        &mut ctx.node.runtime_manager,
+        &unapproved.candidate,
+        ctx.protocol.required_sigs,
+        ctx.protocol.deploy_timestamp,
+        &ctx.protocol.vaults,
+        &ctx.protocol.bonds_bytes,
+        ctx.protocol.minimum_bond + 1,                // incorrect
+        ctx.protocol.maximum_bond - 1,                // incorrect
+        ctx.protocol.epoch_length + 1,                // incorrect
+        ctx.protocol.quarantine_length + 1,           // incorrect
+        ctx.protocol.number_of_active_validators + 1, // incorrect
+        SHARD_ID,
+        &ctx.protocol.pos_multi_sig_public_keys,
+        ctx.protocol.pos_multi_sig_quorum,
+    )
+    .await;
+
+    assert!(result.is_err());
+}

--- a/casper/tests/engine/mod.rs
+++ b/casper/tests/engine/mod.rs
@@ -9,3 +9,6 @@ pub mod lfs_state_requester_effects_spec;
 pub mod lfs_state_requester_state_spec;
 pub mod running_spec;
 pub mod setup;
+pub mod block_approver_protocol_test;
+pub mod running_handle_has_block_request_spec;
+pub mod running_handle_has_block_spec;

--- a/casper/tests/engine/running_handle_has_block_request_spec.rs
+++ b/casper/tests/engine/running_handle_has_block_request_spec.rs
@@ -1,0 +1,117 @@
+// See casper/src/test/scala/coop/rchain/casper/engine/RunningHandleHasBlockRequestSpec.scala
+
+use crate::engine::setup::TestFixture;
+use comm::rust::peer_node::{Endpoint, NodeIdentifier, PeerNode};
+use models::{
+    casper::HasBlockProto,
+    routing::{protocol::Message::Packet, Protocol},
+    rust::{
+        block_hash::BlockHash,
+        casper::protocol::casper_message::{HasBlock, HasBlockRequest},
+    },
+};
+use prost::{bytes::Bytes, Message};
+
+const HASH_BYTES: &[u8] = b"hash";
+
+struct TestContext {
+    hbr: HasBlockRequest,
+    // Note: Using full TestFixture for convenience, though this test only needs
+    // engine and transport_layer. The overhead is acceptable for test simplicity.
+    fixture: TestFixture,
+}
+
+impl TestContext {
+    async fn new() -> Self {
+        let hash = Bytes::from(HASH_BYTES.to_vec());
+        let hbr = HasBlockRequest { hash: hash.clone() };
+        let fixture = TestFixture::new().await;
+
+        Self { hbr, fixture }
+    }
+
+    fn endpoint(port: u16) -> Endpoint {
+        Endpoint {
+            host: "host".to_string(),
+            tcp_port: port as u32,
+            udp_port: port as u32,
+        }
+    }
+
+    fn peer_node(name: &str, port: u16) -> PeerNode {
+        PeerNode {
+            id: NodeIdentifier {
+                key: Bytes::from(name.as_bytes().to_vec()),
+            },
+            endpoint: Self::endpoint(port),
+        }
+    }
+
+    fn to_has_block(protocol: &Protocol) -> HasBlock {
+        if let Some(message) = &protocol.message {
+            if let Packet(packet_data) = message {
+                if let Ok(hb) = HasBlockProto::decode(packet_data.content.as_ref()) {
+                    return HasBlock::from_proto(hb);
+                }
+            }
+        }
+        panic!("Could not convert protocol to HasBlock");
+    }
+
+    // Scala: private def alwaysSuccess: PeerNode => Protocol => CommErr[Unit] = kp(kp(Right(())))
+    // Note: Not ported because TransportLayerTestImpl doesn't require setting success responses.
+
+    // Scala: override def beforeEach(): Unit
+    // Note: Not ported because in Rust we create a fresh TestContext for each test,
+    // eliminating the need for explicit setup/teardown.
+}
+
+#[tokio::test]
+async fn running_handle_has_block_request_if_given_block_is_stored_should_send_back_has_block_message_to_the_sender(
+) {
+    let ctx = TestContext::new().await;
+    // given
+    let sender = TestContext::peer_node("peer", 40400);
+    let block_lookup = |_hash: BlockHash| true;
+    // then
+    ctx.fixture
+        .engine
+        .handle_has_block_request(sender.clone(), ctx.hbr.clone(), block_lookup)
+        .await
+        .unwrap();
+    // then
+    let (peer, protocol_msg) = ctx
+        .fixture
+        .transport_layer
+        .get_request(0)
+        .expect("No request found");
+
+    assert_eq!(peer, sender);
+
+    let has_block = TestContext::to_has_block(&protocol_msg);
+    assert_eq!(has_block.hash, Bytes::from(HASH_BYTES.to_vec()));
+
+    assert_eq!(ctx.fixture.transport_layer.request_count(), 1);
+}
+
+#[tokio::test]
+async fn running_handle_has_block_request_if_given_block_is_not_stored_in_block_store_should_do_nothing(
+) {
+    let ctx = TestContext::new().await;
+    // given
+    let sender = TestContext::peer_node("peer", 40400);
+
+    let block_lookup = |_hash: BlockHash| false;
+    // then
+    ctx.fixture
+        .engine
+        .handle_has_block_request(sender.clone(), ctx.hbr.clone(), block_lookup)
+        .await
+        .unwrap();
+    // then
+    assert_eq!(
+        ctx.fixture.transport_layer.request_count(),
+        0,
+        "Should have no messages"
+    );
+}

--- a/casper/tests/engine/running_handle_has_block_spec.rs
+++ b/casper/tests/engine/running_handle_has_block_spec.rs
@@ -1,0 +1,331 @@
+// See casper/src/test/scala/coop/rchain/casper/engine/RunningHandleHasBlockSpec.scala
+
+use crate::engine::setup::TestFixture;
+use casper::rust::engine::block_retriever::RequestState;
+use comm::rust::peer_node::{Endpoint, NodeIdentifier, PeerNode};
+use models::{
+    casper::BlockRequestProto,
+    routing::{protocol::Message::Packet, Protocol},
+    rust::{
+        block_hash::BlockHash,
+        casper::protocol::casper_message::{BlockRequest, HasBlock},
+    },
+};
+use prost::{bytes::Bytes, Message};
+use std::{
+    collections::{HashMap, HashSet},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+const HASH_BYTES: &[u8] = b"hash";
+
+struct TestContext {
+    hash: BlockHash,
+    hb: HasBlock,
+    // Note: Using full TestFixture for convenience, though this test only needs
+    // engine, block_retriever, and transport_layer. The overhead is acceptable for test simplicity.
+    fixture: TestFixture,
+}
+
+impl TestContext {
+    async fn new() -> Self {
+        let hash = Bytes::from(HASH_BYTES.to_vec());
+
+        let hb = HasBlock { hash: hash.clone() };
+
+        let fixture = TestFixture::new().await;
+
+        Self { hash, hb, fixture }
+    }
+
+    fn endpoint(port: u16) -> Endpoint {
+        Endpoint {
+            host: "host".to_string(),
+            tcp_port: port as u32,
+            udp_port: port as u32,
+        }
+    }
+
+    fn peer_node(name: &str, port: u16) -> PeerNode {
+        PeerNode {
+            id: NodeIdentifier {
+                key: Bytes::from(name.as_bytes().to_vec()),
+            },
+            endpoint: Self::endpoint(port),
+        }
+    }
+
+    // Scala: val br = BlockRequest.from(convert[PacketTypeTag.BlockRequest.type](toPacket(msg).right.get).get)
+    fn to_block_request(protocol: &Protocol) -> BlockRequest {
+        if let Some(message) = &protocol.message {
+            if let Packet(packet_data) = message {
+                if let Ok(br) = BlockRequestProto::decode(packet_data.content.as_ref()) {
+                    return BlockRequest::from_proto(br);
+                }
+            }
+        }
+        panic!("Could not convert protocol to BlockRequest");
+    }
+
+    // Helper to get current timestamp
+    fn current_millis() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64
+    }
+
+    // Scala: private def alwaysSuccess: PeerNode => Protocol => CommErr[Unit] = kp(kp(Right(())))
+    // Note: Not ported because TransportLayerTestImpl doesn't require setting success responses.
+
+    // Scala: private def alwaysDoNotIgnoreF: BlockHash => Task[Boolean] = _ => false.pure[Task]
+    fn always_do_not_ignore_f(_hash: BlockHash) -> Result<bool, casper::rust::errors::CasperError> {
+        Ok(false)
+    }
+
+    // Scala: val casperContains: BlockHash => Task[Boolean] = _ => true.pure[Task]
+    fn casper_contains(_hash: BlockHash) -> Result<bool, casper::rust::errors::CasperError> {
+        Ok(true)
+    }
+
+    // Scala: override def beforeEach(): Unit
+    // Note: Not ported because in Rust we create a fresh TestContext for each test,
+    // eliminating the need for explicit setup/teardown.
+}
+
+#[tokio::test]
+async fn block_retriever_should_store_on_a_waiting_list_and_dont_request_if_request_state_by_different_peer(
+) {
+    let ctx = TestContext::new().await;
+    // given
+    let sender = TestContext::peer_node("some_peer", 40400);
+    let other_peer = TestContext::peer_node("other_peer", 40400);
+
+    let request_state_before = {
+        let mut map = HashMap::new();
+        map.insert(
+            ctx.hash.clone(),
+            RequestState {
+                timestamp: TestContext::current_millis(),
+                peers: HashSet::new(),
+                received: false,
+                in_casper_buffer: false,
+                waiting_list: vec![other_peer],
+            },
+        );
+        map
+    };
+
+    *ctx.fixture
+        .block_retriever
+        .requested_blocks()
+        .lock()
+        .unwrap() = request_state_before;
+    // when
+    ctx.fixture
+        .engine
+        .handle_has_block_message(
+            sender.clone(),
+            ctx.hb.clone(),
+            TestContext::always_do_not_ignore_f,
+        )
+        .await
+        .unwrap();
+
+    // then
+    assert_eq!(
+        ctx.fixture.transport_layer.request_count(),
+        0,
+        "Transport queue should be empty"
+    );
+
+    let request_state_after = ctx
+        .fixture
+        .block_retriever
+        .requested_blocks()
+        .lock()
+        .unwrap();
+    let state = request_state_after.get(&ctx.hash).unwrap();
+    assert_eq!(
+        state.waiting_list.len(),
+        2,
+        "Waiting list should have 2 peers"
+    );
+}
+
+#[tokio::test]
+async fn block_retriever_should_request_block_and_add_peer_to_waiting_list_if_peers_list_is_empty()
+{
+    let ctx = TestContext::new().await;
+    // given
+    let sender = TestContext::peer_node("somePeer", 40400);
+
+    let request_state_before = {
+        let mut map = HashMap::new();
+        map.insert(
+            ctx.hash.clone(),
+            RequestState {
+                timestamp: TestContext::current_millis(),
+                peers: HashSet::new(),
+                received: false,
+                in_casper_buffer: false,
+                waiting_list: vec![],
+            },
+        );
+        map
+    };
+
+    *ctx.fixture
+        .block_retriever
+        .requested_blocks()
+        .lock()
+        .unwrap() = request_state_before;
+
+    // when
+    ctx.fixture
+        .engine
+        .handle_has_block_message(
+            sender.clone(),
+            ctx.hb.clone(),
+            TestContext::always_do_not_ignore_f,
+        )
+        .await
+        .unwrap();
+
+    // then
+    let (peer, protocol_msg) = ctx
+        .fixture
+        .transport_layer
+        .get_request(0)
+        .expect("No request found");
+
+    let br = TestContext::to_block_request(&protocol_msg);
+    assert_eq!(br.hash, ctx.hash);
+    assert_eq!(peer, sender);
+    assert_eq!(ctx.fixture.transport_layer.request_count(), 1);
+
+    let request_state_after = ctx
+        .fixture
+        .block_retriever
+        .requested_blocks()
+        .lock()
+        .unwrap();
+    let state = request_state_after.get(&ctx.hash).unwrap();
+    assert_eq!(
+        state.waiting_list.len(),
+        1,
+        "Waiting list should have 1 peer"
+    );
+    assert_eq!(
+        state.waiting_list[0], sender,
+        "Waiting list should contain sender"
+    );
+}
+
+#[tokio::test]
+async fn if_there_is_no_yet_an_entry_in_the_request_state_blocks_should_request_block_and_store_information_about_request_state_block(
+) {
+    let ctx = TestContext::new().await;
+    // given
+    let sender = TestContext::peer_node("somePeer", 40400);
+
+    *ctx.fixture
+        .block_retriever
+        .requested_blocks()
+        .lock()
+        .unwrap() = HashMap::new();
+
+    // when
+    ctx.fixture
+        .engine
+        .handle_has_block_message(
+            sender.clone(),
+            ctx.hb.clone(),
+            TestContext::always_do_not_ignore_f,
+        )
+        .await
+        .unwrap();
+
+    // then
+    let (peer, protocol_msg) = ctx
+        .fixture
+        .transport_layer
+        .get_request(0)
+        .expect("No request found");
+    // assert RequestState
+    let br = TestContext::to_block_request(&protocol_msg);
+
+    assert_eq!(br.hash, ctx.hash);
+
+    assert_eq!(peer, sender);
+
+    assert_eq!(ctx.fixture.transport_layer.request_count(), 1);
+
+    // assert RequestState informaton stored
+    let request_state_after = ctx
+        .fixture
+        .block_retriever
+        .requested_blocks()
+        .lock()
+        .unwrap();
+    let state = request_state_after.get(&ctx.hash).unwrap();
+    assert_eq!(
+        state.waiting_list.len(),
+        1,
+        "Waiting list should have 1 peer"
+    );
+    assert_eq!(
+        state.waiting_list[0], sender,
+        "Waiting list should contain sender"
+    );
+}
+
+#[tokio::test]
+async fn if_casper_does_not_contain_block_with_given_hash_if_there_is_already_an_entry_in_the_request_state_blocks_should_ignore_if_peer_on_the_request_state_peers_list(
+) {
+    let ctx = TestContext::new().await;
+    // given
+    let sender = TestContext::peer_node("somePeer", 40400);
+
+    // when
+    ctx.fixture
+        .engine
+        .handle_has_block_message(sender.clone(), ctx.hb.clone(), TestContext::casper_contains)
+        .await
+        .unwrap();
+
+    // then
+    assert_eq!(
+        ctx.fixture.transport_layer.request_count(),
+        0,
+        "Transport queue should be empty"
+    );
+}
+
+#[tokio::test]
+async fn running_handle_has_block_should_not_call_send_hash_to_block_receiver_if_it_is_ignorable_hash(
+) {
+    let ctx = TestContext::new().await;
+    // given
+    // Note: Scala passes null as peer because it's not used when ignore_message_f returns true.
+    // In Rust, we can't pass null for PeerNode, so we create a dummy peer instead.
+    let dummy_peer = TestContext::peer_node("dummy", 40400);
+
+    // when
+    ctx.fixture
+        .engine
+        .handle_has_block_message(
+            dummy_peer.clone(),
+            ctx.hb.clone(),
+            TestContext::casper_contains,
+        )
+        .await
+        .unwrap();
+
+    // then
+    assert_eq!(
+        ctx.fixture.transport_layer.request_count(),
+        0,
+        "Transport queue should be empty"
+    );
+}


### PR DESCRIPTION
## Overview
- ported block_approver_protocol_test.rs
- ported running_handle_has_block_request_spec.rs;
- ported running_handle_has_block_spec.rs;

additional:
- added static functions to block_approver_protocol.rs as Scala do it;

