### PR TITLE
Add heartbeat configuration options to command line interface

### DIFF
--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -93,6 +93,10 @@ object ConfigMapper {
       add("casper.genesis-ceremony.autogen-shard-size", run.autogenShardSize)
       add("casper.min-phlo-price", run.minPhloPrice)
 
+      add("casper.heartbeat.enabled", run.heartbeatEnabled)
+      add("casper.heartbeat.check-interval", run.heartbeatCheckInterval)
+      add("casper.heartbeat.max-lfb-age", run.heartbeatMaxLfbAge)
+
       add("api-server.port-grpc-external", run.apiPortGrpcExternal)
       add("api-server.port-grpc-internal", run.apiPortGrpcInternal)
       add("api-server.grpc-max-recv-message-size", run.apiGrpcMaxRecvMessageSize)

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -543,6 +543,18 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       validate = _ >= 0
     )
 
+    val heartbeatEnabled = opt[Flag](
+      descr = "Enable heartbeat block proposing for liveness"
+    )
+
+    val heartbeatCheckInterval = opt[FiniteDuration](
+      descr = "Check interval - how often to check if heartbeat is needed"
+    )
+
+    val heartbeatMaxLfbAge = opt[FiniteDuration](
+      descr = "Maximum age of last finalized block before triggering heartbeat"
+    )
+
     val rspacePlusPlus = opt[Flag](
       descr = "Enable rpsace++"
     )

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -124,7 +124,10 @@ class ConfigMapperSpec extends FunSuite with Matchers {
         "--influxdb",
         "--influxdb-udp",
         "--zipkin",
-        "--sigar"
+        "--sigar",
+        "--heartbeat-enabled",
+        "--heartbeat-check-interval 111111seconds",
+        "--heartbeat-max-lfb-age 222222seconds"
       ).mkString(" ")
 
     val options = Options(args.split(' '))
@@ -281,9 +284,9 @@ class ConfigMapperSpec extends FunSuite with Matchers {
         mergeableChannelsGCInterval = 5.minutes,
         mergeableChannelsGCDepthBuffer = 10,
         heartbeat = HeartbeatConf(
-          enabled = false,
-          checkInterval = 30.seconds,
-          maxLfbAge = 60.seconds
+          enabled = true,
+          checkInterval = 111111.seconds,
+          maxLfbAge = 222222.seconds
         )
       ),
       metrics = Metrics(


### PR DESCRIPTION
This commit introduces new command line options for enabling and configuring heartbeat block proposing. The following options have been added:
- `casper.heartbeat.enabled`: Enables heartbeat block proposing for liveness.
- `casper.heartbeat.check-interval`: Sets the interval for checking if a heartbeat is needed.
- `casper.heartbeat.max-lfb-age`: Defines the maximum age of the last finalized block before triggering a heartbeat.
