### PR TITLE
Fix LMDB problems in Rust code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,7 +110,7 @@ rspacePlusPlus/
 docker/data/
 
 rholang/**/*.mdb
-rspace++/tests/*.proptest-regressions
+*.proptest-regressions
 rust_libraries/**
 
 .env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,6 +439,9 @@ name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitvec"
@@ -575,12 +578,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytemuck"
-version = "1.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +621,7 @@ dependencies = [
  "rholang",
  "rspace_plus_plus",
  "serde",
+ "serial_test",
  "shared",
  "tempfile",
  "thiserror 2.0.17",
@@ -1128,6 +1126,15 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "doxygen-rs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "415b6ec780d34dcf624666747194393603d0373b7141eef01d12ee58881507d9"
+dependencies = [
+ "phf",
+]
 
 [[package]]
 name = "dunce"
@@ -1699,16 +1706,16 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heed"
-version = "0.11.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "269c7486ed6def5d7b59a427cec3e87b4d4dd4381d01e21c8c9f2d3985688392"
+checksum = "6a56c94661ddfb51aa9cdfbf102cfcc340aa69267f95ebccc4af08d7c530d393"
 dependencies = [
- "bytemuck",
+ "bitflags 2.9.4",
  "byteorder",
  "heed-traits",
  "heed-types",
  "libc",
- "lmdb-rkv-sys",
+ "lmdb-master-sys",
  "once_cell",
  "page_size",
  "serde",
@@ -1718,18 +1725,17 @@ dependencies = [
 
 [[package]]
 name = "heed-traits"
-version = "0.8.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53a94e5b2fd60417e83ffdfe136c39afacff0d4ac1d8d01cd66928ac610e1a2"
+checksum = "eb3130048d404c57ce5a1ac61a903696e8fcde7e8c2991e9fcfc1f27c3ef74ff"
 
 [[package]]
 name = "heed-types"
-version = "0.8.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a6cf0a6952fcedc992602d5cddd1e3fff091fbe87d38636e3ec23a31f32acbd"
+checksum = "13c255bdf46e07fb840d120a36dcc81f385140d7191c76a7391672675c01a55d"
 dependencies = [
  "bincode",
- "bytemuck",
  "byteorder",
  "heed-traits",
  "serde",
@@ -2361,14 +2367,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
-name = "lmdb-rkv-sys"
-version = "0.11.2"
+name = "lmdb-master-sys"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b9ce6b3be08acefa3003c57b7565377432a89ec24476bbe72e11d101f852fe"
+checksum = "864808e0b19fb6dd3b70ba94ee671b82fce17554cf80aeb0a155c65bb08027df"
 dependencies = [
  "cc",
+ "doxygen-rs",
  "libc",
- "pkg-config",
 ]
 
 [[package]]
@@ -3140,9 +3146,9 @@ dependencies = [
 
 [[package]]
 name = "page_size"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
@@ -3210,6 +3216,48 @@ checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
  "indexmap 2.11.4",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -4337,6 +4385,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4366,6 +4423,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "seahash"
@@ -4525,6 +4588,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4627,6 +4715,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "sketches-ddsketch"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4079,6 +4079,7 @@ dependencies = [
  "bincode",
  "chrono",
  "dashmap",
+ "lazy_static",
  "models",
  "prost 0.14.1",
  "rand 0.9.2",

--- a/casper/Cargo.toml
+++ b/casper/Cargo.toml
@@ -46,5 +46,6 @@ proptest = "1.6.0"
 
 [dev-dependencies]
 metrics-util = "0.17"
+serial_test = "3.1"
 
 [build-dependencies]

--- a/casper/tests/add_block/proposer_spec.rs
+++ b/casper/tests/add_block/proposer_spec.rs
@@ -192,7 +192,8 @@ fn dummy_validator_identity() -> ValidatorIdentity {
 #[tokio::test]
 async fn proposer_should_reject_to_propose_if_proposer_is_not_active_validator() {
     with_storage(|block_store, block_dag_storage| async move {
-        let runtime_manager = mk_runtime_manager("block-query-response-api-test", None).await;
+        let (_temp_dir, runtime_manager) =
+            mk_runtime_manager("block-query-response-api-test", None).await;
         let validator_identity = Arc::new(dummy_validator_identity());
 
         let mut proposer = Proposer::new(
@@ -248,7 +249,8 @@ async fn proposer_should_reject_to_propose_if_proposer_is_not_active_validator()
 #[tokio::test]
 async fn proposer_should_reject_to_propose_if_synchrony_constraint_not_met() {
     with_storage(|block_store, block_dag_storage| async move {
-        let runtime_manager = mk_runtime_manager("block-query-response-api-test", None).await;
+        let (_temp_dir, runtime_manager) =
+            mk_runtime_manager("block-query-response-api-test", None).await;
         let validator_identity = Arc::new(dummy_validator_identity());
 
         let mut proposer = Proposer::new(
@@ -304,7 +306,8 @@ async fn proposer_should_reject_to_propose_if_synchrony_constraint_not_met() {
 #[tokio::test]
 async fn proposer_should_reject_to_propose_if_last_finalized_height_constraint_not_met() {
     with_storage(|block_store, block_dag_storage| async move {
-        let runtime_manager = mk_runtime_manager("block-query-response-api-test", None).await;
+        let (_temp_dir, runtime_manager) =
+            mk_runtime_manager("block-query-response-api-test", None).await;
         let validator_identity = Arc::new(dummy_validator_identity());
 
         let mut proposer = Proposer::new(
@@ -360,7 +363,8 @@ async fn proposer_should_reject_to_propose_if_last_finalized_height_constraint_n
 #[tokio::test]
 async fn proposer_should_shut_down_the_node_if_block_created_is_not_successfully_replayed() {
     with_storage(|block_store, block_dag_storage| async move {
-        let runtime_manager = mk_runtime_manager("block-query-response-api-test", None).await;
+        let (_temp_dir, runtime_manager) =
+            mk_runtime_manager("block-query-response-api-test", None).await;
         let validator_identity = Arc::new(dummy_validator_identity());
 
         let mut proposer = Proposer::new(
@@ -407,7 +411,8 @@ async fn proposer_should_execute_propose_effects_if_block_created_successfully_r
         // Reset the effect variable before test
         reset_propose_effect_var();
 
-        let runtime_manager = mk_runtime_manager("block-query-response-api-test", None).await;
+        let (_temp_dir, runtime_manager) =
+            mk_runtime_manager("block-query-response-api-test", None).await;
         let validator_identity = Arc::new(dummy_validator_identity());
 
         let mut proposer = Proposer::new(

--- a/casper/tests/batch1/multi_parent_casper_smoke_spec.rs
+++ b/casper/tests/batch1/multi_parent_casper_smoke_spec.rs
@@ -1,15 +1,26 @@
 // See casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperSmokeSpec.scala
 
 use crate::helper::test_node::TestNode;
-use crate::util::genesis_builder::GenesisBuilder;
+use crate::util::genesis_builder::{GenesisBuilder, GenesisContext};
 use casper::rust::util::construct_deploy;
+use tokio::sync::OnceCell;
+
+static GENESIS: OnceCell<GenesisContext> = OnceCell::const_new();
+
+async fn get_genesis() -> &'static GenesisContext {
+    GENESIS
+        .get_or_init(|| async {
+            GenesisBuilder::new()
+                .build_genesis_with_parameters(None)
+                .await
+                .expect("Failed to build genesis")
+        })
+        .await
+}
 
 #[tokio::test]
 async fn multi_parent_casper_should_perform_the_most_basic_deploy_successfully() {
-    let genesis = GenesisBuilder::new()
-        .build_genesis_with_parameters(None)
-        .await
-        .expect("Failed to build genesis");
+    let genesis = get_genesis().await.clone();
 
     let mut node = TestNode::standalone(genesis.clone()).await.unwrap();
 
@@ -23,4 +34,3 @@ async fn multi_parent_casper_should_perform_the_most_basic_deploy_successfully()
 
     node.add_block_from_deploys(&[deploy]).await.unwrap();
 }
-

--- a/casper/tests/merging/merge_number_channel_spec.rs
+++ b/casper/tests/merging/merge_number_channel_spec.rs
@@ -124,7 +124,7 @@ async fn test_case(
     expected_rejected: HashableSet<prost::bytes::Bytes>,
     expected_final_result: i64,
 ) {
-    let rm = mk_runtime_manager("merging-test", Some(unforgeable_name_seed())).await;
+    let (_temp_dir, rm) = mk_runtime_manager("merging-test", Some(unforgeable_name_seed())).await;
     let mut runtime = rm.spawn_runtime().await;
 
     async fn run_rholang(
@@ -204,7 +204,7 @@ async fn test_case(
         .enumerate()
         .map(|(i, term)| {
             let term = term.clone();
-            let mut runtime_clone = runtime.clone();
+            let runtime_clone = runtime.clone();
 
             async move {
                 let base_res = runtime_clone

--- a/casper/tests/merging/merging_cases.rs
+++ b/casper/tests/merging/merging_cases.rs
@@ -11,8 +11,25 @@ use casper::rust::{
 };
 use rholang::rust::interpreter::system_processes::BlockData;
 use rspace_plus_plus::rspace::{hashing::blake2b256_hash::Blake2b256Hash, merger::merging_logic};
+use tokio::sync::OnceCell;
 
-use crate::util::rholang::resources::with_runtime_manager;
+use crate::util::genesis_builder::{GenesisBuilder, GenesisContext};
+use crate::util::rholang::resources::{
+    copy_storage, mk_runtime_manager_at, mk_test_rnode_store_manager,
+};
+
+static GENESIS: OnceCell<GenesisContext> = OnceCell::const_new();
+
+async fn get_genesis() -> &'static GenesisContext {
+    GENESIS
+        .get_or_init(|| async {
+            GenesisBuilder::new()
+                .build_genesis_with_parameters(None)
+                .await
+                .expect("Failed to build genesis")
+        })
+        .await
+}
 
 /**
  * Two deploys inside single state transition are using the same PVV for precharge and refund.
@@ -21,108 +38,114 @@ use crate::util::rholang::resources::with_runtime_manager;
  */
 #[tokio::test]
 async fn two_deploys_executed_inside_single_state_transition_should_be_dependent() {
-    with_runtime_manager(|mut runtime_manager, genesis_context, _| async move {
-        let base_state = genesis_context.genesis_block.body.state.post_state_hash;
-        let payer1_key = &genesis_context.genesis_vaults[0].0;
-        let payer2_key = &genesis_context.genesis_vaults[1].0;
-        let state_transition_creator = &genesis_context.validator_key_pairs[0].1;
-        let seq_num = 1;
-        let block_num = 1;
+    let genesis_context = get_genesis().await;
+    let (storage_path, _temp_dir) = copy_storage(genesis_context.storage_directory.clone());
+    let kvm = mk_test_rnode_store_manager(storage_path);
+    let mut runtime_manager = mk_runtime_manager_at(kvm, None).await;
 
-        let d1 = construct_deploy::source_deploy_now_full(
-            "Nil".to_string(),
-            None,
-            None,
-            Some(payer1_key.clone()),
-            None,
-            None,
-        )
-        .unwrap();
+    let base_state = genesis_context
+        .genesis_block
+        .body
+        .state
+        .post_state_hash
+        .clone();
+    let payer1_key = &genesis_context.genesis_vaults[0].0;
+    let payer2_key = &genesis_context.genesis_vaults[1].0;
+    let state_transition_creator = &genesis_context.validator_key_pairs[0].1;
+    let seq_num = 1;
+    let block_num = 1;
 
-        let d2 = construct_deploy::source_deploy_now_full(
-            "Nil".to_string(),
-            None,
-            None,
-            Some(payer2_key.clone()),
-            None,
-            None,
-        )
-        .unwrap();
+    let d1 = construct_deploy::source_deploy_now_full(
+        "Nil".to_string(),
+        None,
+        None,
+        Some(payer1_key.clone()),
+        None,
+        None,
+    )
+    .unwrap();
 
-        let block_data = BlockData {
-            time_stamp: d1.data.time_stamp,
+    let d2 = construct_deploy::source_deploy_now_full(
+        "Nil".to_string(),
+        None,
+        None,
+        Some(payer2_key.clone()),
+        None,
+        None,
+    )
+    .unwrap();
+
+    let block_data = BlockData {
+        time_stamp: d1.data.time_stamp,
+        seq_num,
+        block_number: block_num,
+        sender: state_transition_creator.clone(),
+    };
+
+    let invalid_blocks = HashMap::new();
+    let user_deploys = vec![d1, d2];
+    let system_deploys = vec![CloseBlockDeploy {
+        initial_rand: system_deploy_util::generate_close_deploy_random_seed_from_pk(
+            state_transition_creator.clone(),
             seq_num,
-            block_number: block_num,
-            sender: state_transition_creator.clone(),
-        };
+        ),
+    }];
 
-        let invalid_blocks = HashMap::new();
-        let user_deploys = vec![d1, d2];
-        let system_deploys = vec![CloseBlockDeploy {
-            initial_rand: system_deploy_util::generate_close_deploy_random_seed_from_pk(
-                state_transition_creator.clone(),
-                seq_num,
-            ),
-        }];
+    let (post_state_hash, processed_deploys, _) = runtime_manager
+        .compute_state(
+            &base_state,
+            user_deploys,
+            system_deploys,
+            block_data,
+            Some(invalid_blocks),
+        )
+        .await
+        .unwrap();
 
-        let (post_state_hash, processed_deploys, _) = runtime_manager
-            .compute_state(
-                &base_state,
-                user_deploys,
-                system_deploys,
-                block_data,
-                Some(invalid_blocks),
+    assert_eq!(processed_deploys.len(), 2);
+
+    let mergeable_channels = runtime_manager
+        .load_mergeable_channels(
+            &post_state_hash,
+            state_transition_creator.bytes.clone(),
+            seq_num,
+        )
+        .unwrap();
+
+    // Combine processed deploys with cached mergeable channels data
+    let processed_deploys_with_mergeable = processed_deploys
+        .to_vec()
+        .into_iter()
+        .zip(mergeable_channels)
+        .collect::<Vec<_>>();
+
+    let idxs = processed_deploys_with_mergeable
+        .into_iter()
+        .map(|(d, merge_chs)| {
+            block_index::create_event_log_index(
+                d.deploy_log,
+                runtime_manager.get_history_repo(),
+                &Blake2b256Hash::from_bytes_prost(&base_state),
+                merge_chs,
             )
-            .await
-            .unwrap();
+        })
+        .collect::<Vec<_>>();
 
-        assert_eq!(processed_deploys.len(), 2);
+    let first_depends = merging_logic::depends(&idxs[0], &idxs[1]);
+    let second_depends = merging_logic::depends(&idxs[1], &idxs[0]);
+    let conflicts = merging_logic::are_conflicting(&idxs[0], &idxs[1]);
 
-        let mergeable_channels = runtime_manager
-            .load_mergeable_channels(
-                &post_state_hash,
-                state_transition_creator.bytes.clone(),
-                seq_num,
-            )
-            .unwrap();
+    let deploy_chains = merging_logic::compute_related_sets(
+        &idxs.iter().cloned().collect(),
+        merging_logic::depends,
+    );
 
-        // Combine processed deploys with cached mergeable channels data
-        let processed_deploys_with_mergeable = processed_deploys
-            .to_vec()
-            .into_iter()
-            .zip(mergeable_channels)
-            .collect::<Vec<_>>();
-
-        let idxs = processed_deploys_with_mergeable
-            .into_iter()
-            .map(|(d, merge_chs)| {
-                block_index::create_event_log_index(
-                    d.deploy_log,
-                    runtime_manager.get_history_repo(),
-                    &Blake2b256Hash::from_bytes_prost(&base_state),
-                    merge_chs,
-                )
-            })
-            .collect::<Vec<_>>();
-
-        let first_depends = merging_logic::depends(&idxs[0], &idxs[1]);
-        let second_depends = merging_logic::depends(&idxs[1], &idxs[0]);
-        let conflicts = merging_logic::are_conflicting(&idxs[0], &idxs[1]);
-
-        let deploy_chains = merging_logic::compute_related_sets(
-            &idxs.iter().cloned().collect(),
-            merging_logic::depends,
-        );
-
-        // deploys inside one state transition never conflict, as executed in a sequence (for now)
-        assert!(!conflicts);
-        // first deploy does not depend on the second
-        assert!(!first_depends);
-        // second deploy depends on the first, as it consumes produce put by first one when updating per validator vault balance
-        assert!(!second_depends);
-        // deploys should be be put in separate deploy chains
-        assert_eq!(deploy_chains.0.len(), 2);
-    })
-    .await
-    .unwrap()
+    // deploys inside one state transition never conflict, as executed in a sequence (for now)
+    assert!(!conflicts);
+    // first deploy does not depend on the second
+    assert!(!first_depends);
+    // second deploy depends on the first, as it consumes produce put by first one when updating per validator vault balance
+    assert!(!second_depends);
+    // deploys should be be put in separate deploy chains
+    assert_eq!(deploy_chains.0.len(), 2);
 }

--- a/casper/tests/mod.rs
+++ b/casper/tests/mod.rs
@@ -19,7 +19,7 @@ static INIT: Once = Once::new();
 pub fn init_logger() {
     INIT.call_once(|| {
         let filter = EnvFilter::builder()
-            .with_default_directive(LevelFilter::DEBUG.into())
+            .with_default_directive(LevelFilter::INFO.into())
             .parse("")
             .unwrap();
 

--- a/casper/tests/util/in_memory_key_value_store_spec.rs
+++ b/casper/tests/util/in_memory_key_value_store_spec.rs
@@ -124,6 +124,12 @@ impl KeyValueStoreSut {
         Self { kvm }
     }
 
+    /// Explicitly shutdown the underlying KeyValueStoreManager.
+    pub async fn shutdown(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        self.kvm.shutdown().await?;
+        Ok(())
+    }
+
     async fn copy_to_db(
         &mut self,
         data: HashMap<i64, String>,

--- a/rspace++/Cargo.toml
+++ b/rspace++/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 [dependencies]
 shared = { path = "../shared" }
 bincode = { workspace = true }
-heed = "0.11.0"
+heed = "0.22.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
 dashmap = { workspace = true }

--- a/rspace++/libs/rspace_rhotypes/Cargo.toml
+++ b/rspace++/libs/rspace_rhotypes/Cargo.toml
@@ -19,3 +19,4 @@ rand = { workspace = true }
 serde = { workspace = true }
 bincode = { workspace = true }
 chrono = "0.4.38"
+lazy_static = "1.4"

--- a/rspace++/src/rspace/shared/lmdb_dir_store_manager.rs
+++ b/rspace++/src/rspace/shared/lmdb_dir_store_manager.rs
@@ -1,7 +1,6 @@
 use super::key_value_store_manager::KeyValueStoreManager;
 use super::lmdb_store_manager::LmdbStoreManager;
 use async_trait::async_trait;
-use futures::channel::oneshot;
 use shared::rust::store::key_value_store::KeyValueStore;
 use std::sync::Arc;
 use std::{collections::HashMap, path::PathBuf};
@@ -52,76 +51,61 @@ pub struct LmdbDirStoreManager {
 }
 
 struct StoreState {
-    envs: HashMap<String, oneshot::Receiver<Box<dyn KeyValueStoreManager>>>,
+    // Store the actual managers (not receivers) so they can be reused for multiple databases
+    // sharing the same LMDB environment path (e.g., rspace-history and rspace-roots both use "rspace/history")
+    managers: HashMap<String, Box<dyn KeyValueStoreManager>>,
 }
 
 #[async_trait]
 impl KeyValueStoreManager for LmdbDirStoreManager {
     async fn store(&mut self, db_name: String) -> Result<Arc<dyn KeyValueStore>, heed::Error> {
+        // Build mapping from db.id -> (Db, LmdbEnvConfig)
         let db_instance_mapping: HashMap<&String, (&Db, &LmdbEnvConfig)> = self
             .db_mapping
             .iter()
             .map(|(db, cfg)| (&db.id, (db, cfg)))
             .collect();
 
-        let (sender, receiver) = oneshot::channel::<Box<dyn KeyValueStoreManager>>();
+        // Look up the database configuration
+        let (db, cfg) = db_instance_mapping.get(&db_name).ok_or_else(|| {
+            heed::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("LMDB_Dir_Store_Manager: Key {} was not found", db_name),
+            ))
+        })?;
 
-        let action = {
+        let man_name = cfg.name.clone();
+        let database_name = db.name_override.clone().unwrap_or(db.id.clone());
+
+        // Check if manager exists, create if not
+        {
             let mut state = self.managers_state.lock().await;
-
-            let (db, cfg) = db_instance_mapping.get(&db_name).ok_or({
-                heed::Error::Io(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("LMDB_Dir_Store_Manager: Key {} was not found", db_name),
-                ))
-            })?;
-
-            let man_name = cfg.name.to_string();
-
-            let is_new = !state.envs.contains_key(&man_name);
-            if is_new {
-                state.envs.insert(man_name.to_string(), receiver);
+            if !state.managers.contains_key(&man_name) {
+                // Create new manager for this environment path
+                let manager =
+                    LmdbStoreManager::new(self.dir_path.join(&cfg.name), cfg.max_env_size);
+                state.managers.insert(man_name.clone(), manager);
             }
-
-            (is_new, db, cfg)
-        };
-        let (is_new, db, man_cfg) = action;
-
-        if is_new {
-            self.create_lmdb_manager(man_cfg, sender)?;
         }
 
-        let mut manager = {
-            let mut state = self.managers_state.lock().await;
-            let receiver = state.envs.remove(&man_cfg.name).ok_or({
-                heed::Error::Io(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("LMDB_Dir_Store_Manager: Receiver not found"),
-                ))
-            })?;
+        // Get the manager and create the database/store
+        let mut state = self.managers_state.lock().await;
+        let manager = state.managers.get_mut(&man_name).ok_or_else(|| {
+            heed::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("LMDB_Dir_Store_Manager: Manager not found for {}", man_name),
+            ))
+        })?;
 
-            receiver.await.map_err(|e| {
-                heed::Error::Io(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("LMDB_Dir_Store_Manager: Failed to receive manager, {}", e),
-                ))
-            })?
-        };
-
-        let database_name = db.name_override.clone().unwrap_or(db.id.clone());
-        let database = manager.store(database_name);
-
-        database.await
+        manager.store(database_name).await
     }
 
     async fn shutdown(&mut self) -> Result<(), heed::Error> {
         let mut state = self.managers_state.lock().await;
-        for manager_future in state.envs.values_mut() {
-            if let Ok(mut manager) = manager_future.await {
-                let _ = manager.shutdown().await;
-            }
+        for manager in state.managers.values_mut() {
+            let _ = manager.shutdown().await;
         }
-
+        state.managers.clear();
         Ok(())
     }
 }
@@ -135,25 +119,9 @@ impl LmdbDirStoreManager {
             dir_path,
             db_mapping: db_instance_mapping,
             managers_state: Arc::new(Mutex::new(StoreState {
-                envs: HashMap::new(),
+                managers: HashMap::new(),
             })),
         }
-    }
-
-    fn create_lmdb_manager(
-        &self,
-        config: &LmdbEnvConfig,
-        sender: oneshot::Sender<Box<dyn KeyValueStoreManager>>,
-    ) -> Result<(), heed::Error> {
-        let manager = LmdbStoreManager::new(self.dir_path.join(&config.name), config.max_env_size);
-        sender.send(manager).map_err(|_| {
-            heed::Error::Io(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("Failed to send LMDB manager for {}", config.name),
-            ))
-        })?;
-
-        Ok(())
     }
 }
 
@@ -163,15 +131,9 @@ impl Drop for LmdbDirStoreManager {
     fn drop(&mut self) {
         // Use try_lock() for synchronous access in Drop
         if let Ok(mut state) = self.managers_state.try_lock() {
-            // Attempt to receive and drop all pending managers
-            // This allows their Drop implementations to clean up LMDB environments
-            for (_name, mut receiver) in state.envs.drain() {
-                // In Drop context we can't await, so we use try_recv()
-                // If the receiver is ready, we get the manager and let it drop
-                if let Ok(Some(_manager)) = receiver.try_recv() {
-                    // Manager will be dropped here, triggering its Drop implementation
-                }
-            }
+            // Clear all managers, triggering their Drop implementations
+            // which will close LMDB environments
+            state.managers.clear();
         }
     }
 }

--- a/rspace++/src/rspace/shared/lmdb_store_manager.rs
+++ b/rspace++/src/rspace/shared/lmdb_store_manager.rs
@@ -1,7 +1,6 @@
 use crate::rspace::shared::key_value_store_manager::KeyValueStoreManager;
 use async_trait::async_trait;
-use futures::channel::oneshot;
-use heed::{Database, Env, EnvOpenOptions, types::SerdeBincode};
+use heed::{Database, Env, EnvFlags, EnvOpenOptions, WithoutTls, types::SerdeBincode};
 use shared::rust::store::{
     key_value_store::KeyValueStore, lmdb_key_value_store::LmdbKeyValueStore,
 };
@@ -12,81 +11,36 @@ use tokio::sync::Mutex;
 pub struct LmdbStoreManager {
     dir_path: PathBuf,
     max_env_size: usize,
-    env_sender: Option<oneshot::Sender<Env>>,
-    env_receiver: Option<oneshot::Receiver<Env>>,
-    dbs: Arc<Mutex<HashMap<String, DbEnv>>>,
-}
-
-#[derive(Clone)]
-struct DbEnv {
-    env: Env,
-    db: Database<SerdeBincode<Vec<u8>>, SerdeBincode<Vec<u8>>>,
+    // Store the env directly (created on first use) so it can be reused for multiple databases
+    env: Option<Env<WithoutTls>>,
+    dbs: Arc<Mutex<HashMap<String, Database<SerdeBincode<Vec<u8>>, SerdeBincode<Vec<u8>>>>>>,
 }
 
 impl LmdbStoreManager {
     pub fn new(dir_path: PathBuf, max_env_size: usize) -> Box<dyn KeyValueStoreManager> {
-        let (sender, receiver) = oneshot::channel::<Env>();
         Box::new(LmdbStoreManager {
             dir_path,
             max_env_size,
-            env_sender: Some(sender),
-            env_receiver: Some(receiver),
+            env: None,
             dbs: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
-    async fn get_current_env(&mut self, db_name: &str) -> Result<DbEnv, heed::Error> {
-        let dbs = self.dbs.lock().await;
-        if let Some(db_env) = dbs.get(db_name) {
-            return Ok(db_env.clone());
-        }
-        drop(dbs);
-
-        // Create and open the environment if it doesn't exist
-        if self.env_sender.is_some() {
-            let env = self.create_env().await?;
-            let sender = self.env_sender.take().ok_or_else(|| {
-                heed::Error::Io(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "LMDB_Store_Manager: LMDB environment sender unavailable",
-                ))
-            })?;
-            let _ = sender.send(env); // Send the environment to the receiver
-        }
-
-        // Await the environment from the receiver
-        let receiver = self.env_receiver.take().ok_or_else(|| {
-            heed::Error::Io(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "LMDB_Store_Manager: LMDB environment receiver unavailable",
-            ))
-        })?;
-        let env = receiver.await.map_err(|_| {
-            heed::Error::Io(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "LMDB_Store_Manager: LMDB environment was not received",
-            ))
-        })?;
-
-        // Open or create the database
-        let db = env.create_database(Some(db_name))?;
-
-        let mut dbs = self.dbs.lock().await;
-        let db_env = DbEnv { env, db };
-        dbs.insert(db_name.to_string(), db_env.clone());
-        Ok(db_env)
-    }
-
-    async fn create_env(&self) -> Result<Env, heed::Error> {
-        // println!("Creating LMDB environment: {:?}", self.dir_path);
+    fn create_env(&self) -> Result<Env<WithoutTls>, heed::Error> {
         fs::create_dir_all(&self.dir_path)?;
 
-        let mut env_builder = EnvOpenOptions::new();
+        let mut env_builder = EnvOpenOptions::new().read_txn_without_tls();
         env_builder.map_size(self.max_env_size);
         env_builder.max_dbs(20);
         env_builder.max_readers(2048);
 
-        let env = env_builder.open(&self.dir_path)?;
+        // SAFETY: We ensure the directory exists and is writable above.
+        // The environment is properly managed by this struct's lifecycle.
+        unsafe {
+            env_builder.flags(EnvFlags::NO_READ_AHEAD);
+        }
+
+        let env = unsafe { env_builder.open(&self.dir_path)? };
         Ok(env)
     }
 }
@@ -94,25 +48,41 @@ impl LmdbStoreManager {
 #[async_trait]
 impl KeyValueStoreManager for LmdbStoreManager {
     async fn store(&mut self, name: String) -> Result<Arc<dyn KeyValueStore>, heed::Error> {
-        let db_env = self.get_current_env(&name).await?;
-        Ok(Arc::new(LmdbKeyValueStore::new(db_env.env, db_env.db)))
+        // Ensure environment is created first
+        if self.env.is_none() {
+            self.env = Some(self.create_env()?);
+        }
+        let env = self.env.as_ref().unwrap();
+
+        // Check if database already exists
+        {
+            let dbs = self.dbs.lock().await;
+            if let Some(db) = dbs.get(&name) {
+                return Ok(Arc::new(LmdbKeyValueStore::new(env.clone(), db.clone())));
+            }
+        }
+
+        // Create the database (heed v0.22 requires a write transaction)
+        let mut wtxn = env.write_txn()?;
+        let db = env.create_database(&mut wtxn, Some(&name))?;
+        wtxn.commit()?;
+
+        // Store database reference
+        {
+            let mut dbs = self.dbs.lock().await;
+            dbs.insert(name, db.clone());
+        }
+
+        Ok(Arc::new(LmdbKeyValueStore::new(env.clone(), db)))
     }
 
     async fn shutdown(&mut self) -> Result<(), heed::Error> {
-        // Clear the databases HashMap to drop all DbEnv references
+        // Clear the databases HashMap
         let mut dbs = self.dbs.lock().await;
         dbs.clear();
 
-        // If there is an active receiver awaiting the environment, receive it and drop it
-        if let Some(receiver) = self.env_receiver.take() {
-            let env = receiver.await.map_err(|_| {
-                heed::Error::Io(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "LMDB_Store_Manager: Failed to receive LMDB environment for shutdown",
-                ))
-            })?;
-            drop(env);
-        }
+        // Drop the environment
+        self.env = None;
 
         Ok(())
     }
@@ -125,10 +95,7 @@ impl Drop for LmdbStoreManager {
         if let Ok(mut dbs) = self.dbs.try_lock() {
             dbs.clear();
         }
-
-        // If there's an env_receiver, we need to handle it
-        // In Drop context, we can't await, so we just drop it
         // The heed::Env Drop implementation will handle closing file handles
-        self.env_receiver.take();
+        // when self.env is dropped
     }
 }

--- a/rspace++/src/rspace/shared/mod.rs
+++ b/rspace++/src/rspace/shared/mod.rs
@@ -3,6 +3,6 @@ pub mod trie_importer;
 pub mod key_value_store_manager;
 pub mod lmdb_dir_store_manager;
 pub mod rspace_store_manager;
-mod lmdb_store_manager;
+pub mod lmdb_store_manager;
 pub mod in_mem_key_value_store;
 pub mod in_mem_store_manager;

--- a/rspace++/src/rspace/shared/rspace_store_manager.rs
+++ b/rspace++/src/rspace/shared/rspace_store_manager.rs
@@ -1,5 +1,5 @@
 use crate::rspace::rspace::RSpaceStore;
-use heed::EnvOpenOptions;
+use heed::{EnvFlags, EnvOpenOptions};
 use lazy_static::lazy_static;
 use shared::rust::store::lmdb_key_value_store::LmdbKeyValueStore;
 use std::collections::{HashMap, HashSet};
@@ -44,9 +44,14 @@ pub fn get_or_create_rspace_store(
         let history_env_path = format!("{}/rspace/history", lmdb_path);
         let cold_env_path = format!("{}/rspace/cold", lmdb_path);
 
-        let history_store = open_lmdb_store(&history_env_path, "rspace-history")?;
-        let roots_store = open_lmdb_store(&history_env_path, "rspace-roots")?;
-        let cold_store = open_lmdb_store(&cold_env_path, "rspace-cold")?;
+        // Open ONE env for history_env_path and reuse it for both rspace-history and rspace-roots
+        let history_env = open_lmdb_env(&history_env_path)?;
+        let history_store = open_db_in_env(&history_env, "rspace-history")?;
+        let roots_store = open_db_in_env(&history_env, "rspace-roots")?;
+
+        // Open separate env for cold
+        let cold_env = open_lmdb_env(&cold_env_path)?;
+        let cold_store = open_db_in_env(&cold_env, "rspace-cold")?;
 
         let rspace_store = RSpaceStore {
             history: Arc::new(history_store),
@@ -65,9 +70,14 @@ pub fn get_or_create_rspace_store(
         create_dir_all(&history_env_path).expect("Failed to create RSpace++ history directory");
         create_dir_all(&cold_env_path).expect("Failed to create RSpace++ cold directory");
 
-        let history_store = create_lmdb_store(&history_env_path, "rspace-history", map_size)?;
-        let roots_store = create_lmdb_store(&history_env_path, "rspace-roots", map_size)?;
-        let cold_store = create_lmdb_store(&cold_env_path, "rspace-cold", map_size)?;
+        // Create ONE env for history_env_path and reuse it for both rspace-history and rspace-roots
+        let history_env = create_lmdb_env(&history_env_path, map_size)?;
+        let history_store = create_db_in_env(&history_env, "rspace-history")?;
+        let roots_store = create_db_in_env(&history_env, "rspace-roots")?;
+
+        // Create separate env for cold
+        let cold_env = create_lmdb_env(&cold_env_path, map_size)?;
+        let cold_store = create_db_in_env(&cold_env, "rspace-cold")?;
 
         let rspace_store = RSpaceStore {
             history: Arc::new(history_store),
@@ -83,31 +93,55 @@ pub fn close_rspace_store(rspace_store: RSpaceStore) {
     drop(rspace_store);
 }
 
-fn create_lmdb_store(
-    lmdb_path: &str,
-    db_name: &str,
-    max_env_size: usize,
-) -> Result<LmdbKeyValueStore, heed::Error> {
-    let mut env_builder = EnvOpenOptions::new();
+fn create_lmdb_env(lmdb_path: &str, max_env_size: usize) -> Result<Env<WithoutTls>, heed::Error> {
+    let mut env_builder = EnvOpenOptions::new().read_txn_without_tls();
     env_builder.map_size(max_env_size);
     env_builder.max_dbs(20);
     env_builder.max_readers(2048);
 
-    let env = env_builder.open(&lmdb_path)?;
-    let db = env.create_database(Some(db_name))?;
+    // SAFETY: We ensure the directory exists before calling this function.
+    unsafe {
+        env_builder.flags(EnvFlags::NO_READ_AHEAD);
+    }
 
-    Ok(LmdbKeyValueStore::new(env, db))
+    unsafe { env_builder.open(&lmdb_path) }
 }
 
-fn open_lmdb_store(lmdb_path: &str, db_name: &str) -> Result<LmdbKeyValueStore, heed::Error> {
-    let mut env_builder = EnvOpenOptions::new();
+fn create_db_in_env(
+    env: &Env<WithoutTls>,
+    db_name: &str,
+) -> Result<LmdbKeyValueStore, heed::Error> {
+    let mut wtxn = env.write_txn()?;
+    let db = env.create_database(&mut wtxn, Some(db_name))?;
+    wtxn.commit()?;
+
+    Ok(LmdbKeyValueStore {
+        env: Arc::new(env.clone()),
+        db: Arc::new(Mutex::new(db)),
+    })
+}
+
+use heed::{Env, WithoutTls};
+
+fn open_lmdb_env(lmdb_path: &str) -> Result<Env<WithoutTls>, heed::Error> {
+    let mut env_builder = EnvOpenOptions::new().read_txn_without_tls();
     env_builder.max_dbs(20);
 
-    let env = env_builder.open(lmdb_path)?;
-    let db = env.open_database(Some(db_name))?;
+    // SAFETY: We verify the path exists before calling this function.
+    unsafe {
+        env_builder.flags(EnvFlags::NO_READ_AHEAD);
+    }
+
+    unsafe { env_builder.open(lmdb_path) }
+}
+
+fn open_db_in_env(env: &Env<WithoutTls>, db_name: &str) -> Result<LmdbKeyValueStore, heed::Error> {
+    let rtxn = env.read_txn()?;
+    let db = env.open_database(&rtxn, Some(db_name))?;
+    rtxn.commit()?;
     match db {
         Some(open_db) => Ok(LmdbKeyValueStore {
-            env: env.into(),
+            env: Arc::new(env.clone()),
             db: Arc::new(Mutex::new(open_db)),
         }),
         None => panic!("\nFailed to open database: {}", db_name),

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 bincode = "1"
-heed = "0.11.0"
+heed = "0.22.0"
 hex = { workspace = true }
 proptest = "1.6.0"
 prost = { workspace = true }
@@ -18,7 +18,7 @@ futures = { workspace = true }
 tokio = { workspace = true }
 axum = "0.8"
 tonic = { workspace = true }
-tower = { workspace = true}
+tower = { workspace = true }
 http = "1.0"
 http-body-util = "0.1"
 bytes = "1"

--- a/shared/src/rust/store/lmdb_key_value_store.rs
+++ b/shared/src/rust/store/lmdb_key_value_store.rs
@@ -1,5 +1,5 @@
 use heed::types::SerdeBincode;
-use heed::{Database, Env};
+use heed::{Database, Env, WithoutTls};
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
@@ -7,8 +7,10 @@ use crate::rust::ByteBuffer;
 
 use super::key_value_store::{KeyValueStore, KvStoreError};
 
+/// LMDB-backed key-value store.
+/// Uses `WithoutTls` to match Scala's `MDB_NOTLS` flag for async/multi-threaded compatibility.
 pub struct LmdbKeyValueStore {
-    pub env: Arc<Env>,
+    pub env: Arc<Env<WithoutTls>>,
     pub db: Arc<Mutex<Database<SerdeBincode<ByteBuffer>, SerdeBincode<ByteBuffer>>>>,
 }
 
@@ -123,7 +125,10 @@ impl KeyValueStore for LmdbKeyValueStore {
 }
 
 impl LmdbKeyValueStore {
-    pub fn new(env: Env, db: Database<SerdeBincode<ByteBuffer>, SerdeBincode<ByteBuffer>>) -> Self {
+    pub fn new(
+        env: Env<WithoutTls>,
+        db: Database<SerdeBincode<ByteBuffer>, SerdeBincode<ByteBuffer>>,
+    ) -> Self {
         let env_arc = Arc::new(env);
         let db_arc = Arc::new(Mutex::new(db));
 


### PR DESCRIPTION
# Fix LMDB Environment Management and Test Infrastructure

## Problem
Casper tests failing with infrastructure errors:
- `EnvAlreadyOpened` - LMDB environments opened multiple times
- "Too many open files" (os error 24) - File descriptor exhaustion  
- "No space left on device" (os error 28) - LMDB mmap failures on macOS
- Test race conditions causing intermittent failures

## Root Causes
1. **LMDB env reuse bug**: `rspace-history` and `rspace-roots` share same LMDB path but code opened separate environments
2. **heed 0.11 limitations**: Outdated LMDB bindings had mmap issues on macOS
3. **Genesis caching**: Tests bypassed cache, creating excessive LMDB environments
4. **Metrics isolation**: Rust shared global metrics recorder (Scala creates per-test instances)

## Changes

### LMDB Fixes
- `rspace_store_manager.rs`: Reuse single LMDB env for databases sharing same path
- `lmdb_store_manager.rs`: Simplified env lifecycle management
- `lmdb_dir_store_manager.rs`: Store and reuse managers by env name (matching Scala)
- Upgraded `heed` 0.11 → 0.22, added `read_txn_without_tls()` for `MDB_NOTLS` flag

### Test Fixes
- Added per-module `OnceCell` genesis caching aligned with Scala's per-class pattern
- API tests: Use separate temp directories for DAG and RuntimeManager
- `approve_block_protocol_test.rs`: Added `#[serial]` to prevent metrics race condition
- `multi_parent_casper_merge_spec.rs`: Fixed async runtime nesting panic