### PR TITLE
fix: serialize metrics tests to prevent flaky failures #312

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2766,6 +2766,7 @@ dependencies = [
  "rustyline",
  "serde",
  "serde_json",
+ "serial_test",
  "shared",
  "sysinfo",
  "thiserror 2.0.17",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -64,7 +64,7 @@ tonic-reflection = "0.14"
 
 [dev-dependencies]
 tower = { workspace = true }
-# No dependencies yet - empty module
+serial_test = "3.1"
 
 [build-dependencies]
 tonic-prost-build = { workspace = true }

--- a/node/src/rust/diagnostics/sigar_reporter.rs
+++ b/node/src/rust/diagnostics/sigar_reporter.rs
@@ -25,6 +25,7 @@ pub fn start_sigar_reporter(interval_duration: Duration) {
 mod tests {
     use super::*;
     use crate::rust::diagnostics::new_prometheus_reporter::NewPrometheusReporter;
+    use serial_test::serial;
     use std::time::Duration;
 
     #[tokio::test]
@@ -36,6 +37,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_sigar_reporter_records_cpu_metric() {
         let reporter = NewPrometheusReporter::initialize().unwrap();
 
@@ -52,6 +54,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_sigar_reporter_records_memory_metric() {
         let reporter = NewPrometheusReporter::initialize().unwrap();
 
@@ -68,6 +71,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_sigar_metrics_use_correct_source() {
         let reporter = NewPrometheusReporter::initialize().unwrap();
 
@@ -84,6 +88,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_sigar_reporter_respects_interval() {
         let _reporter = NewPrometheusReporter::initialize().unwrap();
 

--- a/node/src/rust/diagnostics/tests.rs
+++ b/node/src/rust/diagnostics/tests.rs
@@ -11,6 +11,7 @@ mod tests {
     use casper::rust::casper_conf::{
         CasperConf, GenesisBlockData, GenesisCeremony, HeartbeatConf, RoundRobinDispatcher,
     };
+    use serial_test::serial;
     use std::collections::HashMap;
     use std::path::PathBuf;
     use std::sync::Arc;
@@ -199,12 +200,14 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_reporter_initialize() {
         let result = NewPrometheusReporter::initialize();
         assert!(result.is_ok());
     }
 
     #[test]
+    #[serial]
     fn test_reporter_scrape_data() {
         let reporter = NewPrometheusReporter::initialize().unwrap();
         let output = reporter.scrape_data();
@@ -213,6 +216,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_reporter_singleton_pattern() {
         let reporter1 = NewPrometheusReporter::initialize().unwrap();
         let reporter2 = NewPrometheusReporter::initialize().unwrap();
@@ -221,6 +225,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_reporter_global_access() {
         let _reporter = NewPrometheusReporter::initialize().unwrap();
         let global = NewPrometheusReporter::global();
@@ -229,6 +234,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_reporter_with_custom_config() {
         let config = PrometheusConfiguration {
             default_buckets: vec![0.001, 0.01, 0.1, 1.0],
@@ -243,6 +249,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_reporter_records_counter() {
         let reporter = NewPrometheusReporter::initialize().unwrap();
 
@@ -259,6 +266,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_reporter_records_gauge() {
         let reporter = NewPrometheusReporter::initialize().unwrap();
 
@@ -275,6 +283,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_reporter_records_histogram() {
         let reporter = NewPrometheusReporter::initialize().unwrap();
 
@@ -291,6 +300,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_reporter_scrape_includes_recorded_metrics() {
         let reporter = NewPrometheusReporter::initialize().unwrap();
 
@@ -312,6 +322,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_reporter_concurrent_access() {
         let reporter = Arc::new(NewPrometheusReporter::initialize().unwrap());
         let mut handles = vec![];
@@ -416,6 +427,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_initialize_with_all_disabled() {
         let node_conf = create_test_node_conf_all_disabled();
         let kamon_conf = create_test_kamon_conf();
@@ -427,6 +439,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_initialize_with_prometheus_only() {
         let node_conf = create_test_node_conf_with_prometheus();
         let kamon_conf = create_test_kamon_conf();
@@ -438,6 +451,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_initialize_with_sigar_only() {
         let node_conf = create_test_node_conf_with_sigar();
         let kamon_conf = create_test_kamon_conf();
@@ -448,6 +462,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_initialize_metrics_interval_default() {
         let node_conf = create_test_node_conf_with_prometheus();
         let kamon_conf = create_test_kamon_conf_no_metric();
@@ -458,6 +473,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_initialize_metrics_interval_custom() {
         let node_conf = create_test_node_conf_with_prometheus();
         let custom_interval = Duration::from_secs(5);


### PR DESCRIPTION
## Fix flaky metrics tests

### Problem
`test_sigar_metrics_use_correct_source` failed intermittently due to shared global metrics state when tests ran in parallel. #312 

### Solution
Added `serial_test` crate and `#[serial]` attribute to tests that interact with the global `metrics` recorder.

### Changes
- `node/Cargo.toml`: Added `serial_test = "3.1"` dev-dependency
- `node/src/rust/diagnostics/sigar_reporter.rs`: Added `#[serial]` to 4 tests
- `node/src/rust/diagnostics/tests.rs`: Added `#[serial]` to 15 tests
