### PR TITLE
Improve Rust build performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,15 +2963,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "openssl-src"
-version = "300.5.3+3.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6bad8cd0233b63971e232cc9c5e83039375b8586d2312f31fda85db8f888c2"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2979,7 +2970,6 @@ checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -3888,7 +3878,6 @@ dependencies = [
  "lazy_static",
  "models",
  "openai-api-rs",
- "openssl",
  "pretty_assertions",
  "prost",
  "rand 0.8.5",

--- a/comm/build.rs
+++ b/comm/build.rs
@@ -14,6 +14,16 @@ fn main() {
 
     let absolute_proto_files: Vec<_> = proto_files.iter().map(|f| proto_src_dir.join(f)).collect();
 
+    // Tell Cargo to only rerun this build script if proto files change
+    for proto_file in &absolute_proto_files {
+        println!("cargo:rerun-if-changed={}", proto_file.display());
+    }
+    // Also watch the scalapb proto used for imports
+    println!(
+        "cargo:rerun-if-changed={}",
+        scala_proto_base_dir.join("scalapb/scalapb.proto").display()
+    );
+
     tonic_prost_build::configure()
         .build_client(true)
         .build_server(true)

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -36,7 +36,7 @@ x509-certificate = "0.23"
 yasna = { version = "0.5.2", features = ["num-bigint"] }
 eyre = { workspace = true }
 pem = "3.0"
-openssl = { version = "0.10", features = ["vendored"] }
+openssl = "0.10"
 
 [dev-dependencies]
 proptest = "1.0"

--- a/models/build.rs
+++ b/models/build.rs
@@ -27,6 +27,16 @@ fn main() {
 
     let absolute_proto_files: Vec<_> = proto_files.iter().map(|f| proto_src_dir.join(f)).collect();
 
+    // Tell Cargo to only rerun this build script if proto files change
+    for proto_file in &absolute_proto_files {
+        println!("cargo:rerun-if-changed={}", proto_file.display());
+    }
+    // Also watch the scalapb proto used for imports
+    println!(
+        "cargo:rerun-if-changed={}",
+        scala_proto_base_dir.join("scalapb/scalapb.proto").display()
+    );
+
     tonic_prost_build::configure()
         .build_client(true)
         .build_server(true)
@@ -45,7 +55,7 @@ fn main() {
         .enum_attribute(".rhoapi", "#[repr(C)]")
         .bytes(".casper")
         .bytes(".routing")
-         // needed for grpc services from deploy_grpc_service_v1.rs to avoid upper camel case warnings
+        // needed for grpc services from deploy_grpc_service_v1.rs to avoid upper camel case warnings
         .server_mod_attribute(".", "#[allow(non_camel_case_types)]")
         .client_mod_attribute(".", "#[allow(non_camel_case_types)]")
         .compile_protos(

--- a/node/build.rs
+++ b/node/build.rs
@@ -9,9 +9,6 @@ fn main() {
 
     let proto_src_models_dir = manifest_dir.join("../models/src/main/protobuf");
 
-    // Rerun build script if proto directory would have any changes
-    println!("cargo:rerun-if-changed={}", proto_src_dir.display());
-
     let proto_files = ["lsp.proto", "repl.proto"];
 
     let models_proto_files = ["DeployServiceV1.proto", "ProposeServiceV1.proto"];
@@ -28,6 +25,11 @@ fn main() {
     for entry in proto_files.iter() {
         println!("cargo:rerun-if-changed={}", entry.display());
     }
+    // Also watch the scalapb proto used for imports
+    println!(
+        "cargo:rerun-if-changed={}",
+        scala_proto_base_dir.join("scalapb/scalapb.proto").display()
+    );
 
     tonic_prost_build::configure()
         .file_descriptor_set_path("build/descriptors/reflection_protos.bin")

--- a/rholang/Cargo.toml
+++ b/rholang/Cargo.toml
@@ -40,7 +40,6 @@ openai-api-rs = "6.0.3"
 dotenv = "0.15.0"
 indexmap = "2.8.0"
 rayon = "1.10.0"
-openssl = { version = "0.10", features = ["vendored"] }
 tempfile = "3.19.1"
 clap = { version = "4.5", features = ["derive"] }
 tracing = { workspace = true }


### PR DESCRIPTION
## Overview

This PR improves Rust build performance by addressing two main issues:

### 1. Add `cargo:rerun-if-changed` directives to build scripts

Previously, build scripts in `models`, `comm`, and `node` would re-run proto compilation on every build, even when no proto files changed.

**Changes:**
- `models/build.rs`: Added rerun-if-changed for all 12 proto files + scalapb.proto
- `comm/build.rs`: Added rerun-if-changed for kademlia.proto + scalapb.proto
- `node/build.rs`: Removed directory-level watch (which triggered on any file change), added scalapb.proto watch

### 2. Remove vendored OpenSSL

Previously, OpenSSL was compiled from source (~86 MB) on every clean build due to the `vendored` feature.

**Changes:**
- `crypto/Cargo.toml`: Removed `vendored` feature - now uses system OpenSSL
- `rholang/Cargo.toml`: Removed unnecessary explicit openssl dependency (rholang doesn't use OpenSSL directly)

### Prerequisites

Developers need `libssl-dev` installed:
```bash
# Ubuntu/Debian
sudo apt-get install libssl-dev pkg-config
```

Docker builds already have this via `apt-get install libssl-dev` in the Dockerfile.

### Expected Impact

- **Incremental builds**: Proto regeneration only when .proto files change
- **Clean builds**: Save ~30-60 seconds from OpenSSL compilation