### PR TITLE
fix(integration-tests): Fix WSL2 networking and HTTP deploy signature

### DIFF
--- a/.github/workflows/optional-workflow.yml
+++ b/.github/workflows/optional-workflow.yml
@@ -270,6 +270,7 @@ jobs:
           - test_storage
           - test_wallets
           - test_healthcheck
+          - test_web_api
     env:
       TESTS: ${{ matrix.tests }}
       ARCH: arm64

--- a/.github/workflows/required-workflow.yml
+++ b/.github/workflows/required-workflow.yml
@@ -407,6 +407,7 @@ jobs:
           - test_storage
           - test_wallets
           - test_healthcheck
+          - test_web_api
     env:
       TESTS: ${{ matrix.tests }}
       _JAVA_OPTIONS: -XX:MaxRAMPercentage=35.0

--- a/integration-tests/test/test_web_api.py
+++ b/integration-tests/test/test_web_api.py
@@ -11,11 +11,11 @@ from .http_client import HttpClient
 def node_with_blocks(started_standalone_bootstrap_node: Node, docker_client: DockerClient) -> Generator[Tuple[Node, List[str], List[str]], None, None]:
     deploy_hash = []
     block_hash = []
-    deploy_hash.append(started_standalone_bootstrap_node.deploy('/opt/docker/rholang/examples/tut-hello.rho', STANDALONE_KEY, 100000, 1))
+    deploy_hash.append(started_standalone_bootstrap_node.deploy('/opt/docker/examples/tut-hello.rho', STANDALONE_KEY, 100000, 1))
     block_hash.append(started_standalone_bootstrap_node.propose())
-    deploy_hash.append(started_standalone_bootstrap_node.deploy('/opt/docker/rholang/examples/tut-hello.rho', STANDALONE_KEY, 100000, 1))
+    deploy_hash.append(started_standalone_bootstrap_node.deploy('/opt/docker/examples/tut-hello.rho', STANDALONE_KEY, 100000, 1))
     block_hash.append(started_standalone_bootstrap_node.propose())
-    deploy_hash.append(started_standalone_bootstrap_node.deploy('/opt/docker/rholang/examples/tut-hello.rho', STANDALONE_KEY, 100000, 1))
+    deploy_hash.append(started_standalone_bootstrap_node.deploy('/opt/docker/examples/tut-hello.rho', STANDALONE_KEY, 100000, 1))
     block_hash.append(started_standalone_bootstrap_node.propose())
     with get_node_ip_of_network(docker_client, started_standalone_bootstrap_node.network):
         yield (started_standalone_bootstrap_node, deploy_hash, block_hash)
@@ -25,8 +25,10 @@ def test_web_api(node_with_blocks: Tuple[Node, List[str], List[str]]) -> None :
     node = node_with_blocks[0]
     deploy_hash = node_with_blocks[1]
     block_hash = node_with_blocks[2]
-    ip = node.get_peer_node_ip(node.network)
-    client = HttpClient(ip, 40403)
+    # Use get_self_host() which returns localhost on non-Linux systems (where port mapping is used)
+    ip = node.get_self_host()
+    http_port = node.get_http_port()
+    client = HttpClient(ip, http_port)
 
     status = client.status()
     assert status.version

--- a/integration-tests/test/utils.py
+++ b/integration-tests/test/utils.py
@@ -8,7 +8,21 @@ from typing import Dict, Set, Generator
 
 from docker import DockerClient
 
-ISLINUX = platform.system() == 'Linux'
+
+def _is_native_linux() -> bool:
+    """Check if running on native Linux (not WSL2).
+
+    WSL2 is detected as Linux but can't route to Docker bridge networks,
+    so it needs to use port mapping like macOS/Windows.
+    """
+    if platform.system() != 'Linux':
+        return False
+    # WSL2 has 'microsoft' or 'WSL' in the kernel release
+    release = platform.uname().release.lower()
+    return 'microsoft' not in release and 'wsl' not in release
+
+
+ISLINUX = _is_native_linux()
 
 
 def parse_mvdag_str(mvdag_output: str) -> Dict[str, Set[str]]:


### PR DESCRIPTION
## Summary

- Add WSL2 detection to use port mapping instead of direct container IP (WSL2 cannot route to Docker bridge networks)
- Fix HTTP deploy signature to include shardId (pyf1r3fly library bug workaround)
- Update test_web_api.py to use get_self_host() and get_http_port()
- Add test_web_api to required CI tests

## Details

### WSL2 Networking Fix
WSL2 is detected as Linux by `platform.system()` but cannot route to Docker bridge network IPs (e.g., 172.19.0.x). The fix adds WSL2 detection to treat it like macOS/Windows, using port mapping via localhost instead.

### HTTP Deploy Signature Fix
The pyf1r3fly library's `sign_deploy_data` function does not include `shardId` in the signature calculation, but the server expects it. This adds a local `_sign_deploy_data_with_shard` function that correctly includes `shardId`, matching the existing workaround in `rnode.py` for gRPC deploys.

## Test plan

- [x] Verified test_web_api passes locally on WSL2
- [x] CI should pass with test_web_api now included in required tests