### PR TITLE
RUST - fix: disable static OpenSSL linking on all platforms

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -171,12 +171,6 @@
                 name = "PROTOC_INCLUDE";
                 value = "${pkgs.protobuf}/include";
               }
-            ] ++ (if system != "x86_64-darwin" && system != "aarch64-darwin" then [
-              {
-                name = "OPENSSL_STATIC";
-                value = "1";
-              }
-            ] else []) ++ [
               {
                 name = "OPENSSL_INCLUDE_DIR";
                 value = "${pkgs.openssl.dev}/include";


### PR DESCRIPTION
## Summary

Nix's OpenSSL package does not reliably provide static libraries (`libssl.a`, `libcrypto.a`) on either macOS or Linux/WSL2, causing `could not find native static library ssl` errors when building `openssl-sys`.

## Changes

This change removes the `OPENSSL_STATIC=1` environment variable entirely, allowing all platforms to use dynamic linking (the default) which works reliably with Nix's OpenSSL package.

- **Linux/WSL2**: Uses dynamic linking (previously static linking failed due to missing static libs)
- **macOS (x86_64-darwin, aarch64-darwin)**: Uses dynamic linking

## Testing

After this change, users should:
1. Exit and re-enter the nix shell to pick up the new config
2. Build should now work without OpenSSL static library errors on any platform

## Related PRs

- PR #323: Improve Rust build performance (removed vendored OpenSSL)
- PR #324: Align Docker config and README with Scala branch (updated nix flake)