### PR TITLE
added stack logic into registry, backport from Scala to Rust;

### DIFF
--- a/casper/src/main/resources/Registry.rho
+++ b/casper/src/main/resources/Registry.rho
@@ -345,6 +345,7 @@ in {
             `rho:lang:either` : `rho:id:qrh6mgfp5z6orgchgszyxnuonanz7hw3amgrprqtciia6astt66ypn`,
             `rho:lang:listOps` : `rho:id:6fzorimqngeedepkrizgiqms6zjt76zjeciktt1eifequy4osz35ks`,
             `rho:lang:nonNegativeNumber` : `rho:id:hxyadh1ffypra47ry9mk6b8r1i33ar1w9wjsez4khfe9huzrfcytx9`,
+            `rho:lang:stack` : `rho:id:eb6a9iqn4tqr9gaa6dzspiuee9g3mt9c1umrfwcpaugp6ctuijbnwj`,
             `rho:rchain:authKey` : `rho:id:1qw5ehmq1x49dey4eadr1h4ncm361w3536asho7dr38iyookwcsp6i`,
             `rho:rchain:makeMint` : `rho:id:asysrwfgzf8bf7sxkiowp4b3tcsy4f8ombi3w96ysox4u3qdmn1wbc`,
             `rho:rchain:pos` : `rho:id:m3xk7h8r54dtqtwsrnxqzhe81baswey66nzw6m533nyd45ptyoybqr`,

--- a/casper/src/main/resources/Stack.rho
+++ b/casper/src/main/resources/Stack.rho
@@ -1,0 +1,102 @@
+/*
+ The table below describes the required computations and their dependencies
+
+ No. | Dependency | Computation method | Result
+ ----+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ 1.  |            | given              | sk = c94e647de6876c954ebb7b64c40a220227770f9be003635edfe3336a1a2c8605
+ 2.  |            | given              | timestamp = 1751539590099
+ 3.  |            | lastNonce          | nonce = 9223372036854775807
+ 4.  | 1,         | secp256k1          | pk = 04d545071374ee35b3c68dea1446f992a8539627f9c77ce6a99f4946cb3d9514c5c3e13cb74af509d4e5a31aa82253d927e9d549273a69c8ec22209cf05a8ff9c1
+ 5.  | 4, 2,      | genIds             | uname = Unforgeable(0xd768e57159280561389f6e7fbc7daeada5a8c0acf1e3aac87203b5ea070abbae)
+ 6.  | 3, 5,      | registry           | value = (9223372036854775807, bundle+ {   Unforgeable(0xd768e57159280561389f6e7fbc7daeada5a8c0acf1e3aac87203b5ea070abbae) })
+ 7.  | 6,         | protobuf           | toSign = 2a40aa013d0a0d2a0b10feffffffffffffffff010a2c5a2a0a263a240a220a20d768e57159280561389f6e7fbc7daeada5a8c0acf1e3aac87203b5ea070abbae1001
+ 8.  | 7, 1,      | secp256k1          | sig = 304402203975acecd9a2da3f76be255deca08efacdbab58845dfcb70e334cfbfa437ce530220686fdb874b11b58d80aca06af80d57ee60c27c68f061bffd81c5ad73eb203e24
+ 9.  | 4,         | registry           | uri = rho:id:eb6a9iqn4tqr9gaa6dzspiuee9g3mt9c1umrfwcpaugp6ctuijbnwj
+ ----+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------
+ */
+
+new
+  Stack, rs(`rho:registry:insertSigned:secp256k1`), uriOut, merge, sizeP, elemP
+in {
+  contract Stack(@"init", ret) = {
+    new stack in {
+      @(*stack, *sizeP)!(0) |
+      ret!(*stack)
+    }
+  } |
+
+  contract Stack(@"isEmpty", @stack, ret) = {
+    for (@size <<- @(stack, *sizeP)) {
+      ret!(size == 0)
+    }
+  } |
+
+  contract Stack(@"size", @stack, ret) = {
+    for (@size <<- @(stack, *sizeP)) {
+      ret!(size)
+    }
+  } |
+
+  contract Stack(@"push", @stack, @value, ret) = {
+    for (@size <- @(stack, *sizeP)) {
+      @(stack, *elemP, size)!(value) |
+      @(stack, *sizeP)!(size + 1) |
+      ret!(size + 1)
+    }
+  } |
+
+  contract Stack(@"pop", @stack, ret) = {
+    for (@size <- @(stack, *sizeP)) {
+      if (size == 0) {
+        @(stack, *sizeP)!(size) |
+        ret!((false, "stack is empty"))
+      } else {
+        for(@value <- @(stack, *elemP, size - 1)) {
+          @(stack, *sizeP)!(size - 1) |
+          ret!((true, value))
+        }
+      }
+    }
+  } |
+
+  contract merge(@stack, @begin, @end, ret) = {
+    match (end - begin) {
+      0 => ret!([])
+      1 => {
+        for(@value <<- @(stack, *elemP, begin)) {
+          ret!([value])
+        }
+      }
+      _ => {
+        new left, right in {
+          merge!(stack, begin, begin + (end - begin) / 2, *left) |
+          merge!(stack, begin + (end - begin) / 2, end, *right) |
+
+          for(@leftList <- left & @rightList <- right) {
+            ret!(leftList ++ rightList)
+          }
+        }
+      }
+    }
+  } |
+
+  contract Stack(@"toList", @stack, ret) = {
+    new mergedCh in {
+      for (@size <- @(stack, *sizeP)) {
+        merge!(stack, 0, size, *mergedCh) |
+
+        for(@merged <- mergedCh) {
+          @(stack, *sizeP)!(size) |
+          ret!(merged)
+        }
+      }
+    }
+  } |
+
+  rs!(
+    "04d545071374ee35b3c68dea1446f992a8539627f9c77ce6a99f4946cb3d9514c5c3e13cb74af509d4e5a31aa82253d927e9d549273a69c8ec22209cf05a8ff9c1".hexToBytes(),
+    (9223372036854775807, bundle+{*Stack}),
+    "304402203975acecd9a2da3f76be255deca08efacdbab58845dfcb70e334cfbfa437ce530220686fdb874b11b58d80aca06af80d57ee60c27c68f061bffd81c5ad73eb203e24".hexToBytes(),
+    *uriOut
+  )
+}

--- a/casper/src/rust/genesis/contracts/standard_deploys.rs
+++ b/casper/src/rust/genesis/contracts/standard_deploys.rs
@@ -31,6 +31,7 @@ pub const POS_GENERATOR_PK: &str =
     "a9585a0687761139ab3587a4938fb5ab9fcba675c79fefba889859674046d4a5";
 pub const REV_GENERATOR_PK: &str =
     "a06959868e39bb3a8502846686a23119716ecd001700baf9e2ecfa0dbf1a3247";
+pub const STACK_PK: &str = "c94e647de6876c954ebb7b64c40a220227770f9be003635edfe3336a1a2c8605";
 
 // Timestamps for each deploy
 pub const REGISTRY_TIMESTAMP: i64 = 1559156071321;
@@ -42,6 +43,7 @@ pub const AUTH_KEY_TIMESTAMP: i64 = 1559156356769;
 pub const REV_VAULT_TIMESTAMP: i64 = 1559156183943;
 pub const MULTI_SIG_REV_VAULT_TIMESTAMP: i64 = 1571408470880;
 pub const POS_GENERATOR_TIMESTAMP: i64 = 1559156420651;
+pub const STACK_TIMESTAMP: i64 = 1751539590099;
 
 lazy_static! {
     pub static ref REGISTRY_PUB_KEY: PublicKey = to_public(REGISTRY_PK);
@@ -54,6 +56,7 @@ lazy_static! {
     pub static ref MULTI_SIG_REV_VAULT_PUB_KEY: PublicKey = to_public(MULTI_SIG_REV_VAULT_PK);
     pub static ref POS_GENERATOR_PUB_KEY: PublicKey = to_public(POS_GENERATOR_PK);
     pub static ref REV_GENERATOR_PUB_KEY: PublicKey = to_public(REV_GENERATOR_PK);
+    pub static ref STACK_PUB_KEY: PublicKey = to_public(STACK_PK);
 }
 
 pub fn system_public_keys() -> Vec<&'static PublicKey> {
@@ -68,6 +71,7 @@ pub fn system_public_keys() -> Vec<&'static PublicKey> {
         &MULTI_SIG_REV_VAULT_PUB_KEY,
         &POS_GENERATOR_PUB_KEY,
         &REV_GENERATOR_PUB_KEY,
+        &STACK_PUB_KEY,
     ]
 }
 
@@ -164,6 +168,15 @@ pub fn multi_sig_rev_vault(shard_id: &str) -> Signed<DeployData> {
             .expect("Failed to compile MultiSigRevVault.rho"),
         MULTI_SIG_REV_VAULT_PK,
         MULTI_SIG_REV_VAULT_TIMESTAMP,
+        shard_id,
+    )
+}
+
+pub fn stack(shard_id: &str) -> Signed<DeployData> {
+    to_deploy(
+        CompiledRholangSource::apply("Stack.rho").expect("Failed to compile Stack.rho"),
+        STACK_PK,
+        STACK_TIMESTAMP,
         shard_id,
     )
 }

--- a/casper/src/rust/genesis/genesis.rs
+++ b/casper/src/rust/genesis/genesis.rs
@@ -96,9 +96,10 @@ impl Genesis {
         let auth_key = standard_deploys::auth_key(shard_id);
         let rev_vault = standard_deploys::rev_vault(shard_id);
         let multi_sig_rev_vault = standard_deploys::multi_sig_rev_vault(shard_id);
+        let stack = standard_deploys::stack(shard_id);
         let pos_generator = standard_deploys::pos_generator(&pos_params, shard_id);
 
-        let mut all_deploys = Vec::with_capacity(9 + vault_deploys.len());
+        let mut all_deploys = Vec::with_capacity(10 + vault_deploys.len());
         all_deploys.push(registry);
         all_deploys.push(list_ops);
         all_deploys.push(either);
@@ -107,6 +108,7 @@ impl Genesis {
         all_deploys.push(auth_key);
         all_deploys.push(rev_vault);
         all_deploys.push(multi_sig_rev_vault);
+        all_deploys.push(stack);
         all_deploys.extend(vault_deploys);
         all_deploys.push(pos_generator);
 

--- a/casper/src/test/resources/StackTest.rho
+++ b/casper/src/test/resources/StackTest.rho
@@ -1,0 +1,186 @@
+new
+  rl(`rho:registry:lookup`), RhoSpecCh,
+  stdlog(`rho:io:stdlog`),
+  test_size,
+  test_if_empty,
+  test_push_item,
+  test_pop_item,
+  test_pop_item_from_empty_collection,
+  test_convert_to_list_0,
+  test_convert_to_list_1,
+  test_convert_to_list_2,
+  test_convert_to_list_3,
+  test_convert_to_list_4,
+  fill
+in {
+  rl!(`rho:id:zphjgsfy13h1k85isc8rtwtgt3t9zzt5pjd5ihykfmyapfc4wt3x5h`, *RhoSpecCh) |
+  for(@(_, RhoSpec) <- RhoSpecCh) {
+    @RhoSpec!("testSuite",
+      [
+        ("check size", *test_size),
+        ("check if empty", *test_if_empty),
+        ("Push item", *test_push_item),
+        ("Pop item", *test_pop_item),
+        ("Pop item from empty collection", *test_pop_item_from_empty_collection),
+        ("Convert to list (size 0)", *test_convert_to_list_0),
+        ("Convert to list (size 1)", *test_convert_to_list_1),
+        ("Convert to list (size 2)", *test_convert_to_list_2),
+        ("Convert to list (size 3)", *test_convert_to_list_3),
+        ("Convert to list (size 4)", *test_convert_to_list_4),
+      ])
+  } |
+
+  new StackCh in {
+    rl!(`rho:lang:stack`, *StackCh) |
+    for(@(_, Stack) <- StackCh) {
+
+      contract test_size(rhoSpec, _, ackCh) = {
+        new stackCh, filledCh, ch in {
+          @Stack!("init", *stackCh) |
+
+          for(@stack <- stackCh) {
+            fill!(stack, [1, 2, 3], *filledCh) |
+
+            for(<- filledCh) {
+              @Stack!("size", stack, *ch) |
+              rhoSpec!("assert", (3, "== <-", *ch), "Size return number of elements in stack", *ackCh)
+            }
+          }
+        }
+      } |
+
+      contract test_if_empty(rhoSpec, _, ackCh) = {
+        new stackCh, ch in {
+          @Stack!("init", *stackCh) |
+
+          for(@stack <- stackCh) {
+            @Stack!("isEmpty", stack, *ch) |
+            rhoSpec!("assert", (true, "== <-", *ch), "Empty stack reports its empty", *ackCh)
+          }
+        }
+      } |
+
+      contract test_push_item(rhoSpec, _, ackCh) = {
+        new stackCh, ch in {
+          @Stack!("init", *stackCh) |
+
+          for(@stack <- stackCh) {
+            @Stack!("push", stack, "value", *ch) |
+            rhoSpec!("assert", (1, "== <-", *ch), "Push returns updated size", *ackCh)
+          }
+        }
+      } |
+
+      contract test_pop_item(rhoSpec, _, ackCh) = {
+        new stackCh, pushCh, ch in {
+          @Stack!("init", *stackCh) |
+
+          for(@stack <- stackCh) {
+            @Stack!("push", stack, "value", *pushCh) |
+
+            for(_ <- pushCh) {
+              @Stack!("pop", stack, *ch) |
+              rhoSpec!("assert", ((true, "value"), "== <-", *ch), "Pop returns last inserted item", *ackCh)
+            }
+          }
+        }
+      } |
+
+      contract test_pop_item_from_empty_collection(rhoSpec, _, ackCh) = {
+        new stackCh, ch in {
+          @Stack!("init", *stackCh) |
+
+          for(@stack <- stackCh) {
+            @Stack!("pop", stack, *ch) |
+            rhoSpec!("assert", ((false, "stack is empty"), "== <-", *ch), "Pop returns error if stack is empty", *ackCh)
+          }
+        }
+      } |
+
+      contract test_convert_to_list_0(rhoSpec, _, ackCh) = {
+        new stackCh, ch in {
+          @Stack!("init", *stackCh) |
+
+          for(@stack <- stackCh) {
+            @Stack!("toList", stack, *ch) |
+            rhoSpec!("assert", ([], "== <-", *ch), "Stack can be converted to list when empty", *ackCh)
+          }
+        }
+      } |
+
+      contract test_convert_to_list_1(rhoSpec, _, ackCh) = {
+        new stackCh, filledCh, ch in {
+          @Stack!("init", *stackCh) |
+
+          for(@stack <- stackCh) {
+            fill!(stack, [1], *filledCh) |
+
+            for(<- filledCh) {
+              @Stack!("toList", stack, *ch) |
+              rhoSpec!("assert", ([1], "== <-", *ch), "Stack can be converted to list when 1 value is present", *ackCh)
+            }
+          }
+        }
+      } |
+
+      contract test_convert_to_list_2(rhoSpec, _, ackCh) = {
+        new stackCh, filledCh, ch in {
+          @Stack!("init", *stackCh) |
+
+          for(@stack <- stackCh) {
+            fill!(stack, [1, 2], *filledCh) |
+
+            for(<- filledCh) {
+              @Stack!("toList", stack, *ch) |
+              rhoSpec!("assert", ([1, 2], "== <-", *ch), "Stack can be converted to list when 2 values are present", *ackCh)
+            }
+          }
+        }
+      } |
+
+      contract test_convert_to_list_3(rhoSpec, _, ackCh) = {
+        new stackCh, filledCh, ch in {
+          @Stack!("init", *stackCh) |
+
+          for(@stack <- stackCh) {
+            fill!(stack, [1, 2, 3], *filledCh) |
+
+            for(<- filledCh) {
+              @Stack!("toList", stack, *ch) |
+              rhoSpec!("assert", ([1, 2, 3], "== <-", *ch), "Stack can be converted to list when 3 values are present", *ackCh)
+            }
+          }
+        }
+      } |
+
+      contract test_convert_to_list_4(rhoSpec, _, ackCh) = {
+        new stackCh, filledCh, ch in {
+          @Stack!("init", *stackCh) |
+
+          for(@stack <- stackCh) {
+            fill!(stack, [1, 2, 3, 4], *filledCh) |
+
+            for(<- filledCh) {
+              @Stack!("toList", stack, *ch) |
+              rhoSpec!("assert", ([1, 2, 3, 4], "== <-", *ch), "Stack can be converted to list when 4 values are present", *ackCh)
+            }
+          }
+        }
+      } |
+
+      contract fill(@stack, @data, ret) = {
+        match data {
+          [] => ret!()
+          [head ...tail] => {
+            new done in {
+              @Stack!("push", stack, head, *done) |
+              for(_ <- done) {
+                fill!(stack, tail, *ret)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/casper/tests/genesis/contracts/mod.rs
+++ b/casper/tests/genesis/contracts/mod.rs
@@ -17,6 +17,7 @@ pub mod rev_address_spec;
 pub mod rev_issuance_test;
 pub mod rev_vault_spec;
 pub mod rho_spec_contract_spec;
+pub mod stack_spec;
 pub mod standard_deploys_spec;
 pub mod timeout_result_collector_spec;
 pub mod tree_hash_map_spec;

--- a/casper/tests/genesis/contracts/stack_spec.rs
+++ b/casper/tests/genesis/contracts/stack_spec.rs
@@ -1,0 +1,23 @@
+// See casper/src/test/scala/coop/rchain/casper/genesis/contracts/StackSpec.scala
+
+use crate::genesis::contracts::GENESIS_TEST_TIMEOUT;
+use crate::helper::rho_spec::RhoSpec;
+use rholang::rust::build::compile_rholang_source::CompiledRholangSource;
+use std::collections::HashMap;
+
+#[tokio::test]
+async fn stack_spec() {
+    let test_object = CompiledRholangSource::load_source("StackTest.rho")
+        .expect("Failed to load StackTest.rho");
+
+    let compiled = CompiledRholangSource::new(
+        test_object,
+        HashMap::new(), // NormalizerEnv.Empty
+        "StackTest.rho".to_string(),
+    )
+    .expect("Failed to compile StackTest.rho");
+
+    let spec = RhoSpec::new(compiled, vec![], GENESIS_TEST_TIMEOUT);
+
+    spec.run_tests().await.expect("StackSpec tests failed");
+}


### PR DESCRIPTION
## Overview
This PR adds new stack logic to the Rholang registry in the Rust code base, and backports PR #63 from Scala to Rust.
