### PR TITLE
SCALA - fix: Add stackPubKey to systemPublicKeys

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/StandardDeploys.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/StandardDeploys.scala
@@ -67,7 +67,8 @@ object StandardDeploys {
     revVaultPubKey,
     multiSigRevVaultPubKey,
     poSGeneratorPubKey,
-    revGeneratorPubKey
+    revGeneratorPubKey,
+    stackPubKey
   )
 
   def registry(shardId: String): Signed[DeployData] = toDeploy(


### PR DESCRIPTION
## Summary

The stack contract was added in PR #63 but `stackPubKey` was not added to `systemPublicKeys`. This security fix adds it.

## Problem

Without this fix, the stack private key (`c94e647de6876c954ebb7b64c40a220227770f9be003635edfe3336a1a2c8605`) could be used to sign regular deploys, bypassing the forbidden key check in `BlockAPI.scala`.

## Solution

Add `stackPubKey` to `systemPublicKeys` sequence, consistent with all other system contracts (registry, listOps, either, nonNegativeNumber, makeMint, authKey, revVault, multiSigRevVault, poSGenerator, revGenerator).

## Related

- Fixes oversight from PR #63
- Rust backport PR #356 already includes this fix