### PR TITLE
Revert "added getOrElse[187] function and delete[196] functions in TreeHashMap, backport from Scala to Rust; "

### DIFF
--- a/casper/src/main/resources/Registry.rho
+++ b/casper/src/main/resources/Registry.rho
@@ -55,8 +55,8 @@ in {
   // }
 
   new MakeNode, ByteArrayToNybbleList,
-      TreeHashMapSetter, TreeHashMapGetter, TreeHashMapContains, TreeHashMapUpdater, TreeHashMapDeleter,
-      powersCh, storeToken, nodeGet, depthP in {
+      TreeHashMapSetter, TreeHashMapGetter, TreeHashMapContains, TreeHashMapUpdater,
+      powersCh, storeToken, nodeGet in {
     match [1,2,4,8,16,32,64,128,256,512,1024,2048,4096,8192,16384,32768,65536] {
       powers => {
         contract MakeNode(@initVal, @node) = {
@@ -321,72 +321,6 @@ in {
                 ByteArrayToNybbleList!(hash, 0, depth, [], *nybListCh) |
                 for (@nybList <- nybListCh) {
                   TreeHashMapUpdater!(map, nybList, 0, 2 * depth, *update, hash.slice(depth, 32), *ret)
-                }
-              }
-            }
-          }
-        } |
-        contract TreeHashMap(@"getOrElse", @map, @key, valueCh, nilCh) = {
-          new retCh in {
-            TreeHashMap!("get", map, key, *retCh) |
-            for(@value <- retCh) {
-              match value {
-                Nil => nilCh!()
-                value => valueCh!(value)
-              }
-            }
-          }
-        } |
-
-        contract TreeHashMap(@"delete", @map, @key, ret) = {
-          new hashCh, nybListCh, keccak256Hash(`rho:crypto:keccak256Hash`) in {
-            // Hash the key to get a 256-bit array
-            keccak256Hash!(key.toByteArray(), *hashCh) |
-            for (@hash <- hashCh) {
-              for (@depth <<- @(map, *depthP)) {
-                // Get the bit list
-                ByteArrayToNybbleList!(hash, 0, depth, [], *nybListCh) |
-                for (@nybList <- nybListCh) {
-                  TreeHashMapDeleter!(map, nybList, 0, 2 * depth, hash.slice(depth, 32), *ret)
-                }
-              }
-            }
-          }
-        } |
-
-        contract TreeHashMapDeleter(@map, @nybList, @n, @len, @suffix, ret) = {
-          // Look up the value of the node at [map, nybList.slice(0, n + 1)
-          new valCh in {
-            match (map, nybList.slice(0, n)) {
-              node => {
-                for (@val <<- @[node, *storeToken]) {
-                  if (n == len) {
-                    // We're at the end of the path.
-                    if (val == 0) {
-                      // There's nothing here.
-                      // Return
-                      ret!(Nil)
-                    } else {
-                      // Acquire the lock on this node
-                      for (@val <- @[node, *storeToken]) {
-                        // Release the lock
-                        @[node, *storeToken]!(val.delete(suffix)) |
-                        // Return
-                        ret!(val.get(suffix))
-                      }
-                    }
-                  } else {
-                    // Otherwise try to reach the end of the path.
-                    // Bit k set means child node k exists.
-                    if ((val/powers.nth(nybList.nth(n))) % 2 == 0) {
-                      // If the path doesn't exist, there's no value to delete.
-                      // Return
-                      ret!(Nil)
-                    } else {
-                      // Child node exists, loop
-                      TreeHashMapDeleter!(map, nybList, n + 1, len, suffix, *ret)
-                    }
-                  }
                 }
               }
             }

--- a/casper/src/test/resources/RhoSpecContract.rho
+++ b/casper/src/test/resources/RhoSpecContract.rho
@@ -58,11 +58,6 @@ in {
             contract privateAssert(@assertion, @clue, ackCh) = {
               stdlog!("debug", "asserting: " ++ clue) |
               match assertion {
-                ("nothing <-", actualCh) => {
-                  for (<- @actualCh) {
-                    assert!(testName, attempt, true, clue, *ackCh)
-                  }
-                }
                 (expected, "== <-", actualCh) => {
                   for (@actual <- @actualCh) {
                     stdlog!("info", {"actual": actual, "expected": expected}) |

--- a/casper/src/test/resources/TreeHashMapTest.rho
+++ b/casper/src/test/resources/TreeHashMapTest.rho
@@ -10,12 +10,7 @@ new
   test_contains_after_set,
   test_get_after_set_to_nil,
   test_contains_after_set_to_nil,
-  test_contention,
-  test_depth_matches_init,
-  test_get_or_else_when_key_missing,
-  test_get_or_else_when_key_present,
-  test_delete_key,
-  test_delete_missing_key
+  test_contention
 in {
   rl!(`rho:id:zphjgsfy13h1k85isc8rtwtgt3t9zzt5pjd5ihykfmyapfc4wt3x5h`, *RhoSpecCh) |
   for(@(_, RhoSpec) <- RhoSpecCh) {
@@ -30,12 +25,7 @@ in {
         ("Contains after set returns true", *test_contains_after_set),
         ("Get after set to Nil returns Nil", *test_get_after_set_to_nil),
         ("Contains after set to Nil returns true", *test_contains_after_set_to_nil),
-        ("Works under contention", *test_contention),
-        ("Depth matches init", *test_depth_matches_init),
-        ("GetOrElse when key missing", *test_get_or_else_when_key_missing),
-        ("GetOrElse when key present", *test_get_or_else_when_key_present),
-        ("Delete key", *test_delete_key),
-        ("Delete missing key", *test_delete_missing_key)
+        ("Works under contention", *test_contention)
       ])
   } |
 
@@ -47,7 +37,10 @@ in {
           TreeHashMap!("init", 3, *ret) |
           for (@thm <- ret) {
             TreeHashMap!("get", thm, "no such key", *ch) |
-            rhoSpec!("assert", (Nil, "== <-", *ch), "Getting with an unused key returns Nil", *ackCh)
+            rhoSpec!("assertMany",
+              [
+                ((Nil, "== <-", *ch), "Getting with an unused key returns Nil")
+              ], *ackCh)
           }
         }
       } |
@@ -62,7 +55,10 @@ in {
             TreeHashMap!("update", thm, "no such key", *update, *ack) |
             for (_ <- ack) {
               TreeHashMap!("get", thm, "no such key", *ch) |
-              rhoSpec!("assert", (Nil, "== <-", *ch), "Getting after updating with an unused key returns Nil", *ackCh)
+              rhoSpec!("assertMany",
+                [
+                  ((Nil, "== <-", *ch), "Getting after updating with an unused key returns Nil")
+                ], *ackCh)
             }
           }
         }
@@ -80,7 +76,10 @@ in {
               TreeHashMap!("update", thm, "key", *update, *ack2) |
               for (_ <- ack2) {
                 TreeHashMap!("get", thm, "key", *ch) |
-                rhoSpec!("assert", (1, "== <-", *ch), "Getting after updating after setting returns the right value", *ackCh)
+                rhoSpec!("assertMany",
+                  [
+                    ((1, "== <-", *ch), "Getting after updating after setting returns the right value")
+                  ], *ackCh)
               }
             }
           }
@@ -112,7 +111,10 @@ in {
             TreeHashMap!("set", thm, "some key", "some val", *ch1) |
             for (_ <- ch1) {
               TreeHashMap!("fastUnsafeGet", thm, "some key", *ch2) |
-              rhoSpec!("assert", ("some val", "== <-", *ch2), "Getting with the proper key returns the correct value", *ackCh)
+              rhoSpec!("assertMany",
+                [
+                  (("some val", "== <-", *ch2), "Getting with the proper key returns the correct value"),
+                ], *ackCh)
             }
           }
         }
@@ -123,7 +125,10 @@ in {
           TreeHashMap!("init", 3, *ret) |
           for (@thm <- ret) {
             TreeHashMap!("contains", thm, "no such key", *ch) |
-            rhoSpec!("assert", (false, "== <-", *ch), "Getting with an unused key returns false", *ackCh)
+            rhoSpec!("assertMany",
+              [
+                ((false, "== <-", *ch), "Getting with an unused key returns false")
+              ], *ackCh)
           }
         }
       } |
@@ -153,7 +158,10 @@ in {
             TreeHashMap!("set", thm, "some key", Nil, *ch1) |
             for (_ <- ch1) {
               TreeHashMap!("get", thm, "some key", *ch2) |
-              rhoSpec!("assert", (Nil, "== <-", *ch2), "Getting with the proper key returns the correct value", *ackCh)
+              rhoSpec!("assertMany",
+                [
+                  ((Nil, "== <-", *ch2), "Getting with the proper key returns the correct value"),
+                ], *ackCh)
             }
           }
         }
@@ -191,7 +199,10 @@ in {
                     for (@val3 <- ret3) {
                       out!("info", [n, val3]) |
                       if (n == 9) {
-                        rhoSpec!("assert", (flag, "==", true), "Placeholder", *ackCh)
+                        rhoSpec!("assertMany",
+                        [
+                          ((flag, "==", true), "Placeholder")
+                        ], *ackCh)
                       } else {
                         tryIt!(n+1, flag and (val3 != Nil))
                       }
@@ -202,69 +213,6 @@ in {
             }
           } |
           tryIt!(0, true)
-        }
-      } |
-
-      contract test_depth_matches_init(rhoSpec, _, ackCh) = {
-        new ret, ch in {
-          TreeHashMap!("init", 3, *ret) |
-          for (@thm <- ret) {
-            TreeHashMap!("depth", thm, *ch) |
-            rhoSpec!("assert", (3, "== <-", *ch), "Depth returns same value provided to init", *ackCh)
-          }
-        }
-      } |
-
-      contract test_get_or_else_when_key_missing(rhoSpec, _, ackCh) = {
-        new ret, valueCh, nilCh in {
-          TreeHashMap!("init", 3, *ret) |
-          for (@thm <- ret) {
-            TreeHashMap!("getOrElse", thm, 0, *valueCh, *nilCh) |
-            rhoSpec!("assert", ("nothing <-", *nilCh), "nilCh is triggered when key is missing", *ackCh)
-          }
-        }
-      } |
-
-      contract test_get_or_else_when_key_present(rhoSpec, _, ackCh) = {
-        new ret, ch1, valueCh, nilCh in {
-          TreeHashMap!("init", 3, *ret) |
-          for (@thm <- ret) {
-            TreeHashMap!("set", thm, "some key", "some val", *ch1) |
-            for (_ <- ch1) {
-              TreeHashMap!("getOrElse", thm, "some key", *valueCh, *nilCh) |
-              rhoSpec!("assert", ("some val", "== <-", *valueCh), "valueCh is triggered when key is present", *ackCh)
-            }
-          }
-        }
-      } |
-
-      contract test_delete_key(rhoSpec, _, ackCh) = {
-        new ret, ch1, deleteCh, getAfterDeleteCh in {
-          TreeHashMap!("init", 3, *ret) |
-          for (@thm <- ret) {
-            TreeHashMap!("set", thm, "some key", "some val", *ch1) |
-            for (_ <- ch1) {
-              TreeHashMap!("delete", thm, "some key", *deleteCh) |
-              for (@deleted <- deleteCh) {
-                TreeHashMap!("get", thm, "some key", *getAfterDeleteCh) |
-                rhoSpec!("assertMany",
-                  [
-                    (("some val", "==", deleted), "deleteCh contains deleted value"),
-                    ((Nil, "== <-", *getAfterDeleteCh), "value is not present in map"),
-                  ], *ackCh)
-              }
-            }
-          }
-        }
-      } |
-
-      contract test_delete_missing_key(rhoSpec, _, ackCh) = {
-        new ret, deleteCh in {
-          TreeHashMap!("init", 3, *ret) |
-          for (@thm <- ret) {
-            TreeHashMap!("delete", thm, "some key", *deleteCh) |
-            rhoSpec!("assert", (Nil, "== <-", *deleteCh), "deleteCh contains Nil", *ackCh)
-          }
         }
       }
     }


### PR DESCRIPTION

This reverts commit b51a9ec5b6cff244295e0be6b7bedebc75d23d11.

