### PR TITLE
RUST - Port Prometheus/Grafana monitoring from Scala PR #173

### DIFF
--- a/casper/src/rust/engine/block_retriever.rs
+++ b/casper/src/rust/engine/block_retriever.rs
@@ -47,6 +47,7 @@ pub struct AdmitHashResult {
 #[derive(Debug, Clone)]
 pub struct RequestState {
     pub timestamp: u64,
+    pub initial_timestamp: u64,
     pub peers: HashSet<PeerNode>,
     pub received: bool,
     pub in_casper_buffer: bool,
@@ -138,6 +139,7 @@ impl<T: TransportLayer + Send + Sync> BlockRetriever<T> {
                 hash,
                 RequestState {
                     timestamp: now,
+                    initial_timestamp: now,
                     peers: HashSet::new(),
                     received: mark_as_received,
                     in_casper_buffer: false,
@@ -415,12 +417,12 @@ impl<T: TransportLayer + Send + Sync> BlockRetriever<T> {
                     (AckReceiveResult::AddedAsReceived, None)
                 }
                 Some(requested) => {
-                    let timestamp = requested.timestamp;
+                    let initial_timestamp = requested.initial_timestamp;
                     // Make Casper loop aware that the block has been received
                     let mut updated_request = requested.clone();
                     updated_request.received = true;
                     state.insert(hash.clone(), updated_request);
-                    (AckReceiveResult::MarkedAsReceived, Some(timestamp))
+                    (AckReceiveResult::MarkedAsReceived, Some(initial_timestamp))
                 }
             }
         };

--- a/casper/tests/engine/running_handle_has_block_spec.rs
+++ b/casper/tests/engine/running_handle_has_block_spec.rs
@@ -107,6 +107,7 @@ async fn block_retriever_should_store_on_a_waiting_list_and_dont_request_if_requ
             ctx.hash.clone(),
             RequestState {
                 timestamp: TestContext::current_millis(),
+                initial_timestamp: TestContext::current_millis(),
                 peers: HashSet::new(),
                 received: false,
                 in_casper_buffer: false,
@@ -166,6 +167,7 @@ async fn block_retriever_should_request_block_and_add_peer_to_waiting_list_if_pe
             ctx.hash.clone(),
             RequestState {
                 timestamp: TestContext::current_millis(),
+                initial_timestamp: TestContext::current_millis(),
                 peers: HashSet::new(),
                 received: false,
                 in_casper_buffer: false,

--- a/casper/tests/sync/block_retriever_request_all_spec.rs
+++ b/casper/tests/sync/block_retriever_request_all_spec.rs
@@ -153,6 +153,7 @@ struct TestFixture {
 
                     let request_state = casper::rust::engine::block_retriever::RequestState {
                         timestamp: timed_out_timestamp,
+                        initial_timestamp: timed_out_timestamp,
                         peers,
                         received: false,
                         in_casper_buffer: false,
@@ -199,6 +200,7 @@ struct TestFixture {
 
                     let request_state = casper::rust::engine::block_retriever::RequestState {
                         timestamp: timed_out_timestamp,
+                        initial_timestamp: timed_out_timestamp,
                         peers,
                         received: false,
                         in_casper_buffer: false,
@@ -247,6 +249,7 @@ struct TestFixture {
 
                     let request_state = casper::rust::engine::block_retriever::RequestState {
                         timestamp: timed_out_timestamp,
+                        initial_timestamp: timed_out_timestamp,
                         peers,
                         received: false,
                         in_casper_buffer: false,
@@ -318,6 +321,7 @@ struct TestFixture {
 
                     let request_state = casper::rust::engine::block_retriever::RequestState {
                         timestamp: timed_out_timestamp,
+                        initial_timestamp: timed_out_timestamp,
                         peers,
                         received: false,
                         in_casper_buffer: false,
@@ -367,6 +371,7 @@ struct TestFixture {
 
                     let request_state = casper::rust::engine::block_retriever::RequestState {
                         timestamp: timed_out_timestamp,
+                        initial_timestamp: timed_out_timestamp,
                         peers,
                         received: false,
                         in_casper_buffer: false,
@@ -401,6 +406,7 @@ struct TestFixture {
 
                     let request_state = casper::rust::engine::block_retriever::RequestState {
                         timestamp: timed_out_timestamp,
+                        initial_timestamp: timed_out_timestamp,
                         peers,
                         received: false,
                         in_casper_buffer: true, // Already in casper buffer

--- a/docker/monitoring/grafana/dashboards/block-transfer.json
+++ b/docker/monitoring/grafana/dashboards/block-transfer.json
@@ -108,7 +108,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_retriever:block_download_end_to_end_time:p50",
+          "expr": "f1r3fly:casper:block_retriever:block_download_end_to_end_time:p50",
           "legendFormat": "p50",
           "refId": "A"
         },
@@ -117,7 +117,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_retriever:block_download_end_to_end_time:p95",
+          "expr": "f1r3fly:casper:block_retriever:block_download_end_to_end_time:p95",
           "legendFormat": "p95",
           "refId": "B"
         },
@@ -126,7 +126,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_retriever:block_download_end_to_end_time:p99",
+          "expr": "f1r3fly:casper:block_retriever:block_download_end_to_end_time:p99",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -221,7 +221,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_processor:block_validation_time:p50",
+          "expr": "f1r3fly:casper:block_processor:block_validation_time:p50",
           "legendFormat": "p50",
           "refId": "A"
         },
@@ -230,7 +230,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_processor:block_validation_time:p95",
+          "expr": "f1r3fly:casper:block_processor:block_validation_time:p95",
           "legendFormat": "p95",
           "refId": "B"
         },
@@ -239,7 +239,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_processor:block_validation_time:p99",
+          "expr": "f1r3fly:casper:block_processor:block_validation_time:p99",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -334,7 +334,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_processor:block_size:avg5m",
+          "expr": "f1r3fly:casper:block_processor:block_size:avg5m",
           "legendFormat": "Average",
           "refId": "A"
         },
@@ -343,7 +343,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_processor:block_size:p95",
+          "expr": "f1r3fly:casper:block_processor:block_size:p95",
           "legendFormat": "p95",
           "refId": "B"
         }
@@ -437,7 +437,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "(rchain:casper:block_processor:block_size:avg5m / 1000000) / (rchain:casper:block_retriever:block_download_end_to_end_time:p50 / 1000)",
+          "expr": "(f1r3fly:casper:block_processor:block_size:avg5m / 1000000) / (f1r3fly:casper:block_retriever:block_download_end_to_end_time:p50 / 1000)",
           "legendFormat": "Transfer Rate (avg size / p50 time)",
           "refId": "A"
         }
@@ -531,7 +531,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_retriever:block_requests_total:rate5m",
+          "expr": "f1r3fly:casper:block_retriever:block_requests_total:rate5m",
           "legendFormat": "Requests",
           "refId": "A"
         },
@@ -540,7 +540,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_retriever:block_requests_retries:rate5m",
+          "expr": "f1r3fly:casper:block_retriever:block_requests_retries:rate5m",
           "legendFormat": "Retries",
           "refId": "B"
         }
@@ -637,7 +637,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_processor:block_validation:success_rate5m",
+          "expr": "f1r3fly:casper:block_processor:block_validation:success_rate5m",
           "legendFormat": "Success Rate",
           "refId": "A"
         }
@@ -731,7 +731,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:running:block_hash_received:rate5m",
+          "expr": "f1r3fly:casper:running:block_hash_received:rate5m",
           "legendFormat": "Hash Broadcasts",
           "refId": "A"
         },
@@ -740,7 +740,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:running:block_request_received:rate5m",
+          "expr": "f1r3fly:casper:running:block_request_received:rate5m",
           "legendFormat": "Block Requests",
           "refId": "B"
         }
@@ -834,7 +834,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:comm:rp:transport:send_time:p95",
+          "expr": "f1r3fly:comm:rp:transport:send_time:p95",
           "legendFormat": "Send Time (p95)",
           "refId": "A"
         }
@@ -960,7 +960,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:comm:rp:transport:packets_received:rate5m",
+          "expr": "f1r3fly:comm:rp:transport:packets_received:rate5m",
           "legendFormat": "Packets Received",
           "refId": "A"
         },
@@ -969,7 +969,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:comm:rp:transport:packets_dropped:rate5m",
+          "expr": "f1r3fly:comm:rp:transport:packets_dropped:rate5m",
           "legendFormat": "Packets Dropped",
           "refId": "B"
         },
@@ -978,7 +978,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:comm:rp:transport:stream_chunks_received:rate5m",
+          "expr": "f1r3fly:comm:rp:transport:stream_chunks_received:rate5m",
           "legendFormat": "Stream Chunks Received",
           "refId": "C"
         },
@@ -987,7 +987,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:comm:rp:transport:stream_chunks_dropped:rate5m",
+          "expr": "f1r3fly:comm:rp:transport:stream_chunks_dropped:rate5m",
           "legendFormat": "Stream Chunks Dropped",
           "refId": "D"
         }
@@ -1049,7 +1049,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_retriever:block_download_end_to_end_time:p95",
+          "expr": "f1r3fly:casper:block_retriever:block_download_end_to_end_time:p95",
           "legendFormat": "Download p95 (ms)",
           "refId": "A"
         },
@@ -1058,7 +1058,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_processor:block_validation_time:p95",
+          "expr": "f1r3fly:casper:block_processor:block_validation_time:p95",
           "legendFormat": "Validation p95 (ms)",
           "refId": "B"
         },
@@ -1067,7 +1067,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_processor:block_validation:success_rate5m * 100",
+          "expr": "f1r3fly:casper:block_processor:block_validation:success_rate5m * 100",
           "legendFormat": "Success Rate (%)",
           "refId": "C"
         },
@@ -1076,7 +1076,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_processor:block_size:avg5m / 1024",
+          "expr": "f1r3fly:casper:block_processor:block_size:avg5m / 1024",
           "legendFormat": "Avg Block Size (KB)",
           "refId": "D"
         }
@@ -1171,7 +1171,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_retriever:block_download_end_to_end_time:rate5m",
+          "expr": "f1r3fly:casper:block_retriever:block_download_end_to_end_time:rate5m",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -1266,7 +1266,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_processor:block_validation_time:rate5m",
+          "expr": "f1r3fly:casper:block_processor:block_validation_time:rate5m",
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
@@ -1361,7 +1361,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:casper:block_processing_stage_replay_time:p50",
+          "expr": "f1r3fly:casper:casper:block_processing_stage_replay_time:p50",
           "legendFormat": "p50",
           "refId": "A"
         },
@@ -1370,7 +1370,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:casper:block_processing_stage_replay_time:p95",
+          "expr": "f1r3fly:casper:casper:block_processing_stage_replay_time:p95",
           "legendFormat": "p95",
           "refId": "B"
         },
@@ -1379,7 +1379,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:casper:block_processing_stage_replay_time:p99",
+          "expr": "f1r3fly:casper:casper:block_processing_stage_replay_time:p99",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -1474,7 +1474,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_processor:block_processing_stage_validation_setup_time:p50",
+          "expr": "f1r3fly:casper:block_processor:block_processing_stage_validation_setup_time:p50",
           "legendFormat": "p50",
           "refId": "A"
         },
@@ -1483,7 +1483,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_processor:block_processing_stage_validation_setup_time:p95",
+          "expr": "f1r3fly:casper:block_processor:block_processing_stage_validation_setup_time:p95",
           "legendFormat": "p95",
           "refId": "B"
         },
@@ -1492,7 +1492,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_processor:block_processing_stage_validation_setup_time:p99",
+          "expr": "f1r3fly:casper:block_processor:block_processing_stage_validation_setup_time:p99",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -1587,7 +1587,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_processor:block_processing_stage_storage_time:p50",
+          "expr": "f1r3fly:casper:block_processor:block_processing_stage_storage_time:p50",
           "legendFormat": "p50",
           "refId": "A"
         },
@@ -1596,7 +1596,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_processor:block_processing_stage_storage_time:p95",
+          "expr": "f1r3fly:casper:block_processor:block_processing_stage_storage_time:p95",
           "legendFormat": "p95",
           "refId": "B"
         },
@@ -1605,7 +1605,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "rchain:casper:block_processor:block_processing_stage_storage_time:p99",
+          "expr": "f1r3fly:casper:block_processor:block_processing_stage_storage_time:p99",
           "legendFormat": "p99",
           "refId": "C"
         }

--- a/docker/monitoring/prometheus-rules.yml
+++ b/docker/monitoring/prometheus-rules.yml
@@ -1,7 +1,6 @@
 # Prometheus Recording Rules for F1r3fly Node
 #
-# WIP: These rules use rchain_* metrics (Scala). Not yet implemented in Rust.
-# When ported to Rust, metrics will use f1r3fly_* prefix.
+# These rules use f1r3fly_* metrics (Rust).
 # See docker/prometheus-grafana.md for details.
 
 groups:
@@ -9,112 +8,112 @@ groups:
     interval: 30s
     rules:
       # Block download end-to-end time aggregations
-      - record: rchain:casper:block_retriever:block_download_end_to_end_time:rate5m
-        expr: rate(rchain_casper_block_retriever_block_download_end_to_end_time_count[5m])
+      - record: f1r3fly:casper:block_retriever:block_download_end_to_end_time:rate5m
+        expr: rate(f1r3fly_casper_block_retriever_block_download_end_to_end_time_count[5m])
 
-      - record: rchain:casper:block_retriever:block_download_end_to_end_time:p50
-        expr: histogram_quantile(0.50, sum by (job, instance, le) (rate(rchain_casper_block_retriever_block_download_end_to_end_time_bucket[5m])))
+      - record: f1r3fly:casper:block_retriever:block_download_end_to_end_time:p50
+        expr: histogram_quantile(0.50, sum by (job, instance, le) (rate(f1r3fly_casper_block_retriever_block_download_end_to_end_time_bucket[5m])))
 
-      - record: rchain:casper:block_retriever:block_download_end_to_end_time:p95
-        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(rchain_casper_block_retriever_block_download_end_to_end_time_bucket[5m])))
+      - record: f1r3fly:casper:block_retriever:block_download_end_to_end_time:p95
+        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(f1r3fly_casper_block_retriever_block_download_end_to_end_time_bucket[5m])))
 
-      - record: rchain:casper:block_retriever:block_download_end_to_end_time:p99
-        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(rchain_casper_block_retriever_block_download_end_to_end_time_bucket[5m])))
+      - record: f1r3fly:casper:block_retriever:block_download_end_to_end_time:p99
+        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(f1r3fly_casper_block_retriever_block_download_end_to_end_time_bucket[5m])))
 
       # Block validation time aggregations (Kamon adds _seconds suffix)
-      - record: rchain:casper:block_processor:block_validation_time:rate5m
-        expr: rate(rchain_casper_block_processor_block_validation_time_seconds_count[5m])
+      - record: f1r3fly:casper:block_processor:block_validation_time:rate5m
+        expr: rate(f1r3fly_casper_block_processor_block_validation_time_seconds_count[5m])
 
-      - record: rchain:casper:block_processor:block_validation_time:p50
-        expr: histogram_quantile(0.50, sum by (job, instance, le) (rate(rchain_casper_block_processor_block_validation_time_seconds_bucket[5m])))
+      - record: f1r3fly:casper:block_processor:block_validation_time:p50
+        expr: histogram_quantile(0.50, sum by (job, instance, le) (rate(f1r3fly_casper_block_processor_block_validation_time_seconds_bucket[5m])))
 
-      - record: rchain:casper:block_processor:block_validation_time:p95
-        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(rchain_casper_block_processor_block_validation_time_seconds_bucket[5m])))
+      - record: f1r3fly:casper:block_processor:block_validation_time:p95
+        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(f1r3fly_casper_block_processor_block_validation_time_seconds_bucket[5m])))
 
-      - record: rchain:casper:block_processor:block_validation_time:p99
-        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(rchain_casper_block_processor_block_validation_time_seconds_bucket[5m])))
+      - record: f1r3fly:casper:block_processor:block_validation_time:p99
+        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(f1r3fly_casper_block_processor_block_validation_time_seconds_bucket[5m])))
 
       # Block processing stage: validation-setup (getting CasperSnapshot)
-      - record: rchain:casper:block_processor:block_processing_stage_validation_setup_time:rate5m
-        expr: rate(rchain_casper_block_processor_block_processing_stage_validation_setup_time_seconds_count[5m])
+      - record: f1r3fly:casper:block_processor:block_processing_stage_validation_setup_time:rate5m
+        expr: rate(f1r3fly_casper_block_processor_block_processing_stage_validation_setup_time_seconds_count[5m])
 
-      - record: rchain:casper:block_processor:block_processing_stage_validation_setup_time:p50
-        expr: histogram_quantile(0.50, sum by (job, instance, le) (rate(rchain_casper_block_processor_block_processing_stage_validation_setup_time_seconds_bucket[5m])))
+      - record: f1r3fly:casper:block_processor:block_processing_stage_validation_setup_time:p50
+        expr: histogram_quantile(0.50, sum by (job, instance, le) (rate(f1r3fly_casper_block_processor_block_processing_stage_validation_setup_time_seconds_bucket[5m])))
 
-      - record: rchain:casper:block_processor:block_processing_stage_validation_setup_time:p95
-        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(rchain_casper_block_processor_block_processing_stage_validation_setup_time_seconds_bucket[5m])))
+      - record: f1r3fly:casper:block_processor:block_processing_stage_validation_setup_time:p95
+        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(f1r3fly_casper_block_processor_block_processing_stage_validation_setup_time_seconds_bucket[5m])))
 
-      - record: rchain:casper:block_processor:block_processing_stage_validation_setup_time:p99
-        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(rchain_casper_block_processor_block_processing_stage_validation_setup_time_seconds_bucket[5m])))
+      - record: f1r3fly:casper:block_processor:block_processing_stage_validation_setup_time:p99
+        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(f1r3fly_casper_block_processor_block_processing_stage_validation_setup_time_seconds_bucket[5m])))
 
       # Block processing stage: storage (BlockStore.put)
-      - record: rchain:casper:block_processor:block_processing_stage_storage_time:rate5m
-        expr: rate(rchain_casper_block_processor_block_processing_stage_storage_time_seconds_count[5m])
+      - record: f1r3fly:casper:block_processor:block_processing_stage_storage_time:rate5m
+        expr: rate(f1r3fly_casper_block_processor_block_processing_stage_storage_time_seconds_count[5m])
 
-      - record: rchain:casper:block_processor:block_processing_stage_storage_time:p50
-        expr: histogram_quantile(0.50, sum by (job, instance, le) (rate(rchain_casper_block_processor_block_processing_stage_storage_time_seconds_bucket[5m])))
+      - record: f1r3fly:casper:block_processor:block_processing_stage_storage_time:p50
+        expr: histogram_quantile(0.50, sum by (job, instance, le) (rate(f1r3fly_casper_block_processor_block_processing_stage_storage_time_seconds_bucket[5m])))
 
-      - record: rchain:casper:block_processor:block_processing_stage_storage_time:p95
-        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(rchain_casper_block_processor_block_processing_stage_storage_time_seconds_bucket[5m])))
+      - record: f1r3fly:casper:block_processor:block_processing_stage_storage_time:p95
+        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(f1r3fly_casper_block_processor_block_processing_stage_storage_time_seconds_bucket[5m])))
 
-      - record: rchain:casper:block_processor:block_processing_stage_storage_time:p99
-        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(rchain_casper_block_processor_block_processing_stage_storage_time_seconds_bucket[5m])))
+      - record: f1r3fly:casper:block_processor:block_processing_stage_storage_time:p99
+        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(f1r3fly_casper_block_processor_block_processing_stage_storage_time_seconds_bucket[5m])))
 
       # Block processing stage: replay (Rholang execution) - uses record() not timer()
-      - record: rchain:casper:casper:block_processing_stage_replay_time:rate5m
-        expr: rate(rchain_casper_casper_block_processing_stage_replay_time_count[5m])
+      - record: f1r3fly:casper:casper:block_processing_stage_replay_time:rate5m
+        expr: rate(f1r3fly_casper_casper_block_processing_stage_replay_time_count[5m])
 
-      - record: rchain:casper:casper:block_processing_stage_replay_time:p50
-        expr: histogram_quantile(0.50, sum by (job, instance, le) (rate(rchain_casper_casper_block_processing_stage_replay_time_bucket[5m])))
+      - record: f1r3fly:casper:casper:block_processing_stage_replay_time:p50
+        expr: histogram_quantile(0.50, sum by (job, instance, le) (rate(f1r3fly_casper_casper_block_processing_stage_replay_time_bucket[5m])))
 
-      - record: rchain:casper:casper:block_processing_stage_replay_time:p95
-        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(rchain_casper_casper_block_processing_stage_replay_time_bucket[5m])))
+      - record: f1r3fly:casper:casper:block_processing_stage_replay_time:p95
+        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(f1r3fly_casper_casper_block_processing_stage_replay_time_bucket[5m])))
 
-      - record: rchain:casper:casper:block_processing_stage_replay_time:p99
-        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(rchain_casper_casper_block_processing_stage_replay_time_bucket[5m])))
+      - record: f1r3fly:casper:casper:block_processing_stage_replay_time:p99
+        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(f1r3fly_casper_casper_block_processing_stage_replay_time_bucket[5m])))
 
       # Block size aggregations
-      - record: rchain:casper:block_processor:block_size:avg5m
-        expr: sum by (job, instance) (rate(rchain_casper_block_processor_block_size_sum[5m])) / sum by (job, instance) (rate(rchain_casper_block_processor_block_size_count[5m]))
+      - record: f1r3fly:casper:block_processor:block_size:avg5m
+        expr: sum by (job, instance) (rate(f1r3fly_casper_block_processor_block_size_sum[5m])) / sum by (job, instance) (rate(f1r3fly_casper_block_processor_block_size_count[5m]))
 
-      - record: rchain:casper:block_processor:block_size:p95
-        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(rchain_casper_block_processor_block_size_bucket[5m])))
+      - record: f1r3fly:casper:block_processor:block_size:p95
+        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(f1r3fly_casper_block_processor_block_size_bucket[5m])))
 
       # Block request rates (Kamon adds _total suffix to counters)
-      - record: rchain:casper:block_retriever:block_requests_total:rate5m
-        expr: rate(rchain_casper_block_retriever_block_requests_total_total[5m])
+      - record: f1r3fly:casper:block_retriever:block_requests_total:rate5m
+        expr: rate(f1r3fly_casper_block_retriever_block_requests_total_total[5m])
 
-      - record: rchain:casper:block_retriever:block_requests_retries:rate5m
-        expr: rate(rchain_casper_block_retriever_block_requests_retries_total[5m])
+      - record: f1r3fly:casper:block_retriever:block_requests_retries:rate5m
+        expr: rate(f1r3fly_casper_block_retriever_block_requests_retries_total[5m])
 
       # Block validation success rate (handle case where failed metric doesn't exist yet)
       # Compute per-instance success rate, defaulting to 1.0 (100%) when no failures
-      - record: rchain:casper:block_processor:block_validation:success_rate5m
-        expr: rate(rchain_casper_block_processor_block_validation_success_total[5m]) / (rate(rchain_casper_block_processor_block_validation_success_total[5m]) + rate(rchain_casper_block_processor_block_validation_failed_total[5m])) or (rate(rchain_casper_block_processor_block_validation_success_total[5m]) * 0 + 1)
+      - record: f1r3fly:casper:block_processor:block_validation:success_rate5m
+        expr: rate(f1r3fly_casper_block_processor_block_validation_success_total[5m]) / (rate(f1r3fly_casper_block_processor_block_validation_success_total[5m]) + rate(f1r3fly_casper_block_processor_block_validation_failed_total[5m])) or (rate(f1r3fly_casper_block_processor_block_validation_success_total[5m]) * 0 + 1)
 
       # Block hash and request message rates
-      - record: rchain:casper:running:block_hash_received:rate5m
-        expr: rate(rchain_casper_running_block_hash_received_total[5m])
+      - record: f1r3fly:casper:running:block_hash_received:rate5m
+        expr: rate(f1r3fly_casper_running_block_hash_received_total[5m])
 
-      - record: rchain:casper:running:block_request_received:rate5m
-        expr: rate(rchain_casper_running_block_request_received_total[5m])
+      - record: f1r3fly:casper:running:block_request_received:rate5m
+        expr: rate(f1r3fly_casper_running_block_request_received_total[5m])
 
       # Transport layer metrics aggregations (Kamon adds _seconds suffix to timers)
-      - record: rchain:comm:rp:transport:send_time:p95
-        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(rchain_comm_rp_transport_send_time_seconds_bucket[5m])))
+      - record: f1r3fly:comm:rp:transport:send_time:p95
+        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(f1r3fly_comm_rp_transport_send_time_seconds_bucket[5m])))
 
-      - record: rchain:comm:rp:transport:packets_received:rate5m
-        expr: rate(rchain_comm_rp_transport_packets_received_total[5m])
+      - record: f1r3fly:comm:rp:transport:packets_received:rate5m
+        expr: rate(f1r3fly_comm_rp_transport_packets_received_total[5m])
 
-      - record: rchain:comm:rp:transport:packets_enqueued:rate5m
-        expr: rate(rchain_comm_rp_transport_packets_enqueued_total[5m])
+      - record: f1r3fly:comm:rp:transport:packets_enqueued:rate5m
+        expr: rate(f1r3fly_comm_rp_transport_packets_enqueued_total[5m])
 
-      - record: rchain:comm:rp:transport:dispatched_packets:rate5m
-        expr: rate(rchain_comm_rp_transport_dispatched_packets_total[5m])
+      - record: f1r3fly:comm:rp:transport:dispatched_packets:rate5m
+        expr: rate(f1r3fly_comm_rp_transport_dispatched_packets_total[5m])
 
       # Stream chunks metrics
-      - record: rchain:comm:rp:transport:stream_chunks_received:rate5m
-        expr: rate(rchain_comm_rp_transport_stream_chunks_received_total[5m])
+      - record: f1r3fly:comm:rp:transport:stream_chunks_received:rate5m
+        expr: rate(f1r3fly_comm_rp_transport_stream_chunks_received_total[5m])
 
-      - record: rchain:comm:rp:transport:stream_chunks_enqueued:rate5m
-        expr: rate(rchain_comm_rp_transport_stream_chunks_enqueued_total[5m])
+      - record: f1r3fly:comm:rp:transport:stream_chunks_enqueued:rate5m
+        expr: rate(f1r3fly_comm_rp_transport_stream_chunks_enqueued_total[5m])

--- a/docker/prometheus-grafana.md
+++ b/docker/prometheus-grafana.md
@@ -33,14 +33,14 @@ open http://localhost:3000   # Grafana (default user: admin / password: admin)
 
 Note: Grafana default credentials are `admin` / `admin`. You may be prompted to change the password on first login.
 
-## ⚠️ Rust Metrics Status (WIP)
+## Rust Metrics Status (Ported) ✅
 
-The Block Transfer Performance dashboard uses `rchain_*` metrics which are currently **not implemented in the Rust node**. When these metrics are ported to Rust, they will use the `f1r3fly_*` prefix instead:
+The Block Transfer Performance dashboard uses `f1r3fly_*` metrics which are now implemented in the Rust node. 
 
-| Scala Node | Rust Node (planned) |
-|------------|---------------------|
-| `rchain_casper_*` | `f1r3fly_casper_*` |
-| `rchain_comm_*` | `f1r3fly_comm_*` |
+| Metric Category | Rust Prefix | Status |
+|-----------------|-------------|--------|
+| Casper / Block | `f1r3fly_casper_*` | ✅ Ported |
+| Transport / Comm| `f1r3fly_comm_*` | ✅ Ported |
 
 **Current Rust metrics available:**
 - `comm_produce`, `comm_consume` (RSpace operations)

--- a/scripts/rnode-metric-counters-to-grafana-dash.sh
+++ b/scripts/rnode-metric-counters-to-grafana-dash.sh
@@ -94,8 +94,8 @@ footer=$(cat <<-EOM
     ]
   },
   "timezone": "",
-  "title": "F1r3Node Counter Metrics(All)",
-  "uid": "f1r3node-metrics-all",
+  "title": "F1r3fly Counter Metrics(All)",
+  "uid": "f1r3fly-metrics-all",
   "version": 3
 }
 EOM


### PR DESCRIPTION
## Summary
Ports Scala monitoring and metrics improvements from f1r3node:
- https://github.com/F1R3FLY-io/f1r3node/pull/230 (comprehensive block transfer metrics)
- https://github.com/F1R3FLY-io/f1r3node/pull/173 (Prometheus/Grafana monitoring stack)

## Changes
- Add `initial_timestamp` to `RequestState` for accurate end-to-end download time metrics
- Update Prometheus recording rules to use `f1r3fly` prefix instead of `rchain`
- Update Grafana dashboard to use `f1r3fly:` recording rules
- Update monitoring documentation to reflect ported metrics status
- Update dashboard generation script branding to F1r3fly