### PR TITLE
ci: migrate Rust CI to self-hosted runners

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -265,8 +265,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: F1R3FLY-io/system-integration
-          # TODO: Revert to main once fix/custom-shard-cleanup-resilience is merged
-          ref: fix/custom-shard-cleanup-resilience
+          ref: main
           path: system-integration
 
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

Migrate Docker build and integration tests to self-hosted OCI runners for the Rust node.

Extracted from PR #400 to allow the code changes to merge independently.

## Test plan

- [ ] CI pipeline runs successfully on self-hosted runners