### PR TITLE
feat(observability): Phase 1 — jemalloc + comprehensive Prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,7 @@ dependencies = [
  "hex",
  "imbl",
  "lz4_flex",
+ "metrics 0.23.1",
  "models",
  "once_cell",
  "proptest",
@@ -2639,16 +2640,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
-dependencies = [
- "ahash 0.8.12",
- "portable-atomic",
-]
-
-[[package]]
 name = "metrics-exporter-influx"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2942,6 +2933,7 @@ dependencies = [
  "shared",
  "sysinfo",
  "thiserror 2.0.17",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.28.0",
@@ -4120,7 +4112,7 @@ dependencies = [
  "itertools 0.14.0",
  "k256",
  "lazy_static",
- "metrics 0.24.3",
+ "metrics 0.23.1",
  "models",
  "openai-api-rs",
  "pretty_assertions",
@@ -4857,7 +4849,7 @@ dependencies = [
  "http-body-util",
  "indexmap 2.11.4",
  "lz4_flex",
- "metrics 0.24.3",
+ "metrics 0.23.1",
  "proptest",
  "prost",
  "rand 0.9.2",
@@ -5202,6 +5194,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2933,6 +2933,7 @@ dependencies = [
  "shared",
  "sysinfo",
  "thiserror 2.0.17",
+ "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
  "tokio-stream",
@@ -5194,6 +5195,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,9 @@ dashmap = "6.1"
 imbl = "7"
 regex = "1.12"
 async-trait = "0.1"
-metrics = "0.24"
+metrics = "0.23"
 stacker = "0.1"
+tikv-jemallocator = { version = "0.6", features = ["profiling", "background_threads"] }
 
 [profile.dev]
 debug = true

--- a/block-storage/Cargo.toml
+++ b/block-storage/Cargo.toml
@@ -21,5 +21,6 @@ tokio = { workspace = true }
 once_cell = "1.21.1"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+metrics = { workspace = true }
 
 [build-dependencies]

--- a/block-storage/src/rust/casperbuffer/casper_buffer_key_value_storage.rs
+++ b/block-storage/src/rust/casperbuffer/casper_buffer_key_value_storage.rs
@@ -68,6 +68,10 @@ impl CasperBufferKeyValueStorage {
         parents.insert(parent.clone());
         self.parents_store.put_one(child.clone(), parents)?;
         self.block_dependency_dag.add(parent, child);
+        metrics::gauge!("casper_buffer_pending_blocks", "source" => "f1r3fly.casper")
+            .set(self.block_dependency_dag.child_to_parent_adjacency_list.len() as f64);
+        metrics::gauge!("casper_buffer_dependency_free_blocks", "source" => "f1r3fly.casper")
+            .set(self.block_dependency_dag.dependency_free.len() as f64);
         Ok(())
     }
 
@@ -101,6 +105,11 @@ impl CasperBufferKeyValueStorage {
         self.parents_store.put(changes)?;
         let hashes_to_delete: Vec<BlockHashSerde> = hashes_removed.into_iter().collect();
         self.parents_store.delete(hashes_to_delete)?;
+
+        metrics::gauge!("casper_buffer_pending_blocks", "source" => "f1r3fly.casper")
+            .set(self.block_dependency_dag.child_to_parent_adjacency_list.len() as f64);
+        metrics::gauge!("casper_buffer_dependency_free_blocks", "source" => "f1r3fly.casper")
+            .set(self.block_dependency_dag.dependency_free.len() as f64);
 
         Ok(())
     }

--- a/block-storage/src/rust/dag/block_dag_key_value_storage.rs
+++ b/block-storage/src/rust/dag/block_dag_key_value_storage.rs
@@ -711,6 +711,19 @@ impl BlockDagKeyValueStorage {
                 block_metadata_guard.record_finalized(block_hash, HashSet::new())?;
             }
 
+            // Emit DAG size gauges after every block insertion so dashboards
+            // show unbounded growth immediately.
+            {
+                let meta_guard = self.block_metadata_index.read().unwrap();
+                let dag_state = meta_guard.dag_state().read().unwrap();
+                metrics::gauge!("dag_blocks_total", "source" => "f1r3fly.dag")
+                    .set(dag_state.dag_set.len() as f64);
+                metrics::gauge!("dag_finalized_blocks_total", "source" => "f1r3fly.dag")
+                    .set(dag_state.finalized_block_set.len() as f64);
+                metrics::gauge!("dag_height_map_entries", "source" => "f1r3fly.dag")
+                    .set(dag_state.height_map.len() as f64);
+            }
+
             Ok(self.get_representation_internal())
         }
     }

--- a/casper/src/rust/metrics_constants.rs
+++ b/casper/src/rust/metrics_constants.rs
@@ -21,7 +21,7 @@ pub const REPORTING_RUNTIME_METRICS_SOURCE: &str = "f1r3fly.rholang.reportingRun
 // Casper counter metrics
 pub const BLOCK_HASH_RECEIVED_METRIC: &str = "block.hash.received";
 pub const BLOCK_REQUEST_RECEIVED_METRIC: &str = "block.request.received";
-pub const BLOCK_REQUESTS_TOTAL_METRIC: &str = "block.requests.total";
+pub const BLOCK_REQUESTS_TOTAL_METRIC: &str = "block.requests";
 pub const BLOCK_REQUESTS_RETRIES_METRIC: &str = "block.requests.retries";
 pub const GENESIS_METRIC: &str = "genesis";
 pub const BLOCK_VALIDATION_SUCCESS_METRIC: &str = "block.validation.success";

--- a/comm/src/rust/transport/stream_observable.rs
+++ b/comm/src/rust/transport/stream_observable.rs
@@ -71,6 +71,12 @@ impl StreamObservable {
                     // Clean up cache
                     self.cache.remove(&key);
                 }
+
+                // Gauge the shared cache size regardless of push outcome.
+                // The cache is shared across all peer channels; its size reflects
+                // the total in-flight streaming blobs.
+                metrics::gauge!("comm_stream_cache_size", "source" => "f1r3fly.comm")
+                    .set(self.cache.len() as f64);
             }
             Err(e) => {
                 tracing::error!("Failed to store blob packet: {}", e);

--- a/docker/monitoring/prometheus-rules.yml
+++ b/docker/monitoring/prometheus-rules.yml
@@ -1,119 +1,148 @@
-# Prometheus Recording Rules for F1r3fly Node
+# Prometheus Recording Rules for F1r3fly Rust Node
 #
-# These rules use f1r3fly_* metrics (Rust).
-# See docker/prometheus-grafana.md for details.
+# Rust metrics use the pattern: metric_name{source="f1r3fly.category.subcategory"}
+# The source label identifies the subsystem — it is NOT embedded in the metric name.
+# Counters have _total suffix. Histograms have _bucket/_count/_sum suffixes.
+# The metrics crate converts dots and hyphens in metric names to underscores.
+#
+# See docker/prometheus-grafana.md for full metric reference.
 
 groups:
   - name: block_transfer_metrics
     interval: 30s
     rules:
       # Block download end-to-end time aggregations
+      # metric: block.download.end-to-end-time (histogram), source: f1r3fly.casper.block-retriever
       - record: f1r3fly:casper:block_retriever:block_download_end_to_end_time:rate5m
-        expr: rate(f1r3fly_casper_block_retriever_block_download_end_to_end_time_count[5m])
+        expr: rate(block_download_end_to_end_time_count{source="f1r3fly.casper.block-retriever"}[5m])
 
       - record: f1r3fly:casper:block_retriever:block_download_end_to_end_time:p50
-        expr: histogram_quantile(0.50, sum by (job, instance, le) (rate(f1r3fly_casper_block_retriever_block_download_end_to_end_time_bucket[5m])))
+        expr: histogram_quantile(0.50, sum by (job, instance, le) (rate(block_download_end_to_end_time_bucket{source="f1r3fly.casper.block-retriever"}[5m])))
 
       - record: f1r3fly:casper:block_retriever:block_download_end_to_end_time:p95
-        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(f1r3fly_casper_block_retriever_block_download_end_to_end_time_bucket[5m])))
+        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(block_download_end_to_end_time_bucket{source="f1r3fly.casper.block-retriever"}[5m])))
 
       - record: f1r3fly:casper:block_retriever:block_download_end_to_end_time:p99
-        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(f1r3fly_casper_block_retriever_block_download_end_to_end_time_bucket[5m])))
+        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(block_download_end_to_end_time_bucket{source="f1r3fly.casper.block-retriever"}[5m])))
 
-      # Block validation time aggregations (Kamon adds _seconds suffix)
+      # Block validation time aggregations
+      # metric: block.validation.time (histogram), source: f1r3fly.casper.block-processor
       - record: f1r3fly:casper:block_processor:block_validation_time:rate5m
-        expr: rate(f1r3fly_casper_block_processor_block_validation_time_seconds_count[5m])
+        expr: rate(block_validation_time_count{source="f1r3fly.casper.block-processor"}[5m])
 
       - record: f1r3fly:casper:block_processor:block_validation_time:p50
-        expr: histogram_quantile(0.50, sum by (job, instance, le) (rate(f1r3fly_casper_block_processor_block_validation_time_seconds_bucket[5m])))
+        expr: histogram_quantile(0.50, sum by (job, instance, le) (rate(block_validation_time_bucket{source="f1r3fly.casper.block-processor"}[5m])))
 
       - record: f1r3fly:casper:block_processor:block_validation_time:p95
-        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(f1r3fly_casper_block_processor_block_validation_time_seconds_bucket[5m])))
+        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(block_validation_time_bucket{source="f1r3fly.casper.block-processor"}[5m])))
 
       - record: f1r3fly:casper:block_processor:block_validation_time:p99
-        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(f1r3fly_casper_block_processor_block_validation_time_seconds_bucket[5m])))
+        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(block_validation_time_bucket{source="f1r3fly.casper.block-processor"}[5m])))
 
       # Block processing stage: validation-setup (getting CasperSnapshot)
+      # metric: block.processing.stage.validation-setup.time (histogram), source: f1r3fly.casper.block-processor
       - record: f1r3fly:casper:block_processor:block_processing_stage_validation_setup_time:rate5m
-        expr: rate(f1r3fly_casper_block_processor_block_processing_stage_validation_setup_time_seconds_count[5m])
+        expr: rate(block_processing_stage_validation_setup_time_count{source="f1r3fly.casper.block-processor"}[5m])
 
       - record: f1r3fly:casper:block_processor:block_processing_stage_validation_setup_time:p50
-        expr: histogram_quantile(0.50, sum by (job, instance, le) (rate(f1r3fly_casper_block_processor_block_processing_stage_validation_setup_time_seconds_bucket[5m])))
+        expr: histogram_quantile(0.50, sum by (job, instance, le) (rate(block_processing_stage_validation_setup_time_bucket{source="f1r3fly.casper.block-processor"}[5m])))
 
       - record: f1r3fly:casper:block_processor:block_processing_stage_validation_setup_time:p95
-        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(f1r3fly_casper_block_processor_block_processing_stage_validation_setup_time_seconds_bucket[5m])))
+        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(block_processing_stage_validation_setup_time_bucket{source="f1r3fly.casper.block-processor"}[5m])))
 
       - record: f1r3fly:casper:block_processor:block_processing_stage_validation_setup_time:p99
-        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(f1r3fly_casper_block_processor_block_processing_stage_validation_setup_time_seconds_bucket[5m])))
+        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(block_processing_stage_validation_setup_time_bucket{source="f1r3fly.casper.block-processor"}[5m])))
 
       # Block processing stage: storage (BlockStore.put)
+      # metric: block.processing.stage.storage.time (histogram), source: f1r3fly.casper.block-processor
       - record: f1r3fly:casper:block_processor:block_processing_stage_storage_time:rate5m
-        expr: rate(f1r3fly_casper_block_processor_block_processing_stage_storage_time_seconds_count[5m])
+        expr: rate(block_processing_stage_storage_time_count{source="f1r3fly.casper.block-processor"}[5m])
 
       - record: f1r3fly:casper:block_processor:block_processing_stage_storage_time:p50
-        expr: histogram_quantile(0.50, sum by (job, instance, le) (rate(f1r3fly_casper_block_processor_block_processing_stage_storage_time_seconds_bucket[5m])))
+        expr: histogram_quantile(0.50, sum by (job, instance, le) (rate(block_processing_stage_storage_time_bucket{source="f1r3fly.casper.block-processor"}[5m])))
 
       - record: f1r3fly:casper:block_processor:block_processing_stage_storage_time:p95
-        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(f1r3fly_casper_block_processor_block_processing_stage_storage_time_seconds_bucket[5m])))
+        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(block_processing_stage_storage_time_bucket{source="f1r3fly.casper.block-processor"}[5m])))
 
       - record: f1r3fly:casper:block_processor:block_processing_stage_storage_time:p99
-        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(f1r3fly_casper_block_processor_block_processing_stage_storage_time_seconds_bucket[5m])))
+        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(block_processing_stage_storage_time_bucket{source="f1r3fly.casper.block-processor"}[5m])))
 
-      # Block processing stage: replay (Rholang execution) - uses record() not timer()
+      # Block processing stage: replay (Rholang execution)
+      # metric: block.processing.stage.replay.time (histogram), source: f1r3fly.casper
       - record: f1r3fly:casper:casper:block_processing_stage_replay_time:rate5m
-        expr: rate(f1r3fly_casper_casper_block_processing_stage_replay_time_count[5m])
+        expr: rate(block_processing_stage_replay_time_count{source="f1r3fly.casper"}[5m])
 
       - record: f1r3fly:casper:casper:block_processing_stage_replay_time:p50
-        expr: histogram_quantile(0.50, sum by (job, instance, le) (rate(f1r3fly_casper_casper_block_processing_stage_replay_time_bucket[5m])))
+        expr: histogram_quantile(0.50, sum by (job, instance, le) (rate(block_processing_stage_replay_time_bucket{source="f1r3fly.casper"}[5m])))
 
       - record: f1r3fly:casper:casper:block_processing_stage_replay_time:p95
-        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(f1r3fly_casper_casper_block_processing_stage_replay_time_bucket[5m])))
+        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(block_processing_stage_replay_time_bucket{source="f1r3fly.casper"}[5m])))
 
       - record: f1r3fly:casper:casper:block_processing_stage_replay_time:p99
-        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(f1r3fly_casper_casper_block_processing_stage_replay_time_bucket[5m])))
+        expr: histogram_quantile(0.99, sum by (job, instance, le) (rate(block_processing_stage_replay_time_bucket{source="f1r3fly.casper"}[5m])))
 
       # Block size aggregations
+      # metric: block.size (histogram), source: f1r3fly.casper.block-processor
       - record: f1r3fly:casper:block_processor:block_size:avg5m
-        expr: sum by (job, instance) (rate(f1r3fly_casper_block_processor_block_size_sum[5m])) / sum by (job, instance) (rate(f1r3fly_casper_block_processor_block_size_count[5m]))
+        expr: sum by (job, instance) (rate(block_size_sum{source="f1r3fly.casper.block-processor"}[5m])) / sum by (job, instance) (rate(block_size_count{source="f1r3fly.casper.block-processor"}[5m]))
 
       - record: f1r3fly:casper:block_processor:block_size:p95
-        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(f1r3fly_casper_block_processor_block_size_bucket[5m])))
+        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(block_size_bucket{source="f1r3fly.casper.block-processor"}[5m])))
 
-      # Block request rates (Kamon adds _total suffix to counters)
+      # Block request rates
+      # metric: block.requests (counter), source: f1r3fly.casper.block-retriever
       - record: f1r3fly:casper:block_retriever:block_requests_total:rate5m
-        expr: rate(f1r3fly_casper_block_retriever_block_requests_total_total[5m])
+        expr: rate(block_requests_total{source="f1r3fly.casper.block-retriever"}[5m])
 
+      # metric: block.requests.retries (counter), source: f1r3fly.casper.block-retriever
       - record: f1r3fly:casper:block_retriever:block_requests_retries:rate5m
-        expr: rate(f1r3fly_casper_block_retriever_block_requests_retries_total[5m])
+        expr: rate(block_requests_retries_total{source="f1r3fly.casper.block-retriever"}[5m])
 
-      # Block validation success rate (handle case where failed metric doesn't exist yet)
-      # Compute per-instance success rate, defaulting to 1.0 (100%) when no failures
+      # Block validation success rate
+      # metrics: block.validation.success and block.validation.failed (counters), source: f1r3fly.casper.block-processor
+      # Defaults to 1.0 (100%) when no failures have been recorded yet.
       - record: f1r3fly:casper:block_processor:block_validation:success_rate5m
-        expr: rate(f1r3fly_casper_block_processor_block_validation_success_total[5m]) / (rate(f1r3fly_casper_block_processor_block_validation_success_total[5m]) + rate(f1r3fly_casper_block_processor_block_validation_failed_total[5m])) or (rate(f1r3fly_casper_block_processor_block_validation_success_total[5m]) * 0 + 1)
+        expr: rate(block_validation_success_total{source="f1r3fly.casper.block-processor"}[5m]) / (rate(block_validation_success_total{source="f1r3fly.casper.block-processor"}[5m]) + rate(block_validation_failed_total{source="f1r3fly.casper.block-processor"}[5m])) or (rate(block_validation_success_total{source="f1r3fly.casper.block-processor"}[5m]) * 0 + 1)
 
       # Block hash and request message rates
+      # metric: block.hash.received (counter), source: f1r3fly.casper.running
       - record: f1r3fly:casper:running:block_hash_received:rate5m
-        expr: rate(f1r3fly_casper_running_block_hash_received_total[5m])
+        expr: rate(block_hash_received_total{source="f1r3fly.casper.running"}[5m])
 
+      # metric: block.request.received (counter), source: f1r3fly.casper.running
       - record: f1r3fly:casper:running:block_request_received:rate5m
-        expr: rate(f1r3fly_casper_running_block_request_received_total[5m])
+        expr: rate(block_request_received_total{source="f1r3fly.casper.running"}[5m])
 
-      # Transport layer metrics aggregations (Kamon adds _seconds suffix to timers)
+      # Transport layer metrics aggregations
+      # metric: send-time (histogram), source: f1r3fly.comm.rp.transport
       - record: f1r3fly:comm:rp:transport:send_time:p95
-        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(f1r3fly_comm_rp_transport_send_time_seconds_bucket[5m])))
+        expr: histogram_quantile(0.95, sum by (job, instance, le) (rate(send_time_bucket{source="f1r3fly.comm.rp.transport"}[5m])))
 
+      # metric: packets.received (counter), source: f1r3fly.comm.rp.transport
       - record: f1r3fly:comm:rp:transport:packets_received:rate5m
-        expr: rate(f1r3fly_comm_rp_transport_packets_received_total[5m])
+        expr: rate(packets_received_total{source="f1r3fly.comm.rp.transport"}[5m])
 
+      # metric: packets.enqueued (counter), source: f1r3fly.comm.rp.transport
       - record: f1r3fly:comm:rp:transport:packets_enqueued:rate5m
-        expr: rate(f1r3fly_comm_rp_transport_packets_enqueued_total[5m])
+        expr: rate(packets_enqueued_total{source="f1r3fly.comm.rp.transport"}[5m])
 
+      # metric: packets.dropped (counter), source: f1r3fly.comm.rp.transport
+      - record: f1r3fly:comm:rp:transport:packets_dropped:rate5m
+        expr: rate(packets_dropped_total{source="f1r3fly.comm.rp.transport"}[5m])
+
+      # metric: dispatched.packets (counter), source: f1r3fly.comm.rp.transport
       - record: f1r3fly:comm:rp:transport:dispatched_packets:rate5m
-        expr: rate(f1r3fly_comm_rp_transport_dispatched_packets_total[5m])
+        expr: rate(dispatched_packets_total{source="f1r3fly.comm.rp.transport"}[5m])
 
-      # Stream chunks metrics
+      # Stream chunk metrics
+      # metric: stream.chunks.received (counter), source: f1r3fly.comm.rp.transport
       - record: f1r3fly:comm:rp:transport:stream_chunks_received:rate5m
-        expr: rate(f1r3fly_comm_rp_transport_stream_chunks_received_total[5m])
+        expr: rate(stream_chunks_received_total{source="f1r3fly.comm.rp.transport"}[5m])
 
+      # metric: stream.chunks.enqueued (counter), source: f1r3fly.comm.rp.transport
       - record: f1r3fly:comm:rp:transport:stream_chunks_enqueued:rate5m
-        expr: rate(f1r3fly_comm_rp_transport_stream_chunks_enqueued_total[5m])
+        expr: rate(stream_chunks_enqueued_total{source="f1r3fly.comm.rp.transport"}[5m])
+
+      # metric: stream.chunks.dropped (counter), source: f1r3fly.comm.rp.transport
+      - record: f1r3fly:comm:rp:transport:stream_chunks_dropped:rate5m
+        expr: rate(stream_chunks_dropped_total{source="f1r3fly.comm.rp.transport"}[5m])

--- a/docker/monitoring/prometheus-rules.yml
+++ b/docker/monitoring/prometheus-rules.yml
@@ -5,7 +5,7 @@
 # Counters have _total suffix. Histograms have _bucket/_count/_sum suffixes.
 # The metrics crate converts dots and hyphens in metric names to underscores.
 #
-# See docker/prometheus-grafana.md for full metric reference.
+# See services/f1r3node-rust/docker/prometheus-grafana.md for full metric reference.
 
 groups:
   - name: block_transfer_metrics
@@ -146,3 +146,27 @@ groups:
       # metric: stream.chunks.dropped (counter), source: f1r3fly.comm.rp.transport
       - record: f1r3fly:comm:rp:transport:stream_chunks_dropped:rate5m
         expr: rate(stream_chunks_dropped_total{source="f1r3fly.comm.rp.transport"}[5m])
+
+  - name: memory_metrics
+    interval: 30s
+    rules:
+      # jemalloc fragmentation + retention overhead: bytes resident but not in live allocations.
+      # If this grows ~10-17 MB/block, jemalloc is the root cause of unbounded RSS growth.
+      # Metrics source: f1r3fly.system
+      - record: f1r3fly:system:jemalloc_overhead_bytes
+        expr: jemalloc_resident_bytes{source="f1r3fly.system"} - jemalloc_allocated_bytes{source="f1r3fly.system"}
+
+      # jemalloc retention ratio: fraction of resident memory that is overhead.
+      # High values (> 0.5) indicate significant fragmentation or retained-but-free arenas.
+      - record: f1r3fly:system:jemalloc_overhead_ratio
+        expr: (jemalloc_resident_bytes{source="f1r3fly.system"} - jemalloc_allocated_bytes{source="f1r3fly.system"}) / jemalloc_resident_bytes{source="f1r3fly.system"}
+
+      # Total LMDB disk usage across all environments.
+      # If this tracks RSS growth, trie path-copying in LMDB is the root cause.
+      - record: f1r3fly:system:lmdb_total_size_bytes
+        expr: >
+          lmdb_rspace_history_size_bytes{source="f1r3fly.system"}
+          + lmdb_rspace_cold_size_bytes{source="f1r3fly.system"}
+          + lmdb_blockstorage_size_bytes{source="f1r3fly.system"}
+          + lmdb_dagstorage_size_bytes{source="f1r3fly.system"}
+          + lmdb_eval_history_size_bytes{source="f1r3fly.system"}

--- a/docker/prometheus-grafana.md
+++ b/docker/prometheus-grafana.md
@@ -33,20 +33,24 @@ open http://localhost:3000   # Grafana (default user: admin / password: admin)
 
 Note: Grafana default credentials are `admin` / `admin`. You may be prompted to change the password on first login.
 
-## Rust Metrics Status (Ported) ✅
+## Rust Metrics Status
 
-The Block Transfer Performance dashboard uses `f1r3fly_*` metrics which are now implemented in the Rust node. 
+The Rust node emits all block processing, transport, and system metrics via the `metrics` crate.
+Prometheus metric names follow the pattern `<metric_name>{source="<source_label>"}` — the source
+is a label, not part of the metric name.
 
-| Metric Category | Rust Prefix | Status |
-|-----------------|-------------|--------|
-| Casper / Block | `f1r3fly_casper_*` | ✅ Ported |
-| Transport / Comm| `f1r3fly_comm_*` | ✅ Ported |
+| Metric Category | Rust metric name (example) | Source label |
+|-----------------|---------------------------|--------------|
+| Block retrieval | `block_download_end_to_end_time_bucket` | `f1r3fly.casper.block-retriever` |
+| Block processing | `block_validation_time_bucket` | `f1r3fly.casper.block-processor` |
+| Block replay | `block_processing_stage_replay_time_bucket` | `f1r3fly.casper` |
+| Transport | `send_time_bucket`, `packets_received_total` | `f1r3fly.comm.rp.transport` |
+| RSpace | `comm_consume_time_seconds_bucket` | `f1r3fly.rspace` |
+| Discovery | `peers` | `f1r3fly.comm.discovery.kademlia` |
+| System | `process_memory_rss_bytes`, `system_cpu_usage_percent` | `f1r3fly.system` |
 
-**Current Rust metrics available:**
-- `comm_produce`, `comm_consume` (RSpace operations)
-- `peers` (Kademlia discovery)
-
-The dashboard will show "No data" until the Casper and Transport metrics are ported to Rust.
+> **Note**: All recording rules in `docker/monitoring/prometheus-rules.yml` use Rust-style
+> label selectors (`metric_name{source="f1r3fly.category"}`). Kamon-style flat names are not used.
 
 
 ## Pre-Configured Dashboards
@@ -115,14 +119,80 @@ The block processing stage metrics are designed to isolate performance bottlenec
 
 For detailed performance analysis, see `BLOCK_EXCHANGE_ANALYSIS.md`, Section 13.
 
+## Phase 1 Memory Growth Analysis
+
+Phase 1 observability (jemalloc + 16 in-memory structure gauges) was used to characterize memory growth
+on a local 5-node Rust shard (bootstrap + 3 validators + observer). Three snapshots were taken at
+~35, ~100, and ~147 blocks respectively with no user transactions submitted (genesis-level activity only).
+
+### Observed growth rate
+
+| Node type | ~35 blocks | ~100 blocks | ~147 blocks |
+|-----------|-----------|------------|------------|
+| Bootstrap | 360 MB | 1,116 MB | 1,570 MB |
+| Validator | 509–717 MB | 1,674–1,706 MB | 2,337–2,415 MB |
+| Observer | 417 MB | 1,151 MB | 1,571 MB |
+
+**Growth rate: ~10–17 MB per block, linear and unbounded across all node types.**
+
+### What is NOT the cause
+
+- `rspace_history_cache_datums`, `rspace_history_cache_continuations`, `rspace_history_cache_joins` —
+  all completely flat after genesis. RSpace caches are not contributing to growth.
+- `rspace_hot_store_*` — stable at 56/3/3 across all snapshots (flushed to trie each block).
+- `comm_stream_cache_size`, `transport_channels_count` — stable (1–4 per node).
+- `casper_buffer_pending_blocks` — consistently 0 after sync.
+
+### Confirmed growth drivers
+
+**1. DAG retains all blocks in memory without pruning finalized blocks.**
+
+`dag_height_map_entries` grows at ~0.66 entries/block (multiple blocks per height). Despite
+`dag_finalized_blocks_total` tracking 92–95% of blocks as finalized, finalized blocks are not
+removed from the in-memory DAG. At ~147 blocks: 140 finalized, 147 still in `dag_blocks_total`.
+Per-block memory overhead is ~10–17 MB, far exceeding raw block size (~17 KB/block), indicating
+full deserialized block data and associated state snapshots are retained per block.
+
+**2. Block-retriever fetches nearly every block (~94% at 147 blocks).**
+
+`casper_requested_blocks_count` reached 138 out of 147 total blocks. The block-retriever operates
+as the primary block delivery mechanism rather than an exception path. Each fetched block is held
+in memory through the full download + validation pipeline, increasing peak RSS.
+
+### Known metric issues
+
+**`process_memory_peak_bytes` is jemalloc virtual address space, not physical RAM.**
+Values of ~15.1 TB are normal jemalloc behavior (arena reservation on 64-bit Linux). Use
+`process_memory_rss_bytes` for actual physical memory consumption.
+
+**`block_validation_step_*_time` histograms have a unit mismatch.**
+All observations fall in the `+Inf` bucket (>10 seconds) despite total block validation averaging
+~0.228 seconds. The step-level metrics appear to be recorded in nanoseconds or microseconds while
+the histogram bucket boundaries are defined in seconds. Count and sum are still useful (divide sum
+by count for average), but percentile analysis is broken. This is a Phase 2 fix candidate.
+
+### Phase 2 priorities from this analysis
+
+1. **DAG pruning**: Prune finalized blocks from the in-memory DAG structure. Only the tip set and
+   a configurable finalization buffer need to remain in memory.
+2. **Block gossip improvement**: `casper_requested_blocks_count` at 94% indicates validators are
+   not receiving blocks proactively. Investigate why gossip propagation is not reaching peers before
+   the block-retriever timeout triggers.
+3. **Fix `block_validation_step_*_time` unit mismatch**: Align recorded values and histogram bucket
+   boundaries to the same unit (seconds) so percentiles are meaningful.
+
 ## Monitoring Health
 
 Use the dashboard to monitor:
 
-1. **Block Processing Performance**: Watch for replay time spikes indicating cold cache or other issues
-2. **Network Health**: Check block request/retry rates for sync problems
-3. **Validation Success**: Monitor success rate for consensus issues
-4. **System Load**: Track block processing rates and queue depths
+1. **Memory trend**: Watch `process_memory_rss_bytes` rate of increase — should slow as DAG pruning
+   is implemented. Currently grows ~10–17 MB/block without bound.
+2. **DAG state**: `dag_blocks_total - dag_finalized_blocks_total` should stay small (ideally bounded
+   by a pruning window). `dag_height_map_entries` should plateau after pruning is implemented.
+3. **Block gossip health**: `casper_requested_blocks_count / dag_blocks_total` ratio should approach
+   0 as gossip improves. Currently ~94%.
+4. **Block Processing Performance**: Watch for replay time spikes indicating cold cache or other issues.
+5. **Validation Success**: Monitor success rate for consensus issues.
 
 Alert thresholds can be configured in Prometheus based on the recording rules.
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -56,6 +56,7 @@ utoipa-swagger-ui = { version = "9", features = ["axum"] }
 # Metrics dependencies (analog of Scala's Kamon + NewPrometheusReporter)
 metrics = { workspace = true }
 tikv-jemallocator = { workspace = true }
+tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }
 metrics-exporter-prometheus = "0.15"
 metrics-exporter-influx = "0.2.2"
 opentelemetry = { version = "0.20", features = ["rt-tokio"] }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -54,7 +54,8 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 utoipa = { version = "5", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "9", features = ["axum"] }
 # Metrics dependencies (analog of Scala's Kamon + NewPrometheusReporter)
-metrics = "0.23"
+metrics = { workspace = true }
+tikv-jemallocator = { workspace = true }
 metrics-exporter-prometheus = "0.15"
 metrics-exporter-influx = "0.2.2"
 opentelemetry = { version = "0.20", features = ["rt-tokio"] }

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -76,7 +76,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
         aarch64*) export RUSTFLAGS="-C target-feature=+aes" ;; \
         *) export RUSTFLAGS="-C target-feature=+aes,+sse2" ;; \
     esac && \
-    export ac_cv_func_strerror_r_char_p=no && \
+    export je_cv_strerror_r_returns_char_with_gnu_source=yes && \
     xx-cargo build --release -p node --target-dir ./build && \
     xx-verify ./build/${TARGET_TRIPLE}/release/node && \
     cp ./build/${TARGET_TRIPLE}/release/node /build/node_binary && \

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -76,6 +76,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
         aarch64*) export RUSTFLAGS="-C target-feature=+aes" ;; \
         *) export RUSTFLAGS="-C target-feature=+aes,+sse2" ;; \
     esac && \
+    export ac_cv_func_strerror_r_char_p=no && \
     xx-cargo build --release -p node --target-dir ./build && \
     xx-verify ./build/${TARGET_TRIPLE}/release/node && \
     cp ./build/${TARGET_TRIPLE}/release/node /build/node_binary && \

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,3 +1,10 @@
+// Use jemalloc as the global allocator for better memory return behaviour and
+// heap-profiling support (activate via MALLOC_CONF=prof:true,prof_prefix:/tmp/jeprof).
+// Not applied to test builds to avoid conflicts with the default test allocator.
+#[cfg(not(test))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use casper::rust::util::comm::deploy_runtime::DeployRuntime;
 use casper::rust::util::comm::grpc_deploy_service::GrpcDeployService;
 use casper::rust::util::comm::grpc_propose_service::GrpcProposeService;

--- a/node/src/rust/diagnostics/jemalloc_reporter.rs
+++ b/node/src/rust/diagnostics/jemalloc_reporter.rs
@@ -14,44 +14,46 @@
 /// `retained` growing per-block indicates jemalloc is not purging freed arenas.
 use std::time::Duration;
 
-use crate::rust::diagnostics::SYSTEM_METRICS_SOURCE;
-
 /// Start the jemalloc stats background thread.
 ///
 /// Only active in non-test builds because jemalloc itself is only used as
 /// the global allocator outside of tests (`#[cfg(not(test))]` in main.rs).
-pub fn start_jemalloc_reporter(interval: Duration) {
+pub fn start_jemalloc_reporter(_interval: Duration) {
     #[cfg(not(test))]
-    std::thread::spawn(move || {
-        use tikv_jemalloc_ctl::{epoch, stats};
+    {
+        use crate::rust::diagnostics::SYSTEM_METRICS_SOURCE;
 
-        // Pre-build epoch MIB handle once; reuse each iteration.
-        let epoch_mib = match epoch::mib() {
-            Ok(m) => m,
-            Err(_) => return,
-        };
+        std::thread::spawn(move || {
+            use tikv_jemalloc_ctl::{epoch, stats};
 
-        loop {
-            // Advance epoch so jemalloc refreshes its cached stat values.
-            let _ = epoch_mib.advance();
+            // Pre-build epoch MIB handle once; reuse each iteration.
+            let epoch_mib = match epoch::mib() {
+                Ok(m) => m,
+                Err(_) => return,
+            };
 
-            macro_rules! emit_stat {
-                ($read:expr, $name:literal) => {
-                    if let Ok(v) = $read {
-                        let bytes: usize = v;
-                        metrics::gauge!($name, "source" => SYSTEM_METRICS_SOURCE)
-                            .set(bytes as f64);
-                    }
-                };
+            loop {
+                // Advance epoch so jemalloc refreshes its cached stat values.
+                let _ = epoch_mib.advance();
+
+                macro_rules! emit_stat {
+                    ($read:expr, $name:literal) => {
+                        if let Ok(v) = $read {
+                            let bytes: usize = v;
+                            metrics::gauge!($name, "source" => SYSTEM_METRICS_SOURCE)
+                                .set(bytes as f64);
+                        }
+                    };
+                }
+
+                emit_stat!(stats::allocated::read(), "jemalloc_allocated_bytes");
+                emit_stat!(stats::active::read(),    "jemalloc_active_bytes");
+                emit_stat!(stats::mapped::read(),    "jemalloc_mapped_bytes");
+                emit_stat!(stats::resident::read(),  "jemalloc_resident_bytes");
+                emit_stat!(stats::retained::read(),  "jemalloc_retained_bytes");
+
+                std::thread::sleep(_interval);
             }
-
-            emit_stat!(stats::allocated::read(), "jemalloc_allocated_bytes");
-            emit_stat!(stats::active::read(),    "jemalloc_active_bytes");
-            emit_stat!(stats::mapped::read(),    "jemalloc_mapped_bytes");
-            emit_stat!(stats::resident::read(),  "jemalloc_resident_bytes");
-            emit_stat!(stats::retained::read(),  "jemalloc_retained_bytes");
-
-            std::thread::sleep(interval);
-        }
-    });
+        });
+    }
 }

--- a/node/src/rust/diagnostics/jemalloc_reporter.rs
+++ b/node/src/rust/diagnostics/jemalloc_reporter.rs
@@ -1,0 +1,57 @@
+/// jemalloc heap stats reporter.
+///
+/// Advances the jemalloc epoch (forces stat refresh) then reads five
+/// allocator-internal counters and emits them as Prometheus gauges.
+///
+/// Metrics emitted (source = "f1r3fly.system"):
+///   jemalloc_allocated_bytes  – bytes in live allocations
+///   jemalloc_active_bytes     – bytes in active pages (allocated + overhead)
+///   jemalloc_mapped_bytes     – bytes in mapped chunks
+///   jemalloc_resident_bytes   – bytes in resident pages (≈ RSS contribution)
+///   jemalloc_retained_bytes   – bytes freed but not returned to the OS
+///
+/// `resident - allocated` reveals fragmentation + retained overhead.
+/// `retained` growing per-block indicates jemalloc is not purging freed arenas.
+use std::time::Duration;
+
+use crate::rust::diagnostics::SYSTEM_METRICS_SOURCE;
+
+/// Start the jemalloc stats background thread.
+///
+/// Only active in non-test builds because jemalloc itself is only used as
+/// the global allocator outside of tests (`#[cfg(not(test))]` in main.rs).
+pub fn start_jemalloc_reporter(interval: Duration) {
+    #[cfg(not(test))]
+    std::thread::spawn(move || {
+        use tikv_jemalloc_ctl::{epoch, stats};
+
+        // Pre-build epoch MIB handle once; reuse each iteration.
+        let epoch_mib = match epoch::mib() {
+            Ok(m) => m,
+            Err(_) => return,
+        };
+
+        loop {
+            // Advance epoch so jemalloc refreshes its cached stat values.
+            let _ = epoch_mib.advance();
+
+            macro_rules! emit_stat {
+                ($read:expr, $name:literal) => {
+                    if let Ok(v) = $read {
+                        let bytes: usize = v;
+                        metrics::gauge!($name, "source" => SYSTEM_METRICS_SOURCE)
+                            .set(bytes as f64);
+                    }
+                };
+            }
+
+            emit_stat!(stats::allocated::read(), "jemalloc_allocated_bytes");
+            emit_stat!(stats::active::read(),    "jemalloc_active_bytes");
+            emit_stat!(stats::mapped::read(),    "jemalloc_mapped_bytes");
+            emit_stat!(stats::resident::read(),  "jemalloc_resident_bytes");
+            emit_stat!(stats::retained::read(),  "jemalloc_retained_bytes");
+
+            std::thread::sleep(interval);
+        }
+    });
+}

--- a/node/src/rust/diagnostics/memory_reporter.rs
+++ b/node/src/rust/diagnostics/memory_reporter.rs
@@ -1,0 +1,90 @@
+/// Process-level memory reporter and structural size gauge runner.
+///
+/// Runs a background OS thread (like sigar_reporter) that:
+/// 1. On Linux: reads `/proc/self/status` every `interval` and emits
+///    `process_memory_rss_bytes` and `process_memory_peak_bytes` gauges.
+/// 2. Calls each closure in `extra_gauges` and records the returned count
+///    under the given metric name.  Callers use this to expose the live size
+///    of in-process collections (channels_map, requested_blocks, etc.).
+///
+/// Usage:
+/// ```
+/// memory_reporter::start_memory_reporter(
+///     Duration::from_secs(10),
+///     vec![
+///         ("transport_channels_count",
+///          Box::new(move || channels_arc.try_lock().map(|g| g.len()).unwrap_or(0))),
+///     ],
+/// );
+/// ```
+use std::time::Duration;
+#[cfg(target_os = "linux")]
+use tracing::warn;
+
+use crate::rust::diagnostics::SYSTEM_METRICS_SOURCE;
+
+/// Start the memory metrics background thread.
+///
+/// `extra_gauges`: list of `(metric_name, count_fn)` pairs.  Each `count_fn`
+/// must be `Send` (it will be moved into the spawned thread) and returns the
+/// current size of the collection it watches.  The gauge is recorded with the
+/// `source = SYSTEM_METRICS_SOURCE` label so it appears alongside CPU / memory
+/// system metrics in Prometheus.
+pub fn start_memory_reporter(
+    interval: Duration,
+    extra_gauges: Vec<(&'static str, Box<dyn Fn() -> usize + Send>)>,
+) {
+    std::thread::spawn(move || {
+        loop {
+            // ── Process-level memory (Linux only via /proc/self/status) ──────
+            #[cfg(target_os = "linux")]
+            report_process_memory();
+
+            // ── Structural collection sizes ───────────────────────────────────
+            for (name, size_fn) in &extra_gauges {
+                metrics::gauge!(*name, "source" => SYSTEM_METRICS_SOURCE)
+                    .set(size_fn() as f64);
+            }
+
+            std::thread::sleep(interval);
+        }
+    });
+}
+
+/// Parse `/proc/self/status` and emit RSS / peak-virtual gauges (bytes).
+#[cfg(target_os = "linux")]
+fn report_process_memory() {
+    match std::fs::read_to_string("/proc/self/status") {
+        Err(e) => warn!("memory_reporter: failed to read /proc/self/status: {}", e),
+        Ok(contents) => {
+            for line in contents.lines() {
+                let mut parts = line.split_whitespace();
+                match parts.next() {
+                    Some("VmRSS:") => {
+                        if let Some(kb_str) = parts.next() {
+                            if let Ok(kb) = kb_str.parse::<f64>() {
+                                metrics::gauge!(
+                                    "process_memory_rss_bytes",
+                                    "source" => SYSTEM_METRICS_SOURCE
+                                )
+                                .set(kb * 1024.0);
+                            }
+                        }
+                    }
+                    Some("VmPeak:") => {
+                        if let Some(kb_str) = parts.next() {
+                            if let Ok(kb) = kb_str.parse::<f64>() {
+                                metrics::gauge!(
+                                    "process_memory_peak_bytes",
+                                    "source" => SYSTEM_METRICS_SOURCE
+                                )
+                                .set(kb * 1024.0);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}

--- a/node/src/rust/diagnostics/mod.rs
+++ b/node/src/rust/diagnostics/mod.rs
@@ -1,4 +1,5 @@
 pub mod batch_influx_db_reporter;
+pub mod memory_reporter;
 pub mod new_prometheus_reporter;
 pub mod prometheus_config;
 pub mod sigar_reporter;

--- a/node/src/rust/diagnostics/mod.rs
+++ b/node/src/rust/diagnostics/mod.rs
@@ -1,4 +1,5 @@
 pub mod batch_influx_db_reporter;
+pub mod jemalloc_reporter;
 pub mod memory_reporter;
 pub mod new_prometheus_reporter;
 pub mod prometheus_config;
@@ -89,6 +90,11 @@ pub fn initialize_diagnostics(conf: &NodeConf, kamon_conf: &KamonConf) -> Result
     if conf.metrics.sigar {
         sigar_reporter::start_sigar_reporter(metrics_interval);
         info!("Sigar (system metrics) reporter started with interval {:?}.", metrics_interval);
+    }
+
+    if conf.metrics.prometheus {
+        jemalloc_reporter::start_jemalloc_reporter(metrics_interval);
+        info!("jemalloc stats reporter started with interval {:?}.", metrics_interval);
     }
 
     Ok(prometheus_reporter)

--- a/node/src/rust/runtime/node_runtime.rs
+++ b/node/src/rust/runtime/node_runtime.rs
@@ -280,16 +280,35 @@ impl NodeRuntime {
 
         info!("setup_node_program completed successfully");
 
-        // Start memory metrics reporter: process RSS + live sizes of the two
-        // key unbounded collections (transport channel cache and block request
-        // tracker).  The reporter runs on a dedicated OS thread to avoid
-        // blocking the async runtime.
+        // Start memory metrics reporter: process RSS + live sizes of key
+        // collections and LMDB environments.  The reporter runs on a dedicated
+        // OS thread to avoid blocking the async runtime.
         {
             use crate::rust::diagnostics::memory_reporter::start_memory_reporter;
+            use std::path::PathBuf;
             use std::time::Duration;
 
             let ch = channels_map_for_metrics;
             let rb = requested_blocks_for_metrics;
+
+            // Capture data_dir for LMDB file-size closures.
+            let data_dir = self.node_conf.storage.data_dir.clone();
+
+            // Helper: return size of `data.mdb` under `data_dir/<subdir>/`, 0 on error.
+            fn lmdb_size(base: &PathBuf, subdir: &str) -> usize {
+                base.join(subdir)
+                    .join("data.mdb")
+                    .metadata()
+                    .map(|m| m.len() as usize)
+                    .unwrap_or(0)
+            }
+
+            let dd_rspace_history = data_dir.clone();
+            let dd_rspace_cold    = data_dir.clone();
+            let dd_blockstorage   = data_dir.clone();
+            let dd_dagstorage     = data_dir.clone();
+            let dd_eval_history   = data_dir.clone();
+
             start_memory_reporter(
                 Duration::from_secs(10),
                 vec![
@@ -301,6 +320,31 @@ impl NodeRuntime {
                     (
                         "casper_requested_blocks_count",
                         Box::new(move || rb.try_lock().ok().map(|g| g.len()).unwrap_or(0))
+                            as Box<dyn Fn() -> usize + Send>,
+                    ),
+                    (
+                        "lmdb_rspace_history_size_bytes",
+                        Box::new(move || lmdb_size(&dd_rspace_history, "rspace/history"))
+                            as Box<dyn Fn() -> usize + Send>,
+                    ),
+                    (
+                        "lmdb_rspace_cold_size_bytes",
+                        Box::new(move || lmdb_size(&dd_rspace_cold, "rspace/cold"))
+                            as Box<dyn Fn() -> usize + Send>,
+                    ),
+                    (
+                        "lmdb_blockstorage_size_bytes",
+                        Box::new(move || lmdb_size(&dd_blockstorage, "blockstorage"))
+                            as Box<dyn Fn() -> usize + Send>,
+                    ),
+                    (
+                        "lmdb_dagstorage_size_bytes",
+                        Box::new(move || lmdb_size(&dd_dagstorage, "dagstorage"))
+                            as Box<dyn Fn() -> usize + Send>,
+                    ),
+                    (
+                        "lmdb_eval_history_size_bytes",
+                        Box::new(move || lmdb_size(&dd_eval_history, "eval/history"))
                             as Box<dyn Fn() -> usize + Send>,
                     ),
                 ],

--- a/node/src/rust/runtime/node_runtime.rs
+++ b/node/src/rust/runtime/node_runtime.rs
@@ -85,12 +85,15 @@ impl NodeRuntime {
         let _metrics = (); // Placeholder
         let _time = (); // Placeholder
 
-        // Create transport client
-        let transport = {
+        // Create transport client.
+        // channels_map_for_metrics is returned alongside the transport so the
+        // memory reporter can poll the live peer-connection count.
+        let (transport, channels_map_for_metrics) = {
             use comm::rust::transport::grpc_transport_client::GrpcTransportClient;
             use std::collections::HashMap;
 
             let channels_map = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+            let channels_map_for_metrics = channels_map.clone();
 
             // Read certificate and key file contents
             let cert = tokio::fs::read_to_string(&self.node_conf.tls.certificate_path)
@@ -102,7 +105,7 @@ impl NodeRuntime {
 
             const CLIENT_QUEUE_SIZE: i32 = 100;
 
-            GrpcTransportClient::new(
+            let client = GrpcTransportClient::new(
                 self.node_conf.protocol_client.network_id.clone(),
                 cert,
                 key,
@@ -112,7 +115,9 @@ impl NodeRuntime {
                 channels_map,
                 self.node_conf.protocol_client.network_timeout,
             )
-            .map_err(|e| eyre::eyre!("Failed to create transport client: {}", e))?
+            .map_err(|e| eyre::eyre!("Failed to create transport client: {}", e))?;
+
+            (client, channels_map_for_metrics)
         };
 
         info!("Transport client created successfully");
@@ -150,6 +155,8 @@ impl NodeRuntime {
             models::rust::block_hash::BlockHash,
             casper::rust::engine::block_retriever::RequestState,
         >::new()));
+        // Keep a reference for the memory reporter (BlockRetriever gets its own clone below).
+        let requested_blocks_for_metrics = requested_blocks.clone();
 
         info!("RP connections and configuration initialized");
 
@@ -272,6 +279,34 @@ impl NodeRuntime {
         ) = result;
 
         info!("setup_node_program completed successfully");
+
+        // Start memory metrics reporter: process RSS + live sizes of the two
+        // key unbounded collections (transport channel cache and block request
+        // tracker).  The reporter runs on a dedicated OS thread to avoid
+        // blocking the async runtime.
+        {
+            use crate::rust::diagnostics::memory_reporter::start_memory_reporter;
+            use std::time::Duration;
+
+            let ch = channels_map_for_metrics;
+            let rb = requested_blocks_for_metrics;
+            start_memory_reporter(
+                Duration::from_secs(10),
+                vec![
+                    (
+                        "transport_channels_count",
+                        Box::new(move || ch.try_lock().ok().map(|g| g.len()).unwrap_or(0))
+                            as Box<dyn Fn() -> usize + Send>,
+                    ),
+                    (
+                        "casper_requested_blocks_count",
+                        Box::new(move || rb.try_lock().ok().map(|g| g.len()).unwrap_or(0))
+                            as Box<dyn Fn() -> usize + Send>,
+                    ),
+                ],
+            );
+            info!("Memory metrics reporter started");
+        }
 
         // Launch Casper
         info!("Launching Casper...");

--- a/rspace++/Cargo.toml
+++ b/rspace++/Cargo.toml
@@ -43,7 +43,7 @@ counter = "0.5.7"
 multiset = "0.0.5"
 rholang-parser = { git = "https://github.com/F1R3FLY-io/rholang-rs", package = "rholang-parser", branch = "f1r3node_dependecies" }
 validated = "1.0.0"
-metrics = "0.23"
+metrics = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dependencies.uuid]

--- a/rspace++/src/rspace/hot_store.rs
+++ b/rspace++/src/rspace/hot_store.rs
@@ -212,6 +212,8 @@ where
         state
             .continuations
             .insert(channels.to_vec(), new_continuations);
+        metrics::gauge!("rspace_hot_store_continuations", "source" => "f1r3fly.rspace")
+            .set(state.continuations.len() as f64);
         Some(())
     }
 
@@ -323,6 +325,8 @@ where
                 state.data.insert(channel.clone(), new_data);
             }
         }
+        metrics::gauge!("rspace_hot_store_data_channels", "source" => "f1r3fly.rspace")
+            .set(state.data.len() as f64);
     }
 
     fn remove_datum(&self, channel: &C, index: i32) -> Option<()> {
@@ -407,6 +411,8 @@ where
             new_joins.push(join.to_vec());
             new_joins.extend(current_joins);
             state.joins.insert(channel.clone(), new_joins);
+            metrics::gauge!("rspace_hot_store_joins", "source" => "f1r3fly.rspace")
+                .set(state.joins.len() as f64);
             Some(())
         }
     }
@@ -646,6 +652,10 @@ where
         state.data = DashMap::new();
         state.joins = DashMap::new();
         state.installed_joins = DashMap::new();
+        // Reset gauges to 0 so dashboards reflect the cleared state immediately.
+        metrics::gauge!("rspace_hot_store_continuations", "source" => "f1r3fly.rspace").set(0.0);
+        metrics::gauge!("rspace_hot_store_data_channels", "source" => "f1r3fly.rspace").set(0.0);
+        metrics::gauge!("rspace_hot_store_joins", "source" => "f1r3fly.rspace").set(0.0);
     }
 
     // See rspace/src/test/scala/coop/rchain/rspace/test/package.scala
@@ -670,41 +680,55 @@ where
         let cache = self.history_store_cache.lock().unwrap();
         let channels_vec = channels.to_vec();
         let entry = cache.continuations.entry(channels_vec.clone());
-        match entry {
-            Entry::Occupied(o) => o.get().clone(),
+        let (result, is_new) = match entry {
+            Entry::Occupied(o) => (o.get().clone(), false),
             Entry::Vacant(v) => {
                 let ks = self.history_reader_base.get_continuations(&channels_vec);
                 v.insert(ks.clone());
-                ks
+                (ks, true)
             }
+        };
+        if is_new {
+            metrics::gauge!("rspace_history_cache_continuations", "source" => "f1r3fly.rspace")
+                .set(cache.continuations.len() as f64);
         }
+        result
     }
 
     fn get_data_from_history_store(&self, channel: &C) -> Vec<Datum<A>> {
         let cache = self.history_store_cache.lock().unwrap();
         let entry = cache.datums.entry(channel.clone());
-        match entry {
-            Entry::Occupied(o) => o.get().clone(),
+        let (result, is_new) = match entry {
+            Entry::Occupied(o) => (o.get().clone(), false),
             Entry::Vacant(v) => {
                 let datums = self.history_reader_base.get_data(channel);
-                // println!("\ndatums from history store: {:?}", datums);
                 v.insert(datums.clone());
-                datums
+                (datums, true)
             }
+        };
+        if is_new {
+            metrics::gauge!("rspace_history_cache_datums", "source" => "f1r3fly.rspace")
+                .set(cache.datums.len() as f64);
         }
+        result
     }
 
     fn get_joins_from_history_store(&self, channel: &C) -> Vec<Vec<C>> {
         let cache = self.history_store_cache.lock().unwrap();
         let entry = cache.joins.entry(channel.clone());
-        match entry {
-            Entry::Occupied(o) => o.get().clone(),
+        let (result, is_new) = match entry {
+            Entry::Occupied(o) => (o.get().clone(), false),
             Entry::Vacant(v) => {
                 let joins = self.history_reader_base.get_joins(&channel);
                 v.insert(joins.clone());
-                joins
+                (joins, true)
             }
+        };
+        if is_new {
+            metrics::gauge!("rspace_history_cache_joins", "source" => "f1r3fly.rspace")
+                .set(cache.joins.len() as f64);
         }
+        result
     }
 }
 


### PR DESCRIPTION
## Summary

- Installs **tikv-jemallocator 0.6** as the global allocator (with `profiling` + `background_threads` features) to enable jemalloc memory profiling and background thread management
- Wires a **`MemoryReporter`** background task (10s interval) that emits RSS and peak virtual memory gauges on Linux via `/proc/self/status`
- Adds **16 Prometheus gauges** covering all major unbounded in-memory structures across the node, rspace++, block-storage, and comm crates

## Metrics added

| Metric | Crate | What it tracks |
|--------|-------|----------------|
| `process_memory_rss_bytes` | node | Linux RSS |
| `process_memory_peak_bytes` | node | Linux peak virtual |
| `transport_channels_count` | node | gRPC peer channels map |
| `casper_requested_blocks_count` | node | In-flight block requests |
| `rspace_hot_store_data_channels` | rspace++ | HotStore data map |
| `rspace_hot_store_continuations` | rspace++ | HotStore continuations |
| `rspace_hot_store_joins` | rspace++ | HotStore joins |
| `rspace_history_cache_continuations` | rspace++ | History read-through cache (never cleared) |
| `rspace_history_cache_datums` | rspace++ | History read-through cache (never cleared) |
| `rspace_history_cache_joins` | rspace++ | History read-through cache (never cleared) |
| `dag_blocks_total` | block-storage | DAG total blocks |
| `dag_finalized_blocks_total` | block-storage | DAG finalized blocks |
| `dag_height_map_entries` | block-storage | DAG height index |
| `casper_buffer_pending_blocks` | block-storage | Blocks awaiting parent resolution |
| `casper_buffer_dependency_free_blocks` | block-storage | Buffer-ready blocks |
| `comm_stream_cache_size` | comm | Blob streaming cache |

## Test plan

- [ ] `cargo check` passes on the branch
- [ ] Node starts and `/metrics` endpoint (or Prometheus scrape) shows all 16 gauge families
- [ ] Under load, `rspace_history_cache_*` gauges grow monotonically (confirming the unbounded leak is now visible)
- [ ] `process_memory_rss_bytes` tracks actual RSS on a Linux deployment