### PR TITLE
fixed division by zero crashes

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -581,14 +581,16 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
           for {
             v1 <- evalToLong(p1)
             v2 <- evalToLong(p2)
-            _  <- charge[M](DIVISION_COST)
+            _ <- if (v2 == 0L) ReduceError("Division by zero").raiseError[M, Unit]
+                else charge[M](DIVISION_COST)
           } yield GInt(v1 / v2)
 
         case EModBody(EMod(p1, p2)) =>
           for {
             v1 <- evalToLong(p1)
             v2 <- evalToLong(p2)
-            _  <- charge[M](MODULO_COST)
+            _ <- if (v2 == 0L) ReduceError("Modulo by zero").raiseError[M, Unit]
+                else charge[M](MODULO_COST)
           } yield GInt(v1 % v2)
 
         case EPlusBody(EPlus(p1, p2)) =>

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -117,6 +117,54 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
     result.exprs should be(expected)
   }
 
+  "evalExpr" should "handle simple division" in {
+    val result = withTestSpace {
+      case TestFixture(_, reducer) =>
+        val divExpr      = EDiv(GInt(15L), GInt(3L))
+        implicit val env = Env[Par]()
+        val resultTask   = reducer.evalExpr(divExpr)
+        Await.result(resultTask.runToFuture, 3.seconds)
+    }
+
+    val expected = Seq(Expr(GInt(5L)))
+    result.exprs should be(expected)
+  }
+
+  it should "return an error for division by zero" in {
+    val result = withTestSpace {
+      case TestFixture(_, reducer) =>
+        val divExpr      = EDiv(GInt(1L), GInt(0L))
+        implicit val env = Env[Par]()
+        val resultTask   = reducer.evalExpr(divExpr)
+        Await.ready(resultTask.runToFuture, 3.seconds)
+    }
+    result.value shouldBe Failure(ReduceError("Division by zero")).some
+  }
+
+  it should "handle simple modulo" in {
+    val result = withTestSpace {
+      case TestFixture(_, reducer) =>
+        val modExpr      = EMod(GInt(17L), GInt(5L))
+        implicit val env = Env[Par]()
+        val resultTask   = reducer.evalExpr(modExpr)
+        Await.result(resultTask.runToFuture, 3.seconds)
+    }
+
+    val expected = Seq(Expr(GInt(2L)))
+    result.exprs should be(expected)
+  }
+
+  it should "return an error for modulo by zero" in {
+    val result = withTestSpace {
+      case TestFixture(_, reducer) =>
+        val modExpr      = EMod(GInt(1L), GInt(0L))
+        implicit val env = Env[Par]()
+        val resultTask   = reducer.evalExpr(modExpr)
+        Await.ready(resultTask.runToFuture, 3.seconds)
+    }
+    result.value shouldBe Failure(ReduceError("Modulo by zero")).some
+  }
+
   "evalExpr" should "leave ground values alone" in {
     val result = withTestSpace {
       case TestFixture(_, reducer) =>


### PR DESCRIPTION
## Overview
This PR is a fix for https://github.com/F1R3FLY-io/f1r3node/issues/61

### Notes
Before (without fix):
 • Deploy new f in {f!(1 / 0)}
 • validator1 crashes with ArithmeticException: / by zero
 • Logs show: Caught unhandable error. Exiting.
 • Docker container restarts (restart: always)
 
After (with fix):
 • Deploy new f in {f!(1 / 0)}
 • Logs show ReduceError: Division by zero as part of the evaluation result
 • Deploy fails gracefully (block is not finalized with this code)
 • Validator1 continues running, no crash, no container restart
 
**The node now treats division by zero as a Rholang code evaluation error, not as a fatal node error.**

I've tested it with a light Scala shard, and got the following results:
Example: 
```
2026-02-24 17:28:56 2026-02-24 16:28:56,112 [node-runner-34] INFO  coop.rchain.casper.util.rholang.InterpreterUtil$ - Deploy (304402207be968e83363...ab61596078855c3e5401) errors: coop.rchain.rholang.interpreter.errors$ReduceError: Division by zero
```
And then the shard proceeded to work without any fatal errors and restarts.