### PR TITLE
Fix genesis mount for shard-with-autopropose

### DIFF
--- a/docker/shard-with-autopropose.yml
+++ b/docker/shard-with-autopropose.yml
@@ -10,15 +10,17 @@ x-rnode: &default-rnode
 services:
   boot:
     <<: *default-rnode
-    container_name: $BOOTSTRAP_HOST
+    container_name: ${BOOTSTRAP_HOST}
     restart: always
+    healthcheck:
+      disable: true
     command:
       [
         "run",
-        "--host=$BOOTSTRAP_HOST",
-        "--bootstrap=rnode://$BOOTSTRAP_NODE_ID@$BOOTSTRAP_HOST?protocol=40400&discovery=40404", # node will know it's bootstrap node
+        "--host=${BOOTSTRAP_HOST}",
+        "--bootstrap=rnode://${BOOTSTRAP_NODE_ID}@${BOOTSTRAP_HOST}?protocol=40400&discovery=40404",
         "--allow-private-addresses",
-        "--validator-private-key=$BOOTSTRAP_PRIVATE_KEY"
+        "--validator-private-key=${BOOTSTRAP_PRIVATE_KEY}"
       ]
     ports:
       - "40400:40400"
@@ -28,28 +30,23 @@ services:
       - "40404:40404"
       - "40405:40405"
     volumes:
-      # Bootstrap-specific configuration (ceremony master)
-      - ./conf/bootstrap-ceremony.conf:/var/lib/rnode/rnode.conf
-      - ./genesis/wallets.txt:/var/lib/rnode/genesis/wallets.txt
-      - ./genesis/bonds.txt:/var/lib/rnode/genesis/bonds.txt
-      - ./conf/logback.xml:/var/lib/rnode/logback.xml
-      # Node-specific volumes
-      - ./data/$BOOTSTRAP_HOST:/var/lib/rnode/
-      - ./certs/bootstrap/node.certificate.pem:/var/lib/rnode/node.certificate.pem:ro
-      - ./certs/bootstrap/node.key.pem:/var/lib/rnode/node.key.pem:ro
+      - ./data/${BOOTSTRAP_HOST}:/var/lib/rnode
+      - ./genesis:/var/lib/rnode/genesis:ro
 
   validator1:
     <<: *default-rnode
-    container_name: $VALIDATOR1_HOST
+    container_name: ${VALIDATOR1_HOST}
     restart: always
+    healthcheck:
+      disable: true
     command:
       [
         "run",
-        "--host=$VALIDATOR1_HOST",
+        "--host=${VALIDATOR1_HOST}",
         "--allow-private-addresses",
-        "--bootstrap=rnode://$BOOTSTRAP_NODE_ID@$BOOTSTRAP_HOST?protocol=40400&discovery=40404",
-        "--validator-public-key=$VALIDATOR1_PUBLIC_KEY",
-        "--validator-private-key=$VALIDATOR1_PRIVATE_KEY",
+        "--bootstrap=rnode://${BOOTSTRAP_NODE_ID}@${BOOTSTRAP_HOST}?protocol=40400&discovery=40404",
+        "--validator-public-key=${VALIDATOR1_PUBLIC_KEY}",
+        "--validator-private-key=${VALIDATOR1_PRIVATE_KEY}",
         "--genesis-validator"
       ]
     ports:
@@ -60,26 +57,23 @@ services:
       - "40414:40404"
       - "40415:40405"
     volumes:
-      - ./conf/shared-rnode.conf:/var/lib/rnode/rnode.conf
-      - ./genesis/wallets.txt:/var/lib/rnode/genesis/wallets.txt
-      - ./genesis/bonds.txt:/var/lib/rnode/genesis/bonds.txt
-      - ./conf/logback.xml:/var/lib/rnode/logback.xml
-      - ./data/$VALIDATOR1_HOST:/var/lib/rnode/
-      - ./certs/validator1/node.certificate.pem:/var/lib/rnode/node.certificate.pem:ro
-      - ./certs/validator1/node.key.pem:/var/lib/rnode/node.key.pem:ro
+      - ./data/${VALIDATOR1_HOST}:/var/lib/rnode
+      - ./genesis:/var/lib/rnode/genesis:ro
 
   validator2:
     <<: *default-rnode
-    container_name: $VALIDATOR2_HOST
+    container_name: ${VALIDATOR2_HOST}
     restart: always
+    healthcheck:
+      disable: true
     command:
       [
         "run",
-        "--host=$VALIDATOR2_HOST",
+        "--host=${VALIDATOR2_HOST}",
         "--allow-private-addresses",
-        "--bootstrap=rnode://$BOOTSTRAP_NODE_ID@$BOOTSTRAP_HOST?protocol=40400&discovery=40404",
-        "--validator-public-key=$VALIDATOR2_PUBLIC_KEY",
-        "--validator-private-key=$VALIDATOR2_PRIVATE_KEY",
+        "--bootstrap=rnode://${BOOTSTRAP_NODE_ID}@${BOOTSTRAP_HOST}?protocol=40400&discovery=40404",
+        "--validator-public-key=${VALIDATOR2_PUBLIC_KEY}",
+        "--validator-private-key=${VALIDATOR2_PRIVATE_KEY}",
         "--genesis-validator"
       ]
     ports:
@@ -90,26 +84,23 @@ services:
       - "40424:40404"
       - "40425:40405"
     volumes:
-      - ./conf/shared-rnode.conf:/var/lib/rnode/rnode.conf
-      - ./genesis/wallets.txt:/var/lib/rnode/genesis/wallets.txt
-      - ./genesis/bonds.txt:/var/lib/rnode/genesis/bonds.txt
-      - ./conf/logback.xml:/var/lib/rnode/logback.xml
-      - ./data/$VALIDATOR2_HOST:/var/lib/rnode/
-      - ./certs/validator2/node.certificate.pem:/var/lib/rnode/node.certificate.pem:ro
-      - ./certs/validator2/node.key.pem:/var/lib/rnode/node.key.pem:ro
+      - ./data/${VALIDATOR2_HOST}:/var/lib/rnode
+      - ./genesis:/var/lib/rnode/genesis:ro
 
   validator3:
     <<: *default-rnode
-    container_name: $VALIDATOR3_HOST
+    container_name: ${VALIDATOR3_HOST}
     restart: always
+    healthcheck:
+      disable: true
     command:
       [
         "run",
-        "--host=$VALIDATOR3_HOST",
+        "--host=${VALIDATOR3_HOST}",
         "--allow-private-addresses",
-        "--bootstrap=rnode://$BOOTSTRAP_NODE_ID@$BOOTSTRAP_HOST?protocol=40400&discovery=40404",
-        "--validator-public-key=$VALIDATOR3_PUBLIC_KEY",
-        "--validator-private-key=$VALIDATOR3_PRIVATE_KEY",
+        "--bootstrap=rnode://${BOOTSTRAP_NODE_ID}@${BOOTSTRAP_HOST}?protocol=40400&discovery=40404",
+        "--validator-public-key=${VALIDATOR3_PUBLIC_KEY}",
+        "--validator-private-key=${VALIDATOR3_PRIVATE_KEY}",
         "--genesis-validator"
       ]
     ports:
@@ -120,38 +111,9 @@ services:
       - "40434:40404"
       - "40435:40405"
     volumes:
-      - ./conf/shared-rnode.conf:/var/lib/rnode/rnode.conf
-      - ./genesis/wallets.txt:/var/lib/rnode/genesis/wallets.txt
-      - ./genesis/bonds.txt:/var/lib/rnode/genesis/bonds.txt
-      - ./conf/logback.xml:/var/lib/rnode/logback.xml
-      - ./data/$VALIDATOR3_HOST:/var/lib/rnode/
-      - ./certs/validator3/node.certificate.pem:/var/lib/rnode/node.certificate.pem:ro
-      - ./certs/validator3/node.key.pem:/var/lib/rnode/node.key.pem:ro
-
-  readonly:
-    image: f1r3flyindustries/f1r3fly-rust-node:latest
-    user: root
-    networks:
-      - f1r3fly
-    container_name: $READONLY_HOST
-    restart: always
-    ports:
-      - "40451:40401"
-      - "40452:40402"
-      - "40453:40403"
-    command:
-    - run
-    - --host=$READONLY_HOST
-    - --bootstrap=rnode://1e780e5dfbe0a3d9470a2b414f502d59402e09c2@$BOOTSTRAP_HOST?protocol=40400&discovery=40404
-    - --no-upnp
-    - --allow-private-addresses
-
-    volumes:
-      - ./conf/observer.conf:/var/lib/rnode/rnode.conf
-      - ./conf/logback.xml:/var/lib/rnode/logback.xml
-      - ./genesis/bonds.txt:/var/lib/rnode/genesis/bonds.txt
-      - ./genesis/wallets.txt:/var/lib/rnode/genesis/wallets.txt
+      - ./data/${VALIDATOR3_HOST}:/var/lib/rnode
+      - ./genesis:/var/lib/rnode/genesis:ro
 
 networks:
   f1r3fly:
-    driver: bridge 
+    driver: bridge


### PR DESCRIPTION
## Overview

**What was broken:** `wallets.txt` was not mounted into containers.  
**Impact:** deploys fail with `Invalid signature`.  
**Fix:** mount `./genesis` into `/var/lib/rnode/genesis` for all nodes (bootstrap + validators).

## How to verify

```bash
cd docker
docker compose -f shard-with-autopropose.yml down -v --remove-orphans
docker compose -f shard-with-autopropose.yml up -d --force-recreate
docker exec rnode.bootstrap sh -lc 'ls -la /var/lib/rnode/genesis/wallets.txt'