### PR TITLE
feat: publish Docker images on dev branch push

### DIFF
--- a/.github/workflows/required-workflow.yml
+++ b/.github/workflows/required-workflow.yml
@@ -582,7 +582,8 @@ jobs:
       github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') ||
       github.ref == 'refs/heads/trying' ||
       github.ref == 'refs/heads/staging' ||
-      github.ref == 'refs/heads/main')
+      github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/dev')
     runs-on: ubuntu-22.04
     steps:
       - name: Load AMD64 Docker Image
@@ -629,20 +630,27 @@ jobs:
 
           SUFFIX=""
           CI_RUN=""
+          TAG_PREFIX=""
 
           if [[ "$BRANCH" =~ ^(trying|staging)$ ]]; then
             SUFFIX="-$BRANCH"
             if [[ $BRANCH =~ ^trying$ ]]; then
               CI_RUN="-ci-$GITHUB_RUN_NUMBER"
             fi
+          elif [[ "$BRANCH" == "dev" ]]; then
+            TAG_PREFIX="dev-"
           fi
 
           set -x
 
           IMAGE_NAME="$TARGET_DOCKER_IMAGE_NAME$SUFFIX"
-          IMG_VERSION_RAW="$IMAGE_NAME:$VERSION$CI_RUN"
+          IMG_VERSION_RAW="$IMAGE_NAME:${TAG_PREFIX}$VERSION$CI_RUN"
           IMG_VERSION="${IMG_VERSION_RAW//[+]/__}"
-          IMG_LATEST="$IMAGE_NAME:latest"
+          if [[ -n "$TAG_PREFIX" ]]; then
+            IMG_LATEST="$IMAGE_NAME:dev"
+          else
+            IMG_LATEST="$IMAGE_NAME:latest"
+          fi
 
           # Tag and push arch-specific images
           docker tag $SOURCE_DOCKER_IMAGE_NAME_AMD64 $IMG_VERSION-amd64


### PR DESCRIPTION
## Summary
- Add `dev` branch to the `release_docker_image` job gate so Docker images are published on dev pushes
- Dev images use `:dev` rolling tag and `:dev-<VERSION>` pinnable tag on the same Docker Hub repo
- Production `:latest` tag remains exclusive to `main` branch pushes

## Test plan
- [ ] Push to `dev` triggers `release_docker_image` job
- [ ] Dev push produces `f1r3flyindustries/f1r3fly-scala-node:dev` and `:dev-<VERSION>` tags on Docker Hub
- [ ] Push to `main` still produces `:latest` and `:<VERSION>` tags unchanged
- [ ] `trying`/`staging` behavior unchanged