### PR TITLE
feat: publish Docker images on rust/dev branch push

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -379,7 +379,8 @@ jobs:
       github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') ||
       github.ref == 'refs/heads/trying' ||
       github.ref == 'refs/heads/staging' ||
-      github.ref == 'refs/heads/rust/main')
+      github.ref == 'refs/heads/rust/main' ||
+      github.ref == 'refs/heads/rust/dev')
     runs-on: ubuntu-latest
     steps:
       - name: Load AMD64 Docker Image
@@ -421,6 +422,7 @@ jobs:
 
           SUFFIX=""
           CI_RUN=""
+          TAG_PREFIX=""
 
           # Add suffix if trying or merging
           if [[ "$BRANCH" =~ ^(trying|staging)$ ]]; then
@@ -430,15 +432,21 @@ jobs:
             if [[ $BRANCH =~ ^trying$ ]]; then
               CI_RUN="-ci-$GITHUB_RUN_NUMBER"
             fi
+          elif [[ "$BRANCH" == "rust/dev" ]]; then
+            TAG_PREFIX="dev-"
           fi
 
           set -x
 
           IMAGE_NAME="$DOCKER_IMAGE_NAME$SUFFIX"
-          IMG_VERSION_RAW="$IMAGE_NAME:$VERSION$CI_RUN"
+          IMG_VERSION_RAW="$IMAGE_NAME:${TAG_PREFIX}$VERSION$CI_RUN"
           # Replace unsupported character `+`
           IMG_VERSION="${IMG_VERSION_RAW//[+]/__}"
-          IMG_LATEST="$IMAGE_NAME:latest"
+          if [[ -n "$TAG_PREFIX" ]]; then
+            IMG_LATEST="$IMAGE_NAME:dev"
+          else
+            IMG_LATEST="$IMAGE_NAME:latest"
+          fi
 
           # Tag and push arch-specific images
           docker tag $SOURCE_AMD64 $IMG_VERSION-amd64


### PR DESCRIPTION
## Summary
- Add `rust/dev` branch to the `release_rust_docker_image` job gate so Docker images are published on rust/dev pushes
- Dev images use `:dev` rolling tag and `:dev-<VERSION>` pinnable tag on the same Docker Hub repo
- Production `:latest` tag remains exclusive to `rust/main` branch pushes

## Test plan
- [ ] Push to `rust/dev` triggers `release_rust_docker_image` job
- [ ] Dev push produces `f1r3flyindustries/f1r3fly-rust-node:dev` and `:dev-<VERSION>` tags on Docker Hub
- [ ] Push to `rust/main` still produces `:latest` and `:<VERSION>` tags unchanged
- [ ] `trying`/`staging` behavior unchanged