### PR TITLE
fix: backport integer overflow detection to Rust interpreter

### DIFF
--- a/rholang/src/rust/interpreter/reduce.rs
+++ b/rholang/src/rust/interpreter/reduce.rs
@@ -1202,8 +1202,11 @@ impl DebruijnInterpreter {
 
                 ExprInstance::ENegBody(eneg) => {
                     let v = self.eval_to_i64(&eneg.p.as_ref().unwrap(), env)?;
+                    let result = v.checked_neg().ok_or_else(|| {
+                        InterpreterError::ReduceError("Arithmetic overflow in negation".to_string())
+                    })?;
                     Ok(Expr {
-                        expr_instance: Some(ExprInstance::GInt(-v)),
+                        expr_instance: Some(ExprInstance::GInt(result)),
                     })
                 }
 
@@ -1211,8 +1214,13 @@ impl DebruijnInterpreter {
                     let v1 = self.eval_to_i64(&p1.clone().unwrap(), env)?;
                     let v2 = self.eval_to_i64(&p2.clone().unwrap(), env)?;
                     self.cost.charge(multiplication_cost())?;
+                    let result = v1.checked_mul(v2).ok_or_else(|| {
+                        InterpreterError::ReduceError(
+                            "Arithmetic overflow in multiplication".to_string(),
+                        )
+                    })?;
                     Ok(Expr {
-                        expr_instance: Some(ExprInstance::GInt(v1 * v2)),
+                        expr_instance: Some(ExprInstance::GInt(result)),
                     })
                 }
 
@@ -1221,6 +1229,11 @@ impl DebruijnInterpreter {
                     let v2 = self.eval_to_i64(&p2.clone().unwrap(), env)?;
                     if v2 == 0 {
                       return Err(InterpreterError::ReduceError("Division by zero".to_string()));
+                    }
+                    if v1 == i64::MIN && v2 == -1 {
+                      return Err(InterpreterError::ReduceError(
+                          "Arithmetic overflow in division".to_string(),
+                      ));
                     }
                     self.cost.charge(division_cost())?;
                     Ok(Expr {

--- a/rholang/tests/reduce_spec.rs
+++ b/rholang/tests/reduce_spec.rs
@@ -10,9 +10,9 @@ use crypto::rust::hash::blake2b512_random::Blake2b512Random;
 use models::{
     rhoapi::{
         connective::ConnectiveInstance::VarRefBody, expr::ExprInstance, g_unforgeable::UnfInstance,
-        Bundle, Connective, EDiv, EEq, EList, EMatches, EMethod, EMinus, EMinusMinus, EMod,
-        EPercentPercent, EPlus, EPlusPlus, ETuple, GPrivate, GUnforgeable, Match, MatchCase, New,
-        Receive, ReceiveBind, VarRef,
+        Bundle, Connective, EDiv, EEq, EList, EMatches, EMethod, EMinus, EMinusMinus, EMod, EMult,
+        ENeg, EPercentPercent, EPlus, EPlusPlus, ETuple, GPrivate, GUnforgeable, Match, MatchCase,
+        New, Receive, ReceiveBind, VarRef,
     },
     rust::{
         par_map::ParMap,
@@ -232,6 +232,124 @@ async fn eval_expr_should_return_error_for_modulo_by_zero() {
     assert_eq!(
         result.unwrap_err(),
         InterpreterError::ReduceError("Modulo by zero".to_string())
+    );
+}
+
+#[tokio::test]
+async fn eval_expr_should_handle_simple_multiplication() {
+    let (_, reducer) =
+        create_test_space::<RSpace<Par, BindPattern, ListParWithRandom, TaggedContinuation>>()
+            .await;
+    let mult_expr = Par::default().with_exprs(vec![Expr {
+        expr_instance: Some(ExprInstance::EMultBody(EMult {
+            p1: Some(new_gint_par(3, Vec::new(), false)),
+            p2: Some(new_gint_par(5, Vec::new(), false)),
+        })),
+    }]);
+    let env: Env<Par> = Env::new();
+    let result = reducer.eval_expr(&mult_expr, &env);
+    let expected = vec![new_gint_expr(15)];
+
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().exprs, expected);
+}
+
+#[tokio::test]
+async fn eval_expr_should_return_error_for_multiplication_overflow() {
+    let (_, reducer) =
+        create_test_space::<RSpace<Par, BindPattern, ListParWithRandom, TaggedContinuation>>()
+            .await;
+    let mult_expr = Par::default().with_exprs(vec![Expr {
+        expr_instance: Some(ExprInstance::EMultBody(EMult {
+            p1: Some(new_gint_par(i64::MAX, Vec::new(), false)),
+            p2: Some(new_gint_par(2, Vec::new(), false)),
+        })),
+    }]);
+    let env: Env<Par> = Env::new();
+    let result = reducer.eval_expr(&mult_expr, &env);
+
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err(),
+        InterpreterError::ReduceError("Arithmetic overflow in multiplication".to_string())
+    );
+}
+
+#[tokio::test]
+async fn eval_expr_should_handle_simple_subtraction() {
+    let (_, reducer) =
+        create_test_space::<RSpace<Par, BindPattern, ListParWithRandom, TaggedContinuation>>()
+            .await;
+    let sub_expr = Par::default().with_exprs(vec![Expr {
+        expr_instance: Some(ExprInstance::EMinusBody(EMinus {
+            p1: Some(new_gint_par(10, Vec::new(), false)),
+            p2: Some(new_gint_par(3, Vec::new(), false)),
+        })),
+    }]);
+    let env: Env<Par> = Env::new();
+    let result = reducer.eval_expr(&sub_expr, &env);
+    let expected = vec![new_gint_expr(7)];
+
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().exprs, expected);
+}
+
+#[tokio::test]
+async fn eval_expr_should_handle_simple_negation() {
+    let (_, reducer) =
+        create_test_space::<RSpace<Par, BindPattern, ListParWithRandom, TaggedContinuation>>()
+            .await;
+    let neg_expr = Par::default().with_exprs(vec![Expr {
+        expr_instance: Some(ExprInstance::ENegBody(ENeg {
+            p: Some(new_gint_par(5, Vec::new(), false)),
+        })),
+    }]);
+    let env: Env<Par> = Env::new();
+    let result = reducer.eval_expr(&neg_expr, &env);
+    let expected = vec![new_gint_expr(-5)];
+
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().exprs, expected);
+}
+
+#[tokio::test]
+async fn eval_expr_should_return_error_for_negation_overflow() {
+    let (_, reducer) =
+        create_test_space::<RSpace<Par, BindPattern, ListParWithRandom, TaggedContinuation>>()
+            .await;
+    let neg_expr = Par::default().with_exprs(vec![Expr {
+        expr_instance: Some(ExprInstance::ENegBody(ENeg {
+            p: Some(new_gint_par(i64::MIN, Vec::new(), false)),
+        })),
+    }]);
+    let env: Env<Par> = Env::new();
+    let result = reducer.eval_expr(&neg_expr, &env);
+
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err(),
+        InterpreterError::ReduceError("Arithmetic overflow in negation".to_string())
+    );
+}
+
+#[tokio::test]
+async fn eval_expr_should_return_error_for_division_overflow() {
+    let (_, reducer) =
+        create_test_space::<RSpace<Par, BindPattern, ListParWithRandom, TaggedContinuation>>()
+            .await;
+    let div_expr = Par::default().with_exprs(vec![Expr {
+        expr_instance: Some(ExprInstance::EDivBody(EDiv {
+            p1: Some(new_gint_par(i64::MIN, Vec::new(), false)),
+            p2: Some(new_gint_par(-1, Vec::new(), false)),
+        })),
+    }]);
+    let env: Env<Par> = Env::new();
+    let result = reducer.eval_expr(&div_expr, &env);
+
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err(),
+        InterpreterError::ReduceError("Arithmetic overflow in division".to_string())
     );
 }
 


### PR DESCRIPTION
Port overflow guards from Scala PR #415 to Rust reduce.rs: checked_neg for ENeg, checked_mul for EMult, and explicit i64::MIN / -1 guard for EDiv. EPlus/EMinus left with wrapping arithmetic to preserve merge pipeline compatibility.

