### PR TITLE
fix: use amount parameter instead of hardcoded 1000 in BondingUtil

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/helper/BondingUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BondingUtil.scala
@@ -20,7 +20,7 @@ object BondingUtil {
          |new retCh, PoSCh, rl(`rho:registry:lookup`), stdout(`rho:io:stdout`), deployerId(`rho:system:deployerId`) in {
          |  rl!(`rho:system:pos`, *PoSCh) |
          |  for(@(_, PoS) <- PoSCh) {
-         |    @PoS!("bond", *deployerId, 1000, *retCh)
+         |    @PoS!("bond", *deployerId, $amount, *retCh)
          |  }
          |}
          |""".stripMargin,


### PR DESCRIPTION
## Summary
- `BondingUtil.bondingDeploy` ignored the `amount` parameter and always bonded with `1000`
- Changed hardcoded `1000` to `$amount` so the string interpolation uses the actual parameter value

## Test plan
- [ ] Existing tests that call `bondingDeploy` with non-1000 amounts now bond the correct amount