### PR TITLE
Add minimal deploy lookup view to reduce API payload size (#392)

### DIFF
--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -57,6 +57,8 @@ trait WebApi[F[_]] {
 
   def findDeploy(deployId: String): F[LightBlockInfo]
 
+  def findDeployMinimal(deployId: String): F[DeployLookupResponse]
+
   def exploratoryDeploy(
       term: String,
       blockHash: Option[String],
@@ -147,6 +149,9 @@ object WebApi {
       BlockAPI
         .findDeploy[F](deployId.unsafeHexToByteString)
         .flatMap(_.liftToBlockApiErr)
+
+    def findDeployMinimal(deployId: String): F[DeployLookupResponse] =
+      findDeploy(deployId).map(DeployLookupResponse.fromLightBlockInfo)
 
     def exploratoryDeploy(
         term: String,
@@ -319,6 +324,33 @@ object WebApi {
   )
 
   final case class VersionInfo(api: String, node: String)
+
+  final case class DeployLookupResponse(
+      blockHash: String,
+      blockNumber: Long,
+      timestamp: Long,
+      sender: String,
+      seqNum: Long,
+      sig: String,
+      sigAlgorithm: String,
+      shardId: String,
+      version: Long
+  )
+
+  object DeployLookupResponse {
+    def fromLightBlockInfo(info: LightBlockInfo): DeployLookupResponse =
+      DeployLookupResponse(
+        blockHash = info.blockHash,
+        blockNumber = info.blockNumber,
+        timestamp = info.timestamp,
+        sender = info.sender,
+        seqNum = info.seqNum,
+        sig = info.sig,
+        sigAlgorithm = info.sigAlgorithm,
+        shardId = info.shardId,
+        version = info.version
+      )
+  }
 
   // Exception thrown by BlockAPI
   final class BlockApiException(message: String) extends Exception(message)

--- a/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
@@ -10,10 +10,13 @@ import coop.rchain.node.api.WebApi
 import coop.rchain.node.api.WebApi._
 import coop.rchain.shared.Log
 import io.circe.generic.semiauto._
-import org.http4s.{HttpRoutes, Response}
+import org.http4s.{HttpRoutes, QueryParamDecoder, Response}
+import org.http4s.dsl.impl.OptionalQueryParamDecoderMatcher
 import coop.rchain.node.encode.JsonEncoder._
 
 object WebApiRoutes {
+
+  object ViewParam extends OptionalQueryParamDecoderMatcher[String]("view")
 
   def service[F[_]: Sync: Log](webApi: WebApi[F]): HttpRoutes[F] = {
     import coop.rchain.casper.protocol.{BlockInfo, LightBlockInfo}
@@ -89,16 +92,17 @@ object WebApiRoutes {
     implicit val encodeBlockInfo: Encoder[BlockInfo] = deriveEncoder[BlockInfo]
 
     // Encoders
-    implicit val stringEncoder              = jsonEncoderOf[F, String]
-    implicit val booleanEncode              = jsonEncoderOf[F, Boolean]
-    implicit val apiStatusEncoder           = jsonEncoderOf[F, ApiStatus]
-    implicit val blockInfoEncoder           = jsonEncoderOf[F, BlockInfo]
-    implicit val lightBlockEncoder          = jsonEncoderOf[F, LightBlockInfo]
-    implicit val lightBlockListEnc          = jsonEncoderOf[F, List[LightBlockInfo]]
-    implicit val dataAtNameRespEncoder      = jsonEncoderOf[F, DataAtNameResponse]
-    implicit val dataAtParRespEncoder       = jsonEncoderOf[F, RhoDataResponse]
-    implicit val prepareEncoder             = jsonEncoderOf[F, PrepareResponse]
-    implicit val transactionResponseEncoder = jsonEncoderOf[F, TransactionResponse]
+    implicit val stringEncoder               = jsonEncoderOf[F, String]
+    implicit val booleanEncode               = jsonEncoderOf[F, Boolean]
+    implicit val apiStatusEncoder            = jsonEncoderOf[F, ApiStatus]
+    implicit val blockInfoEncoder            = jsonEncoderOf[F, BlockInfo]
+    implicit val lightBlockEncoder           = jsonEncoderOf[F, LightBlockInfo]
+    implicit val lightBlockListEnc           = jsonEncoderOf[F, List[LightBlockInfo]]
+    implicit val dataAtNameRespEncoder       = jsonEncoderOf[F, DataAtNameResponse]
+    implicit val dataAtParRespEncoder        = jsonEncoderOf[F, RhoDataResponse]
+    implicit val prepareEncoder              = jsonEncoderOf[F, PrepareResponse]
+    implicit val transactionResponseEncoder  = jsonEncoderOf[F, TransactionResponse]
+    implicit val deployLookupResponseEncoder = jsonEncoderOf[F, DeployLookupResponse]
     // Decoders
     implicit val deployRequestDecoder     = jsonOf[F, DeployRequest]
     implicit val dataAtNameRequestDecoder = jsonOf[F, DataAtNameRequest]
@@ -162,8 +166,11 @@ object WebApiRoutes {
       case GET -> Root / "blocks" / IntVar(depth) =>
         webApi.getBlocks(depth).handle
 
-      case GET -> Root / "deploy" / deployId =>
-        webApi.findDeploy(deployId).handle
+      case GET -> Root / "deploy" / deployId :? ViewParam(view) =>
+        view match {
+          case Some("minimal") => webApi.findDeployMinimal(deployId).handle
+          case _               => webApi.findDeploy(deployId).handle
+        }
 
       case GET -> Root / "is-finalized" / hash =>
         webApi.isFinalized(hash).handle

--- a/node/src/test/scala/coop/rchain/node/api/DeployLookupResponseSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/api/DeployLookupResponseSpec.scala
@@ -1,0 +1,97 @@
+package coop.rchain.node.api
+
+import com.google.protobuf.ByteString
+import coop.rchain.casper.protocol.{BondInfo, JustificationInfo, LightBlockInfo}
+import coop.rchain.node.api.WebApi.DeployLookupResponse
+import org.scalatest.{FlatSpec, Matchers}
+
+class DeployLookupResponseSpec extends FlatSpec with Matchers {
+
+  val sampleLightBlockInfo: LightBlockInfo = LightBlockInfo(
+    blockHash = "7bf8abc123",
+    sender = "0487def456",
+    seqNum = 17453,
+    sig = "3044abcdef",
+    sigAlgorithm = "secp256k1",
+    shardId = "root",
+    extraBytes = ByteString.EMPTY,
+    version = 1,
+    timestamp = 1770028092477L,
+    headerExtraBytes = ByteString.EMPTY,
+    parentsHashList = List("parent1hash", "parent2hash"),
+    blockNumber = 52331,
+    preStateHash = "preState123",
+    postStateHash = "postState456",
+    bodyExtraBytes = ByteString.EMPTY,
+    bonds = List(BondInfo("validator1", 100), BondInfo("validator2", 200)),
+    blockSize = "4096",
+    deployCount = 5,
+    faultTolerance = 0.5f,
+    justifications = List(JustificationInfo("validator1", "latestBlockHash1")),
+    rejectedDeploys = List.empty
+  )
+
+  "DeployLookupResponse.fromLightBlockInfo" should "extract only the minimal fields" in {
+    val result = DeployLookupResponse.fromLightBlockInfo(sampleLightBlockInfo)
+
+    result.blockHash should be("7bf8abc123")
+    result.blockNumber should be(52331)
+    result.timestamp should be(1770028092477L)
+    result.sender should be("0487def456")
+    result.seqNum should be(17453)
+    result.sig should be("3044abcdef")
+    result.sigAlgorithm should be("secp256k1")
+    result.shardId should be("root")
+    result.version should be(1)
+  }
+
+  it should "not contain block-level fields like bonds, justifications, parentsHashList" in {
+    val result = DeployLookupResponse.fromLightBlockInfo(sampleLightBlockInfo)
+
+    // Verify the case class only has the 9 expected fields
+    // by checking the product arity (case classes extend Product)
+    result.productArity should be(9)
+  }
+
+  it should "handle empty string fields" in {
+    val emptyInfo = sampleLightBlockInfo.copy(
+      blockHash = "",
+      sender = "",
+      sig = "",
+      sigAlgorithm = "",
+      shardId = ""
+    )
+    val result = DeployLookupResponse.fromLightBlockInfo(emptyInfo)
+
+    result.blockHash should be("")
+    result.sender should be("")
+    result.sig should be("")
+    result.sigAlgorithm should be("")
+    result.shardId should be("")
+  }
+
+  it should "handle zero numeric fields" in {
+    val zeroInfo = sampleLightBlockInfo.copy(
+      blockNumber = 0,
+      timestamp = 0,
+      seqNum = 0,
+      version = 0
+    )
+    val result = DeployLookupResponse.fromLightBlockInfo(zeroInfo)
+
+    result.blockNumber should be(0)
+    result.timestamp should be(0)
+    result.seqNum should be(0)
+    result.version should be(0)
+  }
+
+  it should "produce correct result regardless of bonds list size" in {
+    val manyBonds = (1 to 1000).map(i => BondInfo(s"validator$i", i.toLong)).toList
+    val largeInfo = sampleLightBlockInfo.copy(bonds = manyBonds)
+    val result    = DeployLookupResponse.fromLightBlockInfo(largeInfo)
+
+    // The response should be the same regardless of bonds size
+    result.blockHash should be(sampleLightBlockInfo.blockHash)
+    result.blockNumber should be(sampleLightBlockInfo.blockNumber)
+  }
+}

--- a/node/src/test/scala/coop/rchain/node/web/WebApiRoutesDeploySpec.scala
+++ b/node/src/test/scala/coop/rchain/node/web/WebApiRoutesDeploySpec.scala
@@ -1,0 +1,156 @@
+package coop.rchain.node.web
+
+import cats.effect.IO
+import com.google.protobuf.ByteString
+import coop.rchain.casper.protocol.{BlockInfo, LightBlockInfo}
+import coop.rchain.node.api.WebApi
+import coop.rchain.node.api.WebApi._
+import coop.rchain.shared.Log
+import io.circe.parser._
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import org.http4s._
+import org.http4s.implicits._
+import org.scalatest.{FlatSpec, Matchers}
+
+class WebApiRoutesDeploySpec extends FlatSpec with Matchers {
+
+  implicit val log: Log[Task] = Log.log[Task]
+
+  val sampleLightBlockInfo: LightBlockInfo = LightBlockInfo(
+    blockHash = "7bf8abc123",
+    sender = "0487def456",
+    seqNum = 17453,
+    sig = "3044abcdef",
+    sigAlgorithm = "secp256k1",
+    shardId = "root",
+    extraBytes = ByteString.EMPTY,
+    version = 1,
+    timestamp = 1770028092477L,
+    headerExtraBytes = ByteString.EMPTY,
+    parentsHashList = List("parent1hash", "parent2hash"),
+    blockNumber = 52331,
+    preStateHash = "preState123",
+    postStateHash = "postState456",
+    bodyExtraBytes = ByteString.EMPTY,
+    bonds = List(
+      coop.rchain.casper.protocol.BondInfo("validator1", 100),
+      coop.rchain.casper.protocol.BondInfo("validator2", 200)
+    ),
+    blockSize = "4096",
+    deployCount = 5,
+    faultTolerance = 0.5f,
+    justifications = List(
+      coop.rchain.casper.protocol.JustificationInfo("validator1", "latestBlockHash1")
+    ),
+    rejectedDeploys = List.empty
+  )
+
+  val sampleDeployLookupResponse: DeployLookupResponse =
+    DeployLookupResponse.fromLightBlockInfo(sampleLightBlockInfo)
+
+  /** Stub WebApi that only implements findDeploy and findDeployMinimal */
+  val stubWebApi: WebApi[Task] = new WebApi[Task] {
+    def status: Task[ApiStatus] = Task.raiseError(new NotImplementedError)
+    def prepareDeploy(request: Option[PrepareRequest]): Task[PrepareResponse] =
+      Task.raiseError(new NotImplementedError)
+    def deploy(request: DeployRequest): Task[String] = Task.raiseError(new NotImplementedError)
+    def listenForDataAtName(request: DataAtNameRequest): Task[DataAtNameResponse] =
+      Task.raiseError(new NotImplementedError)
+    def getDataAtPar(request: DataAtNameByBlockHashRequest): Task[RhoDataResponse] =
+      Task.raiseError(new NotImplementedError)
+    def lastFinalizedBlock: Task[BlockInfo]               = Task.raiseError(new NotImplementedError)
+    def getBlock(hash: String): Task[BlockInfo]           = Task.raiseError(new NotImplementedError)
+    def getBlocks(depth: Int): Task[List[LightBlockInfo]] = Task.raiseError(new NotImplementedError)
+    def exploratoryDeploy(
+        term: String,
+        blockHash: Option[String],
+        usePreStateHash: Boolean
+    ): Task[RhoDataResponse] = Task.raiseError(new NotImplementedError)
+    def getBlocksByHeights(
+        startBlockNumber: Long,
+        endBlockNumber: Long
+    ): Task[List[LightBlockInfo]] =
+      Task.raiseError(new NotImplementedError)
+    def isFinalized(hash: String): Task[Boolean] = Task.raiseError(new NotImplementedError)
+    def getTransaction(hash: String): Task[TransactionResponse] =
+      Task.raiseError(new NotImplementedError)
+
+    def findDeploy(deployId: String): Task[LightBlockInfo] =
+      Task.pure(sampleLightBlockInfo)
+
+    def findDeployMinimal(deployId: String): Task[DeployLookupResponse] =
+      Task.pure(sampleDeployLookupResponse)
+  }
+
+  val routes: HttpRoutes[Task] = WebApiRoutes.service[Task](stubWebApi)
+
+  private def runRequest(req: Request[Task]): Response[Task] =
+    routes.orNotFound.run(req).runSyncUnsafe()
+
+  private def bodyAsString(resp: Response[Task]): String =
+    resp.body.compile.toVector.runSyncUnsafe().map(_.toChar).mkString
+
+  "GET /deploy/<id>" should "return full LightBlockInfo when no view param" in {
+    val req  = Request[Task](Method.GET, uri"/deploy/abc123def")
+    val resp = runRequest(req)
+
+    resp.status should be(Status.Ok)
+
+    val json = parse(bodyAsString(resp)).getOrElse(fail("Invalid JSON"))
+
+    // Full response should contain block-level fields
+    json.hcursor.get[String]("blockHash").toOption should be(Some("7bf8abc123"))
+    json.hcursor.get[Long]("blockNumber").toOption should be(Some(52331L))
+    json.hcursor.get[Long]("timestamp").toOption should be(Some(1770028092477L))
+    // Should contain fields that minimal view excludes
+    json.hcursor.get[String]("preStateHash").toOption should be(Some("preState123"))
+    json.hcursor.get[String]("postStateHash").toOption should be(Some("postState456"))
+    json.hcursor.downField("bonds").focus should be(defined)
+    json.hcursor.downField("justifications").focus should be(defined)
+    json.hcursor.downField("parentsHashList").focus should be(defined)
+  }
+
+  it should "return minimal DeployLookupResponse when view=minimal" in {
+    val req  = Request[Task](Method.GET, uri"/deploy/abc123def?view=minimal")
+    val resp = runRequest(req)
+
+    resp.status should be(Status.Ok)
+
+    val json = parse(bodyAsString(resp)).getOrElse(fail("Invalid JSON"))
+
+    // Minimal response should contain only deploy-centric fields
+    json.hcursor.get[String]("blockHash").toOption should be(Some("7bf8abc123"))
+    json.hcursor.get[Long]("blockNumber").toOption should be(Some(52331L))
+    json.hcursor.get[Long]("timestamp").toOption should be(Some(1770028092477L))
+    json.hcursor.get[String]("sender").toOption should be(Some("0487def456"))
+    json.hcursor.get[Long]("seqNum").toOption should be(Some(17453L))
+    json.hcursor.get[String]("sig").toOption should be(Some("3044abcdef"))
+    json.hcursor.get[String]("sigAlgorithm").toOption should be(Some("secp256k1"))
+    json.hcursor.get[String]("shardId").toOption should be(Some("root"))
+    json.hcursor.get[Long]("version").toOption should be(Some(1L))
+
+    // Should NOT contain block-level fields
+    json.hcursor.downField("bonds").focus should be(None)
+    json.hcursor.downField("justifications").focus should be(None)
+    json.hcursor.downField("parentsHashList").focus should be(None)
+    json.hcursor.downField("preStateHash").focus should be(None)
+    json.hcursor.downField("postStateHash").focus should be(None)
+    json.hcursor.downField("faultTolerance").focus should be(None)
+    json.hcursor.downField("deployCount").focus should be(None)
+    json.hcursor.downField("blockSize").focus should be(None)
+  }
+
+  it should "return full LightBlockInfo when view param has unknown value" in {
+    val req  = Request[Task](Method.GET, uri"/deploy/abc123def?view=unknown")
+    val resp = runRequest(req)
+
+    resp.status should be(Status.Ok)
+
+    val json = parse(bodyAsString(resp)).getOrElse(fail("Invalid JSON"))
+
+    // Unknown view value should fall back to full response
+    json.hcursor.downField("bonds").focus should be(defined)
+    json.hcursor.downField("justifications").focus should be(defined)
+  }
+}


### PR DESCRIPTION
## Summary

Closes #392

- Added `?view=minimal` query parameter to `GET /api/deploy/<deploy_id>` endpoint
- When `?view=minimal` is set, returns a compact `DeployLookupResponse` with only 9 fields instead of full `LightBlockInfo` (which includes bonds, justifications, parentsHashList, preStateHash, postStateHash, faultTolerance, etc.)
- Fully backward-compatible: requests without `?view` or with unknown values return the original `LightBlockInfo`

## Changes

- `WebApi.scala`: added `DeployLookupResponse` case class, `fromLightBlockInfo` mapper, `findDeployMinimal` method in trait + impl
- `WebApiRoutes.scala`: added `ViewParam` query param matcher, encoder, updated route to dispatch based on `?view=minimal`
- `DeployLookupResponseSpec.scala`: 5 unit tests for the mapping logic
- `WebApiRoutesDeploySpec.scala`: 3 HTTP route tests (full response, minimal response, unknown view fallback)

## Test plan

- [x] `sbt "node/testOnly coop.rchain.node.api.DeployLookupResponseSpec"` — 5/5 passed
- [x] `sbt "node/testOnly coop.rchain.node.web.WebApiRoutesDeploySpec"` — 3/3 passed
- [x] `sbt "casper/testOnly coop.rchain.casper.api.BlockQueryResponseAPITest"` — 6/6 passed (regression)