### PR TITLE
feat: add --ceremony-master-mode and --enable/disable-mergeable-channel-gc CLI flags

### DIFF
--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -88,6 +88,7 @@ object ConfigMapper {
 
       add("casper.genesis-ceremony.required-signatures", run.requiredSignatures)
       add("casper.genesis-ceremony.genesis-validator-mode", run.genesisValidator)
+      add("casper.genesis-ceremony.ceremony-master-mode", run.ceremonyMasterMode)
       add("casper.genesis-ceremony.approve-interval", run.approveInterval)
       add("casper.genesis-ceremony.approve-duration", run.approveDuration) //TODO remove
       add("casper.genesis-ceremony.autogen-shard-size", run.autogenShardSize)
@@ -101,6 +102,11 @@ object ConfigMapper {
       }
       add("casper.heartbeat.check-interval", run.heartbeatCheckInterval)
       add("casper.heartbeat.max-lfb-age", run.heartbeatMaxLfbAge)
+
+      add("casper.enable-mergeable-channel-gc", run.enableMergeableChannelGc)
+      if (run.disableMergeableChannelGc.toOption.contains(true)) {
+        map += "casper.enable-mergeable-channel-gc" -> false
+      }
 
       add("api-server.port-grpc-external", run.apiPortGrpcExternal)
       add("api-server.port-grpc-internal", run.apiPortGrpcInternal)

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -563,6 +563,18 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       descr = "Enable rpsace++"
     )
 
+    val ceremonyMasterMode = opt[Flag](
+      descr = "Enable ceremony master mode for genesis block coordination"
+    )
+
+    val enableMergeableChannelGc = opt[Flag](
+      descr = "Enable background garbage collection for mergeable channels"
+    )
+
+    val disableMergeableChannelGc = opt[Flag](
+      descr = "Disable background garbage collection for mergeable channels"
+    )
+
   }
   addSubcommand(run)
 


### PR DESCRIPTION
## Summary

Closes #442 (Scala side)

- Add `--ceremony-master-mode` CLI flag → maps to `casper.genesis-ceremony.ceremony-master-mode`
- Add `--enable-mergeable-channel-gc` / `--disable-mergeable-channel-gc` CLI flags → maps to `casper.enable-mergeable-channel-gc`
- `--heartbeat-disabled` already exists (added previously), so no change needed there

This allows system-integration to control these settings via compose CLI args instead of maintaining per-role HOCON config file overlays.

## Test plan
- [x] `sbt "project node; compile"` passes
- [x] All three flags appear in `run --help` output

Co-Authored-By: Claude <noreply@anthropic.com>