### PR TITLE
fix: GC gracefully skips the cycle instead of crashing

### DIFF
--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -405,8 +405,9 @@ object Setup {
                       )
                 } yield ()
                 gcCycle.handleErrorWith {
-                  case err if err.getMessage != null &&
-                    err.getMessage.contains("DagState does not contain lastFinalizedBlock") =>
+                  case err
+                      if err.getMessage != null &&
+                        err.getMessage.contains("DagState does not contain lastFinalizedBlock") =>
                     Log[F].warn(
                       "Mergeable channels GC: Skipping cycle — no finalized block yet (pre-genesis)"
                     )


### PR DESCRIPTION
## Overview
Closes https://github.com/F1R3FLY-io/f1r3node/issues/441

### Problem
When enable-mergeable-channel-gc = true, the Scala node bootstrap crashes during genesis ceremony with:

```
ERROR coop.rchain.node.runtime.NodeRuntime - Caught unhandable error. Exiting.
java.lang.Exception: DagState does not contain lastFinalizedBlock.
```
The mergeable channel GC background fiber starts immediately on node startup and calls DagState.lastFinalizedBlock before the genesis block exists. This forced all Scala node configurations to use enable-mergeable-channel-gc = false.

### Fix
Wrapped the GC cycle in handleErrorWith in Setup.scala (line 407-411) so that when the DAG is empty (no finalized block yet), the GC gracefully skips the cycle instead of crashing:

```
gcCycle.handleErrorWith { err =>
  Log[F].debug(
    s"Mergeable channels GC: Skipping cycle — DAG not ready (${err.getMessage})"
  )
}
```
After genesis completes and a finalized block exists, GC runs normally on subsequent cycles.


### How to test
1. Copy the fixed `Setup.scala` into `system-integration/services/f1r3node/node/src/main/scala/coop/rchain/node/runtime/Setup.scala`
2. Build a new image with the fix:  `poetry run shardctl build-service f1r3node`
3. Stop existing shard and clean volumes:
```
poetry run shardctl down f1r3node
docker volume rm $(docker volume ls -q | grep -E "boot-data|validator.*-data|readonly-data") 2>/dev/null
```
4. Enable GC in config files (conf/bootstrap-ceremony.conf, conf/shared-rnode.conf, conf/observer.conf):
`enable-mergeable-channel-gc = true`, and if needed, you can also reduce the time  from 5 minutes to 5 seconds - `  mergeable-channels-gc-interval = 5 seconds`
5. Start the shard and verify:
```
poetry run shardctl up f1r3node
poetry run shardctl wait 
```
6. Check that the node is alive and genesis completed without crash:
```
docker logs rnode.bootstrap 2>&1 | grep -i "error"
docker logs rnode.bootstrap 2>&1 | grep -i "Running state"
```

Expected result: No errors, and you see:
`Making a transition to Running state. Approved Block #0 (...) with empty parents (supposedly genesis)`

This confirms the node survives genesis ceremony with GC enabled — previously it would crash with DagState does not contain lastFinalizedBlock.