### PR TITLE
refactor: separate produce error handling from NonDeterministicProces…

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
@@ -16,6 +16,7 @@ import coop.rchain.rholang.interpreter.errors.{
   InterpreterError,
   NonDeterministicProcessFailure,
   OutOfPhlogistonsError,
+  ProduceFailureWithOutput,
   UserAbortError
 }
 
@@ -95,9 +96,12 @@ class InterpreterImpl[F[_]: Sync: Span](implicit C: _cost[F], mergeChs: Ref[F, S
       case error: OutOfPhlogistonsError.type =>
         EvaluateResult(initialCost, Vector(error), Set()).pure[F]
 
-      // For NonDeterministicProcessFailure and CanNotReplayFailedNonDeterministicProcess,
-      // the evaluation cost is used because the initial cost can be higher
+      // For NonDeterministicProcessFailure, ProduceFailureWithOutput, and
+      // CanNotReplayFailedNonDeterministicProcess, the evaluation cost is used
+      // because the initial cost can be higher
       case error: NonDeterministicProcessFailure =>
+        EvaluateResult(evalCost, Vector(error), Set()).pure[F]
+      case error: ProduceFailureWithOutput =>
         EvaluateResult(evalCost, Vector(error), Set()).pure[F]
       case error: CanNotReplayFailedNonDeterministicProcess.type =>
         EvaluateResult(evalCost, Vector(error), Set()).pure[F]

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -113,6 +113,21 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
                       e.raiseError[M, DispatchType]
                   }
                 })
+            case e: ProduceFailureWithOutput =>
+              val produce1 = produceEvent
+                .markAsNonDeterministic(e.outputNotProduced)
+                .withError()
+
+              space
+                .updateProduce(produce1) // TODO: avoid mutating the produce event
+                .flatMap(_ => {
+                  e.cause match {
+                    case oop @ OutOfPhlogistonsError => // special case
+                      oop.raiseError[M, DispatchType]
+                    case _ => // any other error
+                      e.raiseError[M, DispatchType]
+                  }
+                })
           }
       case other =>
         continue(

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -22,7 +22,11 @@ import coop.rchain.rholang.externalservices.ExternalServices
 import coop.rchain.rholang.interpreter.RhoRuntime.RhoTuplespace
 import coop.rchain.rholang.interpreter.registry.Registry
 import coop.rchain.rholang.interpreter.RholangAndScalaDispatcher.RhoDispatch
-import coop.rchain.rholang.interpreter.errors.{NonDeterministicProcessFailure, ReduceError}
+import coop.rchain.rholang.interpreter.errors.{
+  NonDeterministicProcessFailure,
+  ProduceFailureWithOutput,
+  ReduceError
+}
 import coop.rchain.rholang.interpreter.util.VaultAddress
 import coop.rchain.rspace.{ContResult, Result}
 import coop.rchain.shared.{Base16, Log}
@@ -486,7 +490,14 @@ object SystemProcesses {
 
           def mapOutput(response: String): Seq[Par] = Seq(RhoType.String(response))
 
-          callApi.map(mapOutput).flatMap(output => produce(output, ack).map(_ => output))
+          callApi.map(mapOutput).flatMap { output =>
+            produce(output, ack)
+              .map(_ => output)
+              .recoverWith {
+                case e =>
+                  ProduceFailureWithOutput(output.map(_.toByteArray), e).raiseError
+              }
+          }
         }
       }
 
@@ -506,7 +517,14 @@ object SystemProcesses {
 
           def mapOutput(response: String): Seq[Par] = Seq(RhoType.String(response))
 
-          callApi.map(mapOutput).flatMap(output => produce(output, ack).map(_ => output))
+          callApi.map(mapOutput).flatMap { output =>
+            produce(output, ack)
+              .map(_ => output)
+              .recoverWith {
+                case e =>
+                  ProduceFailureWithOutput(output.map(_.toByteArray), e).raiseError
+              }
+          }
         }
       }
 
@@ -526,7 +544,14 @@ object SystemProcesses {
 
           def mapOutput(bytes: Array[Byte]): Seq[Par] = Seq(RhoType.ByteArray(bytes))
 
-          callApi.map(mapOutput).flatMap(output => produce(output, ack).map(_ => output))
+          callApi.map(mapOutput).flatMap { output =>
+            produce(output, ack)
+              .map(_ => output)
+              .recoverWith {
+                case e =>
+                  ProduceFailureWithOutput(output.map(_.toByteArray), e).raiseError
+              }
+          }
         }
       }
 
@@ -555,7 +580,10 @@ object SystemProcesses {
                              ).raiseError
                          }
             output = Seq(RhoType.String(response))
-            _      <- produce(output, ack)
+            _ <- produce(output, ack).recoverWith {
+                  case e =>
+                    ProduceFailureWithOutput(output.map(_.toByteArray), e).raiseError
+                }
           } yield output
         }
       }
@@ -581,7 +609,10 @@ object SystemProcesses {
                              ).raiseError
                          }
             output = Seq(RhoType.String(response))
-            _      <- produce(output, ack)
+            _ <- produce(output, ack).recoverWith {
+                  case e =>
+                    ProduceFailureWithOutput(output.map(_.toByteArray), e).raiseError
+                }
           } yield output
         }
       }
@@ -600,7 +631,10 @@ object SystemProcesses {
                        }
             modelPars = models.map(model => Par(exprs = Seq(Expr(GString(model)))))
             output    = Seq(Par(exprs = Seq(EList(modelPars))))
-            _         <- produce(output, ack)
+            _ <- produce(output, ack).recoverWith {
+                  case e =>
+                    ProduceFailureWithOutput(output.map(_.toByteArray), e).raiseError
+                }
           } yield output
         }
       }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
@@ -109,6 +109,15 @@ object errors {
                                                         else cause.getMessage)
       )
 
+  final case class ProduceFailureWithOutput(
+      outputNotProduced: Seq[Array[Byte]],
+      cause: Throwable
+  ) extends InterpreterError(
+        s"Produce failed after non-deterministic call. Cause: " + (if (cause.getMessage == null)
+                                                                     cause
+                                                                   else cause.getMessage)
+      )
+
   final case object CanNotReplayFailedNonDeterministicProcess
       extends InterpreterError(
         "Can not replay failed non deterministic process."


### PR DESCRIPTION
## Summary

- Remove `NonDeterministicProcessFailure` wrapping from `produce` calls in all 6 system processes (GPT-4, DALL-E 3, TTS, Ollama chat/generate/models)
- `produce` is a deterministic RSpace operation — only external API calls are non-deterministic
- For OpenAI processes: replaced `produceNonDeterministicOutput` helper with direct `produce` call
- For Ollama processes: moved `recoverWith` from the entire `for`-block to only the API call

## Related

Closes #440 on the Scala side

Identified during #436 review by @AndriiS-DevBrother