### PR TITLE
refactor: separate produce error handling from NonDeterministicProcessFailure (Rust)

### DIFF
--- a/rholang/src/rust/interpreter/errors.rs
+++ b/rholang/src/rust/interpreter/errors.rs
@@ -98,6 +98,12 @@ pub enum InterpreterError {
         cause: Box<InterpreterError>,
         output_not_produced: Vec<Vec<u8>>,
     },
+    /// Raised when a deterministic produce fails after a successful non-deterministic API call.
+    /// Contains the underlying cause and the output that was produced by the API but not stored.
+    ProduceFailureWithOutput {
+        cause: Box<InterpreterError>,
+        output_not_produced: Vec<Vec<u8>>,
+    },
     /// Raised during replay when we encounter a failed non-deterministic produce that we cannot replay.
     CanNotReplayFailedNonDeterministicProcess,
 }
@@ -313,6 +319,10 @@ impl fmt::Display for InterpreterError {
 
             InterpreterError::NonDeterministicProcessFailure { cause, .. } => {
                 write!(f, "Non-deterministic process failure: {}", cause)
+            }
+
+            InterpreterError::ProduceFailureWithOutput { cause, .. } => {
+                write!(f, "Produce failure with output: {}", cause)
             }
 
             InterpreterError::CanNotReplayFailedNonDeterministicProcess => {

--- a/rholang/src/rust/interpreter/reduce.rs
+++ b/rholang/src/rust/interpreter/reduce.rs
@@ -486,20 +486,17 @@ impl DebruijnInterpreter {
                         space_locked.update_produce(failed_produce);
                         drop(space_locked);
                         log_op_step("after_update_produce_failed_nondeterministic");
-                        // Re-raise with the correct error type based on origin
+                        // Re-raise known error types as-is to preserve output_not_produced;
+                        // wrap unknown errors in NonDeterministicProcessFailure.
                         match error {
-                            InterpreterError::ProduceFailureWithOutput { cause, output_not_produced } => {
-                                Err(InterpreterError::ProduceFailureWithOutput {
-                                    cause,
-                                    output_not_produced,
-                                })
+                            InterpreterError::ProduceFailureWithOutput { .. }
+                            | InterpreterError::NonDeterministicProcessFailure { .. } => {
+                                Err(error)
                             }
-                            _ => {
-                                Err(InterpreterError::NonDeterministicProcessFailure {
-                                    cause: Box::new(error),
-                                    output_not_produced: vec![],
-                                })
-                            }
+                            _ => Err(InterpreterError::NonDeterministicProcessFailure {
+                                cause: Box::new(error),
+                                output_not_produced: vec![],
+                            }),
                         }
                     }
 

--- a/rholang/src/rust/interpreter/reduce.rs
+++ b/rholang/src/rust/interpreter/reduce.rs
@@ -486,11 +486,21 @@ impl DebruijnInterpreter {
                         space_locked.update_produce(failed_produce);
                         drop(space_locked);
                         log_op_step("after_update_produce_failed_nondeterministic");
-                        // Wrap the original error in NonDeterministicProcessFailure
-                        Err(InterpreterError::NonDeterministicProcessFailure {
-                            cause: Box::new(error),
-                            output_not_produced: vec![],
-                        })
+                        // Re-raise with the correct error type based on origin
+                        match error {
+                            InterpreterError::ProduceFailureWithOutput { cause, output_not_produced } => {
+                                Err(InterpreterError::ProduceFailureWithOutput {
+                                    cause,
+                                    output_not_produced,
+                                })
+                            }
+                            _ => {
+                                Err(InterpreterError::NonDeterministicProcessFailure {
+                                    cause: Box::new(error),
+                                    output_not_produced: vec![],
+                                })
+                            }
+                        }
                     }
 
                     _ => Ok(dispatch_type),

--- a/rholang/src/rust/interpreter/system_processes.rs
+++ b/rholang/src/rust/interpreter/system_processes.rs
@@ -870,7 +870,7 @@ impl SystemProcesses {
 
         let output = vec![RhoString::create_par(response)];
         if let Err(e) = produce(&output, ack).await {
-            return Err(InterpreterError::NonDeterministicProcessFailure {
+            return Err(InterpreterError::ProduceFailureWithOutput {
                 cause: Box::new(e),
                 output_not_produced: output.iter().map(|p| p.encode_to_vec()).collect(),
             });
@@ -917,7 +917,7 @@ impl SystemProcesses {
 
         let output = vec![RhoString::create_par(response)];
         if let Err(e) = produce(&output, ack).await {
-            return Err(InterpreterError::NonDeterministicProcessFailure {
+            return Err(InterpreterError::ProduceFailureWithOutput {
                 cause: Box::new(e),
                 output_not_produced: output.iter().map(|p| p.encode_to_vec()).collect(),
             });
@@ -968,7 +968,7 @@ impl SystemProcesses {
 
         let output = vec![RhoByteArray::create_par(audio_bytes)];
         if let Err(e) = produce(&output, ack).await {
-            return Err(InterpreterError::NonDeterministicProcessFailure {
+            return Err(InterpreterError::ProduceFailureWithOutput {
                 cause: Box::new(e),
                 output_not_produced: output.iter().map(|p| p.encode_to_vec()).collect(),
             });
@@ -1029,7 +1029,7 @@ impl SystemProcesses {
 
         let output = vec![RhoString::create_par(response)];
         if let Err(e) = produce(&output, ack).await {
-            return Err(InterpreterError::NonDeterministicProcessFailure {
+            return Err(InterpreterError::ProduceFailureWithOutput {
                 cause: Box::new(e),
                 output_not_produced: output.iter().map(|p| p.encode_to_vec()).collect(),
             });
@@ -1085,7 +1085,7 @@ impl SystemProcesses {
 
         let output = vec![RhoString::create_par(response)];
         if let Err(e) = produce(&output, ack).await {
-            return Err(InterpreterError::NonDeterministicProcessFailure {
+            return Err(InterpreterError::ProduceFailureWithOutput {
                 cause: Box::new(e),
                 output_not_produced: output.iter().map(|p| p.encode_to_vec()).collect(),
             });
@@ -1139,7 +1139,7 @@ impl SystemProcesses {
         let output = vec![Par::default().with_exprs(vec![list_expr])];
 
         if let Err(e) = produce(&output, ack).await {
-            return Err(InterpreterError::NonDeterministicProcessFailure {
+            return Err(InterpreterError::ProduceFailureWithOutput {
                 cause: Box::new(e),
                 output_not_produced: output.iter().map(|p| p.encode_to_vec()).collect(),
             });


### PR DESCRIPTION
## Summary

Rust backport of #453 (Scala side). Closes #440 on the Rust side.

### Problem

`produce` is a deterministic RSpace operation, but its failure was wrapped in `NonDeterministicProcessFailure` — the same error type used for external API failures (OpenAI, Ollama, gRPC). This makes it impossible to distinguish where the error originated: was it the external API call that failed, or the internal `produce` that failed after a successful API response?

### What changed

- Added `ProduceFailureWithOutput` error variant — used when `produce` fails after a successful API call (e.g. phlo exhausted on a large response)
- Changed all 6 `produce` error handlers in system processes (GPT-4, DALL-E 3, TTS, Ollama chat/generate/models) from `NonDeterministicProcessFailure` to `ProduceFailureWithOutput`
- `NonDeterministicProcessFailure` is now used **exclusively** for external API call failures, which is what the name implies

### Why only 2 files changed (vs 4 in Scala #453)?

In Scala, `Reduce.scala` and `Interpreter.scala` explicitly pattern-match on `NonDeterministicProcessFailure` to extract `outputNotProduced` for the replay mechanism — so both needed a new match arm for `ProduceFailureWithOutput`.

In Rust, `reduce.rs` and `interpreter.rs` do **not** destructure these error variants. Replay works differently — via `produce_event.mark_as_non_deterministic()` and `produce_event.with_error()`. Errors propagate through `?` without being matched on, so only `errors.rs` (new type) and `system_processes.rs` (use new type) need changes.

## Related

- Backport of #453
- Closes #440