### PR TITLE
ci: explicitly list integration test files (Scala)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,8 @@ jobs:
 
       - name: Generate CHANGELOG
         uses: orhun/git-cliff-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           config: cliff.toml
           args: --tag ${{ steps.version.outputs.TAG_NAME }} -o CHANGELOG.md

--- a/.github/workflows/required-workflow.yml
+++ b/.github/workflows/required-workflow.yml
@@ -733,6 +733,11 @@ jobs:
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Extract release notes for this version
+        run: |
+          # Extract only the latest version section from CHANGELOG.md
+          awk '/^## \[/{if(found) exit; found=1} found' CHANGELOG.md > RELEASE_NOTES.md
+
       - name: Update release and release artifacts
         uses: ncipollo/release-action@v1
         with:
@@ -741,5 +746,5 @@ jobs:
           draft: false
           allowUpdates: true
           omitBodyDuringUpdate: true
-          bodyFile: CHANGELOG.md
+          bodyFile: RELEASE_NOTES.md
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/required-workflow.yml
+++ b/.github/workflows/required-workflow.yml
@@ -543,9 +543,23 @@ jobs:
           if [ "${{ matrix.arch }}" = "arm64" ]; then
             SCALE_FLAG="--timeout-scale=1.5"
           fi
-          poetry run pytest integration-tests/test/ -v --tb=short --log-cli-level=WARNING \
-            --startup-timeout=600 --command-timeout=300 --timeout=600 $SCALE_FLAG \
-            --deselect=integration-tests/test/test_replay_determinism.py
+          poetry run pytest \
+            integration-tests/test/test_web_api.py \
+            integration-tests/test/test_wallets.py \
+            integration-tests/test/test_heartbeat.py \
+            integration-tests/test/test_deployment.py \
+            integration-tests/test/test_storage.py \
+            integration-tests/test/test_genesis_ceremony.py \
+            integration-tests/test/test_dag_correctness.py \
+            integration-tests/test/test_finalization.py \
+            integration-tests/test/test_propose.py \
+            integration-tests/test/test_consensus_health.py \
+            integration-tests/test/test_synchrony_constraint.py \
+            integration-tests/test/test_asymmetric_bonds.py \
+            integration-tests/test/test_bonding_validators.py \
+            integration-tests/test/test_trim_state.py \
+            -v --tb=short --log-cli-level=WARNING \
+            --startup-timeout=600 --command-timeout=300 --timeout=600 $SCALE_FLAG
 
       - name: Upload Integration Test Logs
         if: always()

--- a/cliff.toml
+++ b/cliff.toml
@@ -18,6 +18,7 @@ body = """
 {% for commit in commits %}
 - {{ commit.message | split(pat="\n") | first | trim }}\
   {% if commit.breaking %} [**breaking**]{% endif %}\
+  {%- if commit.github.pr_number %} ([#{{ commit.github.pr_number }}](https://github.com/F1R3FLY-io/f1r3node/pull/{{ commit.github.pr_number }})){% endif %}\
 {% endfor %}
 {% endfor %}\n
 """
@@ -36,11 +37,18 @@ commit_parsers = [
     { message = "^refactor", group = "Refactoring" },
     { message = "^ci", group = "CI" },
     { message = "^test", group = "Testing" },
+    { message = "^style", group = "Style" },
     { message = "^chore\\(release\\)", skip = true },
     { message = "^chore", group = "Miscellaneous" },
     { message = "^Merge", skip = true },
+    # Skip non-standard multi-scope commits (e.g. "casper/node: ...")
+    { message = "^[a-z]+/", skip = true },
 ]
 protect_breaking_commits = false
 filter_commits = false
 tag_pattern = "scala-v[0-9].*"
 sort_commits = "newest"
+
+[remote.github]
+owner = "F1R3FLY-io"
+repo = "f1r3node"


### PR DESCRIPTION
## Summary
- Replaces `pytest integration-tests/test/ --deselect=...` with an explicit list of 14 test files
- New tests added to system-integration must be manually added to this list to run against the Scala node
- Same test set as the Rust workflow minus `test_replay_determinism`

## Changelog Improvements
- **PR links**: git-cliff now queries the GitHub API to resolve which PR each commit belongs to and appends clickable `(#123)` links to each entry
- **Release notes extraction**: GitHub Release body now shows only the current version's changes (not the full history) via `awk` extraction to `RELEASE_NOTES.md`
- **Skip noisy commits**: Non-standard multi-scope commits (e.g. `casper/node/docker: ...`) are now filtered out of the changelog

## Test plan
- [ ] Verify integration tests run the same 14 test modules on both arches
- [ ] Verify next release changelog includes PR links and only current version

Co-Authored-By: Claude <noreply@anthropic.com>