### PR TITLE
ci: stability fixes for GitHub-hosted runner SIGTERM issues

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -490,6 +490,11 @@ jobs:
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Extract release notes for this version
+        run: |
+          # Extract only the latest version section from CHANGELOG.md
+          awk '/^## \[/{if(found) exit; found=1} found' CHANGELOG.md > RELEASE_NOTES.md
+
       - name: Update release and release artifacts
         uses: ncipollo/release-action@v1
         with:
@@ -498,5 +503,5 @@ jobs:
           draft: false
           allowUpdates: true
           omitBodyDuringUpdate: true
-          bodyFile: CHANGELOG.md
+          bodyFile: RELEASE_NOTES.md
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -226,17 +226,16 @@ jobs:
           path: /tmp/rust-node-docker.tar.gz
 
   # Integration tests on GitHub-hosted runners, parallelized by test module.
-  # Each test module gets its own ephemeral runner (2 arches × 16 modules = 32 jobs).
-  required_rust_integration_tests:
-    name: Integration Tests (${{ matrix.arch.name }}/${{ matrix.test }})
+  # amd64 and arm64 are split into separate jobs with different max-parallel
+  # values to match each runner fleet's capacity and avoid SIGTERM preemption.
+  required_rust_integration_tests_amd64:
+    name: Integration Tests (amd64/${{ matrix.test }})
     needs: build_rust_docker_image
-    runs-on: ${{ matrix.arch.runner }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 8
       matrix:
-        arch:
-          - { runner: ubuntu-latest, name: amd64 }
-          - { runner: ubuntu-24.04-arm, name: arm64 }
         test:
           - test_web_api
           - test_wallets
@@ -279,14 +278,14 @@ jobs:
       - name: Load Docker Image
         uses: actions/download-artifact@v4
         with:
-          name: artifacts-docker-${{ matrix.arch.name }}
+          name: artifacts-docker-amd64
           path: /tmp
 
       - name: Import Docker Image
         shell: bash -ex {0}
         run: |
           zcat /tmp/rust-node-docker.tar.gz | docker image load
-          docker tag f1r3flyindustries/f1r3fly-rust-node:${{ matrix.arch.name }} f1r3flyindustries/f1r3fly-rust-node
+          docker tag f1r3flyindustries/f1r3fly-rust-node:amd64 f1r3flyindustries/f1r3fly-rust-node
 
       - name: Install system-integration dependencies
         shell: bash -ex {0}
@@ -308,23 +307,18 @@ jobs:
           DEFAULT_IMAGE: f1r3flyindustries/f1r3fly-rust-node
         run: |
           cd system-integration
-          SCALE_FLAG=""
-          if [ "${{ matrix.arch.name }}" = "arm64" ]; then
-            SCALE_FLAG="--timeout-scale=1.5"
-          fi
           DESELECT_FLAG=""
           if [ "${{ matrix.test }}" = "test_replay_determinism" ]; then
-            # Skip test_network_recovers_from_slow_deploy — see f1r3node#463
             DESELECT_FLAG="--deselect integration-tests/test/test_replay_determinism.py::test_network_recovers_from_slow_deploy"
           fi
           poetry run pytest integration-tests/test/${{ matrix.test }}.py -v --tb=short --log-cli-level=WARNING \
-            --startup-timeout=600 --command-timeout=300 --timeout=600 $SCALE_FLAG $DESELECT_FLAG
+            --startup-timeout=600 --command-timeout=300 --timeout=600 $DESELECT_FLAG
 
       - name: Upload Integration Test Logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: integration-logs-${{ matrix.arch.name }}-${{ matrix.test }}
+          name: integration-logs-amd64-${{ matrix.test }}
           path: system-integration/integration-tests/
           retention-days: 7
 
@@ -332,7 +326,110 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: docker-logs-${{ matrix.arch.name }}-${{ matrix.test }}
+          name: docker-logs-amd64-${{ matrix.test }}
+          path: /tmp/*.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+  required_rust_integration_tests_arm64:
+    name: Integration Tests (arm64/${{ matrix.test }})
+    needs: build_rust_docker_image
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        test:
+          - test_web_api
+          - test_wallets
+          - test_heartbeat
+          - test_deployment
+          - test_storage
+          - test_genesis_ceremony
+          - test_dag_correctness
+          - test_finalization
+          - test_propose
+          - test_replay_determinism
+          - test_consensus_health
+          - test_synchrony_constraint
+          - test_asymmetric_bonds
+          - test_bonding_validators
+          - test_trim_state
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v4
+
+      - name: Clone system-integration
+        uses: actions/checkout@v4
+        with:
+          repository: F1R3FLY-io/system-integration
+          ref: main
+          path: system-integration
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: 'pip'
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.8.5
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Load Docker Image
+        uses: actions/download-artifact@v4
+        with:
+          name: artifacts-docker-arm64
+          path: /tmp
+
+      - name: Import Docker Image
+        shell: bash -ex {0}
+        run: |
+          zcat /tmp/rust-node-docker.tar.gz | docker image load
+          docker tag f1r3flyindustries/f1r3fly-rust-node:arm64 f1r3flyindustries/f1r3fly-rust-node
+
+      - name: Install system-integration dependencies
+        shell: bash -ex {0}
+        run: |
+          cd system-integration
+          poetry lock --no-update
+          poetry install --with integration
+
+      - name: Ensure test ports are free
+        shell: bash {0}
+        run: |
+          for port in $(seq 40400 40545); do
+            fuser -k $port/tcp 2>/dev/null || true
+          done
+
+      - name: Run Integration Tests
+        shell: bash -ex {0}
+        env:
+          DEFAULT_IMAGE: f1r3flyindustries/f1r3fly-rust-node
+        run: |
+          cd system-integration
+          DESELECT_FLAG=""
+          if [ "${{ matrix.test }}" = "test_replay_determinism" ]; then
+            DESELECT_FLAG="--deselect integration-tests/test/test_replay_determinism.py::test_network_recovers_from_slow_deploy"
+          fi
+          poetry run pytest integration-tests/test/${{ matrix.test }}.py -v --tb=short --log-cli-level=WARNING \
+            --startup-timeout=600 --command-timeout=300 --timeout=600 --timeout-scale=1.5 $DESELECT_FLAG
+
+      - name: Upload Integration Test Logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-logs-arm64-${{ matrix.test }}
+          path: system-integration/integration-tests/
+          retention-days: 7
+
+      - name: Upload Docker Logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-logs-arm64-${{ matrix.test }}
           path: /tmp/*.log
           if-no-files-found: ignore
           retention-days: 7
@@ -350,7 +447,8 @@ jobs:
     name: Release Rust Docker Image
     needs:
       - required_rust_unit_tests
-      - required_rust_integration_tests
+      - required_rust_integration_tests_amd64
+      - required_rust_integration_tests_arm64
       - build_rust_docker_image
       - build_base
     if: >-
@@ -458,7 +556,8 @@ jobs:
       contents: write # Required for creating/updating releases
     needs:
       - required_rust_unit_tests
-      - required_rust_integration_tests
+      - required_rust_integration_tests_amd64
+      - required_rust_integration_tests_arm64
       - build_rust_docker_image
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -15,6 +15,10 @@ on:
       - rust/main
       - "feature/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # Enable AES/SSE2 CPU features for gxhash dependency (required by PathMap crate)
   # GitHub Actions runners support these features on x86_64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,8 @@ jobs:
 
       - name: Generate CHANGELOG
         uses: orhun/git-cliff-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           config: cliff.toml
           args: --tag ${{ steps.version.outputs.TAG_NAME }} -o CHANGELOG.md

--- a/cliff.toml
+++ b/cliff.toml
@@ -18,6 +18,7 @@ body = """
 {% for commit in commits %}
 - {{ commit.message | split(pat="\n") | first | trim }}\
   {% if commit.breaking %} [**breaking**]{% endif %}\
+  {%- if commit.github.pr_number %} ([#{{ commit.github.pr_number }}](https://github.com/F1R3FLY-io/f1r3node/pull/{{ commit.github.pr_number }})){% endif %}\
 {% endfor %}
 {% endfor %}\n
 """
@@ -38,12 +39,21 @@ commit_parsers = [
     { message = "^test", group = "Testing" },
     { message = "^chore\\(release\\)", skip = true },
     { message = "^chore", group = "Miscellaneous" },
+    { message = "^style", group = "Style" },
     { message = "^Merge", skip = true },
+    # Skip non-standard multi-scope commits (e.g. "casper/node/docker: ...")
+    { message = "^[a-z]+/", skip = true },
+    # Skip other non-conventional commits
+    { message = ".*", skip = true },
 ]
 protect_breaking_commits = false
 filter_commits = false
 tag_pattern = "rust-v[0-9].*"
 sort_commits = "newest"
+
+[remote.github]
+owner = "F1R3FLY-io"
+repo = "f1r3node"
 # Only include commits touching Rust implementation paths (shared repo with Scala)
 include_path = [
     "node/src/**",


### PR DESCRIPTION
## Summary
- Adds `concurrency` block with `cancel-in-progress: true` to prevent workflow pile-up
- Splits integration tests into separate amd64 and arm64 jobs with `max-parallel` limits:
  - amd64: `max-parallel: 8` (x64 fleet is large)
  - arm64: `max-parallel: 4` (ARM fleet is smaller, more prone to preemption)
- Fixes PR links in changelog, extracts release notes for GitHub Releases, skips noisy commits in changelog

## Problem
Every CI run launched ~30 integration test jobs simultaneously, exceeding GitHub's runner capacity. Runners were being SIGTERM'd (exit 143) during setup — not test failures but infrastructure preemption.

## Test plan
- [ ] Verify concurrency block cancels old runs on same ref
- [ ] Verify amd64 integration tests run with max 8 concurrent
- [ ] Verify arm64 integration tests run with max 4 concurrent
- [ ] Verify no more SIGTERM runner shutdowns

Co-Authored-By: Claude <noreply@anthropic.com>