### PR TITLE
ci: pin system-integration to f4c2a00 for Scala test compatibility

### DIFF
--- a/.github/workflows/required-workflow.yml
+++ b/.github/workflows/required-workflow.yml
@@ -462,7 +462,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: F1R3FLY-io/system-integration
-          ref: main
+          ref: f4c2a00
           path: system-integration
 
       - uses: actions/setup-java@v5

--- a/.github/workflows/required-workflow.yml
+++ b/.github/workflows/required-workflow.yml
@@ -462,7 +462,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: F1R3FLY-io/system-integration
-          ref: f4c2a00
+          ref: f4c2a001673d6613d18cd91966c30bb02dbffe90
           path: system-integration
 
       - uses: actions/setup-java@v5


### PR DESCRIPTION
## Summary

Pin system-integration checkout in CI to commit f4c2a00 (current main). Upcoming changes to integration tests in system-integration are not yet compatible with the Scala node.

## Test plan
- [x] CI will clone system-integration at the known-good commit

Co-Authored-By: Claude <noreply@anthropic.com>