### PR TITLE
ci: add cancel-in-progress to Scala concurrency block

### DIFF
--- a/.github/workflows/required-workflow.yml
+++ b/.github/workflows/required-workflow.yml
@@ -15,11 +15,9 @@ on:
       - main
       - "feature/**"
 
-# Prevent interleaving of integration test jobs on single-runner-per-arch
-# self-hosted runners. A second workflow run for the same ref queues until
-# the first completes rather than cancelling it.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   # This is read by every new JVM. Every JVM thinks it can use up to 80% of


### PR DESCRIPTION
## Summary
- Adds `cancel-in-progress: true` to concurrency block — new pushes cancel in-progress runs instead of queuing

Co-Authored-By: Claude <noreply@anthropic.com>