### PR TITLE
feat: WebSocket startup event replay

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -281,7 +281,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: F1R3FLY-io/system-integration
-          ref: 953582825cfe1b6238eb57ea1a8b98417df6e880
+          ref: 1f553d9237f368926a15439bdb29e4482983e117
           path: system-integration
 
       - uses: actions/setup-python@v5

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -281,7 +281,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: F1R3FLY-io/system-integration
-          ref: 41bb7cbc315294f1a0e9828cf5cbb19136841701
+          ref: 953582825cfe1b6238eb57ea1a8b98417df6e880
           path: system-integration
 
       - uses: actions/setup-python@v5
@@ -357,6 +357,7 @@ jobs:
             integration-tests/test/test_bridge_admin.py \
             integration-tests/test/test_shard_degradation.py \
             integration-tests/test/test_consensus_health.py \
+            integration-tests/test/test_websocket.py \
             integration-tests/test/test_synchrony_constraint.py \
             integration-tests/test/test_asymmetric_bonds.py \
             integration-tests/test/test_bonding_validators.py \

--- a/casper/src/rust/blocks/block_processor.rs
+++ b/casper/src/rust/blocks/block_processor.rs
@@ -16,6 +16,21 @@ use std::sync::Mutex;
 use std::time::Instant;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::rust::block_status::BlockError;
+use crate::rust::engine::block_retriever::{AdmitHashReason, BlockRetriever};
+use crate::rust::metrics_constants::{
+    BLOCK_PROCESSING_STORAGE_TIME_METRIC, BLOCK_PROCESSING_VALIDATION_SETUP_TIME_METRIC,
+    BLOCK_PROCESSOR_METRICS_SOURCE, BLOCK_SIZE_METRIC, BLOCK_VALIDATION_FAILED_METRIC,
+    BLOCK_VALIDATION_SUCCESS_METRIC, BLOCK_VALIDATION_TIME_METRIC,
+};
+use crate::rust::{
+    block_status::InvalidBlock,
+    casper::{Casper, CasperSnapshot},
+    errors::CasperError,
+    util::proto_util,
+    validate::Validate,
+    ValidBlockProcessing,
+};
 use block_storage::rust::dag::block_dag_key_value_storage::BlockDagKeyValueStorage;
 use block_storage::rust::{
     casperbuffer::casper_buffer_key_value_storage::CasperBufferKeyValueStorage,
@@ -33,22 +48,6 @@ use models::rust::{
 };
 use prost::Message;
 use rspace_plus_plus::rspace::history::Either;
-use crate::rust::block_status::BlockError;
-use crate::rust::engine::block_retriever::{AdmitHashReason, BlockRetriever};
-use crate::rust::metrics_constants::{
-    BLOCK_PROCESSING_STORAGE_TIME_METRIC,
-    BLOCK_PROCESSING_VALIDATION_SETUP_TIME_METRIC, BLOCK_PROCESSOR_METRICS_SOURCE,
-    BLOCK_SIZE_METRIC, BLOCK_VALIDATION_FAILED_METRIC, BLOCK_VALIDATION_SUCCESS_METRIC,
-    BLOCK_VALIDATION_TIME_METRIC,
-};
-use crate::rust::{
-    block_status::InvalidBlock,
-    casper::{Casper, CasperSnapshot},
-    errors::CasperError,
-    util::proto_util,
-    validate::Validate,
-    ValidBlockProcessing,
-};
 
 /// Logic for processing incoming blocks
 /// Blocks created by node itself are not held here, but in Proposer.
@@ -87,6 +86,7 @@ fn maybe_trim_allocator_after_block() {
 
     #[cfg(all(target_os = "linux", target_env = "gnu"))]
     {
+        use crate::rust::metrics_constants::ALLOCATOR_TRIM_TOTAL_METRIC;
         // Best-effort return of free heap pages to OS to limit RSS ratcheting.
         unsafe {
             let _ = malloc_trim(0);
@@ -95,7 +95,6 @@ fn maybe_trim_allocator_after_block() {
             .increment(1);
     }
 }
-
 
 impl<T: TransportLayer + Send + Sync> BlockProcessor<T> {
     pub fn new(dependencies: BlockProcessorDependencies<T>) -> Self {
@@ -300,9 +299,7 @@ impl<T: TransportLayer + Send + Sync> BlockProcessor<T> {
                             )
                             .await
                     }
-                    _ => {
-                        Ok(snapshot.dag.clone())
-                    }
+                    _ => Ok(snapshot.dag.clone()),
                 }
             }
         }?;

--- a/casper/src/rust/blocks/block_processor.rs
+++ b/casper/src/rust/blocks/block_processor.rs
@@ -36,7 +36,7 @@ use rspace_plus_plus::rspace::history::Either;
 use crate::rust::block_status::BlockError;
 use crate::rust::engine::block_retriever::{AdmitHashReason, BlockRetriever};
 use crate::rust::metrics_constants::{
-    ALLOCATOR_TRIM_TOTAL_METRIC, BLOCK_PROCESSING_STORAGE_TIME_METRIC,
+    BLOCK_PROCESSING_STORAGE_TIME_METRIC,
     BLOCK_PROCESSING_VALIDATION_SETUP_TIME_METRIC, BLOCK_PROCESSOR_METRICS_SOURCE,
     BLOCK_SIZE_METRIC, BLOCK_VALIDATION_FAILED_METRIC, BLOCK_VALIDATION_SUCCESS_METRIC,
     BLOCK_VALIDATION_TIME_METRIC,

--- a/casper/src/rust/engine/casper_launch.rs
+++ b/casper/src/rust/engine/casper_launch.rs
@@ -555,7 +555,7 @@ impl<T: TransportLayer + Send + Sync + Clone + 'static> CasperLaunchImpl<T> {
             self.conf.genesis_block_data.pos_multi_sig_quorum,
             &mut *self.runtime_manager.lock().await,
             self.last_approved_block.clone(),
-            None, // event_log
+            Some(self.event_publisher.clone()),
             self.transport_layer.clone(),
             Arc::new(self.connections_cell.clone()),
             Arc::new(self.rp_conf_ask.clone()),

--- a/casper/src/rust/engine/casper_launch.rs
+++ b/casper/src/rust/engine/casper_launch.rs
@@ -167,7 +167,8 @@ impl<T: TransportLayer + Send + Sync + Clone + 'static> CasperLaunchImpl<T> {
             synchrony_recovery_cooldown: conf.synchrony_recovery_cooldown,
             synchrony_recovery_max_bypasses: conf.synchrony_recovery_max_bypasses,
             synchrony_finalized_baseline_enabled: conf.synchrony_finalized_baseline_enabled,
-            synchrony_finalized_baseline_max_distance: conf.synchrony_finalized_baseline_max_distance,
+            synchrony_finalized_baseline_max_distance: conf
+                .synchrony_finalized_baseline_max_distance,
             max_user_deploys_per_block: conf.max_user_deploys_per_block,
         };
 

--- a/casper/src/rust/test_utils/helper/test_node.rs
+++ b/casper/src/rust/test_utils/helper/test_node.rs
@@ -1060,7 +1060,7 @@ impl TestNode {
         let clique_oracle = CliqueOracleImpl;
         let estimator = Estimator::apply(max_number_of_parents, max_parent_depth);
         let rp_conf = create_rp_conf_ask(current_peer_node.clone(), None, None);
-        let event_publisher = F1r3flyEvents::new(None);
+        let event_publisher = F1r3flyEvents::new();
         // Scala: implicit val requestedBlocks: RequestedBlocks[F] = Ref.unsafe[F, Map[BlockHash, RequestState]](Map.empty)
         let requested_blocks = Arc::new(Mutex::new(HashMap::<BlockHash, RequestState>::new()));
         // Scala: implicit val blockRetriever: BlockRetriever[F] = BlockRetriever.of[F]

--- a/casper/tests/engine/approve_block_protocol_test.rs
+++ b/casper/tests/engine/approve_block_protocol_test.rs
@@ -35,7 +35,7 @@ use crate::util::genesis_builder::GenesisBuilder;
 // An isolated test fixture created for each test
 struct TestFixture {
     protocol: Arc<ApproveBlockProtocolImpl<TransportLayerStub>>,
-    event_log: Arc<F1r3flyEvents>,
+    collected_events: shared::rust::shared::f1r3fly_events::StartupBuffer,
     transport: Arc<TransportLayerStub>,
     candidate: ApprovedBlockCandidate,
     last_approved_block:
@@ -50,9 +50,12 @@ impl TestFixture {
         key_pairs: Vec<(PrivateKey, PublicKey)>,
     ) -> Self {
         let genesis_block = GenesisBuilder::build_test_genesis(key_pairs.clone());
-        let event_log = Arc::new(F1r3flyEvents::new(Some(100)));
+        let event_log = Arc::new(F1r3flyEvents::new());
         let transport = Arc::new(TransportLayerStub::new());
         let last_approved_block = Arc::new(Mutex::new(None));
+
+        // Use the startup buffer to read published events (no race condition)
+        let collected_events = event_log.startup_buffer();
 
         let test_peer = PeerNode {
             id: NodeIdentifier {
@@ -96,16 +99,18 @@ impl TestFixture {
 
         Self {
             protocol: Arc::new(protocol_impl),
-            event_log,
+            collected_events,
             transport,
             candidate,
             last_approved_block,
         }
     }
 
-    // Isolated event verification using the new get_events() method
+    // Verify published events by name and expected count.
+    // Reads from the startup buffer which captures all events synchronously.
     fn events_contain(&self, event_name: &str, expected_count: usize) -> bool {
-        let events = self.event_log.get_events();
+        let guard = self.collected_events.lock().unwrap();
+        let events = guard.as_ref().map(|v| v.as_slice()).unwrap_or(&[]);
         let actual_count = events
             .iter()
             .filter(|event| match event {

--- a/casper/tests/engine/genesis_validator_spec.rs
+++ b/casper/tests/engine/genesis_validator_spec.rs
@@ -1,5 +1,4 @@
 // See casper/src/test/scala/coop/rchain/casper/engine/GenesisValidatorSpec.scala
-use shared::rust::shared::f1r3fly_events::{EventPublisher, EventPublisherFactory};
 
 use crate::engine::setup::TestFixture;
 use casper::rust::engine::block_approver_protocol::BlockApproverProtocol;
@@ -15,10 +14,6 @@ use tokio::time::{sleep, Duration};
 struct GenesisValidatorSpec;
 
 impl GenesisValidatorSpec {
-    fn event_bus() -> Box<dyn EventPublisher> {
-        EventPublisherFactory::noop()
-    }
-
     // TODO should be moved to Rust BlockApproverProtocolTest.createUnapproved, when BlockApproverProtocolTest will be created
     fn create_unapproved(required_sigs: i32, block: &BlockMessage) -> UnapprovedBlock {
         UnapprovedBlock {
@@ -32,7 +27,7 @@ impl GenesisValidatorSpec {
     }
 
     async fn respond_on_unapproved_block_messages_with_block_approval() {
-        let _event_bus = Self::event_bus();
+        let _event_bus = shared::rust::shared::f1r3fly_events::F1r3flyEvents::new();
 
         let fixture = TestFixture::new().await;
 
@@ -130,7 +125,7 @@ impl GenesisValidatorSpec {
     }
 
     async fn should_not_respond_to_any_other_message() {
-        let _event_bus = Self::event_bus();
+        let _event_bus = shared::rust::shared::f1r3fly_events::F1r3flyEvents::new();
 
         let fixture = TestFixture::new().await;
 

--- a/casper/tests/engine/initializing_spec.rs
+++ b/casper/tests/engine/initializing_spec.rs
@@ -10,6 +10,11 @@ use std::sync::{
 };
 use tokio::sync::mpsc;
 
+use crate::engine::setup::TestFixture;
+use casper::rust::engine::engine::transition_to_initializing;
+use casper::rust::engine::engine_cell::EngineCell;
+use casper::rust::engine::initializing::Initializing;
+use casper::rust::engine::lfs_tuple_space_requester;
 use crypto::rust::{
     hash::blake2b256::Blake2b256,
     signatures::{secp256k1::Secp256k1, signatures_alg::SignaturesAlg},
@@ -22,11 +27,6 @@ use models::rust::casper::protocol::casper_message::{
 };
 use prost::bytes::Bytes;
 use prost::Message;
-use crate::engine::setup::TestFixture;
-use casper::rust::engine::engine::transition_to_initializing;
-use casper::rust::engine::engine_cell::EngineCell;
-use casper::rust::engine::initializing::Initializing;
-use casper::rust::engine::lfs_tuple_space_requester;
 
 use casper::rust::errors::CasperError;
 use comm::rust::rp::protocol_helper::packet_with_content;

--- a/casper/tests/engine/initializing_spec.rs
+++ b/casper/tests/engine/initializing_spec.rs
@@ -22,8 +22,6 @@ use models::rust::casper::protocol::casper_message::{
 };
 use prost::bytes::Bytes;
 use prost::Message;
-use shared::rust::shared::f1r3fly_events::{EventPublisher, EventPublisherFactory};
-
 use crate::engine::setup::TestFixture;
 use casper::rust::engine::engine::transition_to_initializing;
 use casper::rust::engine::engine_cell::EngineCell;
@@ -41,10 +39,6 @@ use shared::rust::ByteVector;
 struct InitializingSpec;
 
 impl InitializingSpec {
-    fn event_bus() -> Box<dyn EventPublisher> {
-        EventPublisherFactory::noop()
-    }
-
     fn before_each(fixture: &TestFixture) {
         fixture
             .transport_layer
@@ -55,7 +49,7 @@ impl InitializingSpec {
         fixture.transport_layer.reset();
     }
     async fn make_transition_to_running_once_approved_block_received() {
-        let _event_bus = Self::event_bus();
+        let _event_bus = shared::rust::shared::f1r3fly_events::F1r3flyEvents::new();
 
         let fixture = TestFixture::new().await;
 

--- a/casper/tests/engine/setup.rs
+++ b/casper/tests/engine/setup.rs
@@ -446,7 +446,7 @@ impl TestFixture {
 
         // NOT in Scala Setup - created locally in each test as: implicit val eventBus = EventPublisher.noop[Task]
         // Rust: Create F1r3flyEvents with default capacity (equivalent to noop for tests)
-        let event_publisher = F1r3flyEvents::default();
+        let event_publisher = F1r3flyEvents::new();
 
         // TODO NOT in Scala Setup - created locally in each test as: implicit val engineCell = Cell.unsafe[Task, Engine[Task]](Engine.noop)
         // Rust: Create EngineCell with Engine::noop (equivalent to Scala)

--- a/casper/tests/helper/test_node.rs
+++ b/casper/tests/helper/test_node.rs
@@ -925,7 +925,7 @@ impl TestNode {
         let _clique_oracle = CliqueOracleImpl;
         let estimator = Estimator::apply(max_number_of_parents, max_parent_depth);
         let rp_conf = create_rp_conf_ask(current_peer_node.clone(), None, None);
-        let event_publisher = F1r3flyEvents::new(None);
+        let event_publisher = F1r3flyEvents::new();
         // Scala: implicit val requestedBlocks: RequestedBlocks[F] = Ref.unsafe[F, Map[BlockHash, RequestState]](Map.empty)
         let requested_blocks = Arc::new(Mutex::new(HashMap::<BlockHash, RequestState>::new()));
         // Scala: implicit val blockRetriever: BlockRetriever[F] = BlockRetriever.of[F]

--- a/docs/README.md
+++ b/docs/README.md
@@ -117,6 +117,7 @@ The Cargo workspace contains 11 crates:
 
 | Document | Description |
 |----------|-------------|
+| [WebSocket Events](./node/websocket-events.md) | `/ws/events` endpoint: 9 event types, startup replay, payload schemas |
 | [Docker Setup](../docker/README.md) | Docker compose for shard, standalone, monitoring |
 | [RNode API](./rnode-api/) | Protocol Buffer API documentation |
 | [LFS Requester Architecture](./plans/lfs_tuple_space_requester_concurrency_architecture.md) | LFS tuple space concurrency design |

--- a/docs/node/README.md
+++ b/docs/node/README.md
@@ -91,6 +91,14 @@ CLI flags are applied to the parsed `NodeConf` by `config_mapper.rs`:
 | 40403 | Public REST (deploy, blocks, finalization, transactions) via Axum |
 | 40405 | Admin (propose, propose_result) |
 
+## WebSocket Events
+
+The `/ws/events` endpoint on the HTTP port (40403) streams real-time node events. See [websocket-events.md](websocket-events.md) for full documentation.
+
+9 event types are streamed: 3 block lifecycle (`block-created`, `block-added`, `block-finalised`), 4 genesis ceremony (`sent-unapproved-block`, `block-approval-received`, `sent-approved-block`, `approved-block-received`), and 2 node lifecycle (`entered-running-state`, `node-started`).
+
+Events published during startup are buffered and replayed to clients that connect after the node is running. The buffer is sealed when engine initialization completes.
+
 ## API Server Startup
 
 `bind_tcp_listener_with_retry()` in `servers_instances.rs` handles `AddrInUse` resilience for HTTP/Admin servers: 60 attempts with 500ms delay between retries.

--- a/docs/node/websocket-events.md
+++ b/docs/node/websocket-events.md
@@ -1,0 +1,90 @@
+# WebSocket Event Streaming
+
+The node streams real-time events to clients via the `/ws/events` WebSocket endpoint.
+
+## Connection
+
+```
+ws://<host>:<http-port>/ws/events
+```
+
+On connect, the server sends:
+1. A `started` handshake: `{"event": "started", "schema-version": 1}`
+2. Buffered startup events (replayed from the startup buffer)
+3. Live events as they occur
+
+Startup events that fired before the client connected are replayed from an in-memory buffer. The buffer is sealed when the node reaches Running state, after which only live events are streamed.
+
+## Event Types
+
+All events use the envelope format:
+
+```json
+{
+  "event": "<event-type>",
+  "schema-version": 1,
+  "payload": { ... }
+}
+```
+
+### Block Lifecycle
+
+These fire continuously as the node processes blocks.
+
+| Event | Description | Payload |
+|-------|-------------|---------|
+| `block-created` | Block proposed by this validator (before validation) | block-hash, parent-hashes, justification-hashes, deploys, creator, seq-num |
+| `block-added` | Block validated and added to DAG | Same as block-created |
+| `block-finalised` | Block finalized by consensus | Same as block-created |
+
+The `deploys` array contains objects with `id`, `cost`, `deployer`, and `errored` fields.
+
+### Genesis Ceremony
+
+These fire once during node startup when the genesis block is being created and approved.
+
+| Event | Description | Payload |
+|-------|-------------|---------|
+| `sent-unapproved-block` | Boot node broadcasts genesis candidate | block-hash |
+| `block-approval-received` | Boot node receives approval from a validator | block-hash, sender |
+| `sent-approved-block` | Boot node broadcasts the approved genesis block | block-hash |
+| `approved-block-received` | Validator receives the approved genesis block | block-hash |
+
+### Node Lifecycle
+
+| Event | Description | Payload |
+|-------|-------------|---------|
+| `entered-running-state` | Engine transitions from Initializing to Running | block-hash |
+| `node-started` | HTTP/gRPC servers are ready | address |
+
+## Startup Event Replay
+
+Events published during startup (before any WebSocket client can connect) are buffered in memory. When a client connects, these events are replayed before entering the live stream. The buffer is sealed when the engine completes initialization.
+
+This ensures clients receive the full node lifecycle regardless of when they connect:
+- `node-started` (HTTP server ready)
+- Genesis ceremony events (`sent-unapproved-block`, `block-approval-received`, etc.)
+- `entered-running-state` (node is operational)
+
+Events that arrive both via replay and live stream are deduplicated.
+
+## Publish Sites
+
+| Event | Source File |
+|-------|------------|
+| `block-created` | `casper/src/rust/blocks/proposer/proposer.rs` |
+| `block-added` | `casper/src/rust/multi_parent_casper_impl.rs` |
+| `block-finalised` | `casper/src/rust/multi_parent_casper_impl.rs` |
+| `sent-unapproved-block` | `casper/src/rust/engine/approve_block_protocol.rs` |
+| `block-approval-received` | `casper/src/rust/engine/approve_block_protocol.rs` |
+| `sent-approved-block` | `casper/src/rust/engine/approve_block_protocol.rs` |
+| `approved-block-received` | `casper/src/rust/engine/initializing.rs` |
+| `entered-running-state` | `casper/src/rust/engine/engine.rs` |
+| `node-started` | `node/src/rust/runtime/node_runtime.rs` |
+
+## Implementation
+
+- **Event bus**: `shared/src/rust/shared/f1r3fly_events.rs` — `F1r3flyEvents` struct with tokio broadcast channel (capacity 100) and startup buffer
+- **Event types**: `shared/src/rust/shared/f1r3fly_event.rs` — `F1r3flyEvent` enum with 9 variants
+- **WebSocket handler**: `node/src/rust/web/events_info.rs` — handles connection, replay, dedup, and live streaming
+- **Startup seal**: `node/src/rust/runtime/node_runtime.rs` — calls `seal_startup()` after engine_init completes

--- a/docs/shared/README.md
+++ b/docs/shared/README.md
@@ -42,7 +42,8 @@ The KV store layer is the persistence backbone of the entire system.
 ## Other Modules
 
 - `compression.rs` -- LZ4 compression/decompression
-- `f1r3fly_event.rs` / `f1r3fly_events.rs` -- Event data structures
+- `f1r3fly_event.rs` -- 9 event types for WebSocket streaming (block lifecycle, genesis ceremony, node lifecycle)
+- `f1r3fly_events.rs` -- Event bus with broadcast channel and startup replay buffer (see [WebSocket Events](../node/websocket-events.md))
 - `grpc_server.rs` -- gRPC server utilities
 - `metrics_constants.rs` / `metrics_semaphore.rs` -- Observability
 - `env.rs` -- Environment variable parsing utilities (`var_parsed`, `var_or`, `var_bool`)

--- a/node/src/rust/runtime/node_runtime.rs
+++ b/node/src/rust/runtime/node_runtime.rs
@@ -222,11 +222,14 @@ impl NodeRuntime {
 
         info!("NodeDiscovery initialized");
 
-        // Create event bus with circular buffer (capacity: 1)
+        // Create event bus backed by a broadcast channel (capacity: 100).
+        // Events published during startup are buffered for replay to
+        // late-connecting WebSocket clients. The buffer is sealed when
+        // engine_init completes (see the tokio::select! loop below).
         let event_bus = {
             use shared::rust::shared::f1r3fly_events::F1r3flyEvents;
 
-            F1r3flyEvents::new(Some(1))
+            F1r3flyEvents::new()
         };
 
         info!("Event bus (F1r3flyEvents) initialized");
@@ -481,6 +484,7 @@ impl NodeRuntime {
             node_discovery.clone(),
             block_report_api,
             event_stream,
+            event_bus.startup_buffer(),
             kademlia_store.clone(),
         )
         .await?;
@@ -495,6 +499,9 @@ impl NodeRuntime {
             .map_err(|e| eyre::eyre!("Failed to publish NodeStarted event: {}", e))?;
 
         info!("NodeStarted event published: {}", address);
+
+        // Keep a reference for sealing the startup buffer after engine_init
+        let event_bus_for_seal = event_bus.clone();
 
         // Start all concurrent tasks with categorized failure handling
         // Critical tasks: Failure triggers immediate shutdown
@@ -806,9 +813,11 @@ impl NodeRuntime {
                 }, if engine_init_handler.is_some() => {
                     match result {
                         Some(Ok(Ok(_))) => {
+                            event_bus_for_seal.seal_startup();
                             continue;
                         }
                         Some(Ok(Err(e))) => {
+                            event_bus_for_seal.seal_startup();
                             tracing::error!("Engine initialization failed: {}", e);
                             // Engine init failure is critical - trigger shutdown
                             break;

--- a/node/src/rust/runtime/servers_instances.rs
+++ b/node/src/rust/runtime/servers_instances.rs
@@ -109,6 +109,7 @@ impl ServersInstances {
     /// * `node_discovery` - Node discovery service (needed for AppState)
     /// * `block_report_api` - Block report API (needed for AppState)
     /// * `event_stream` - Event stream (needed for AppState)
+    /// * `startup_events` - Startup event buffer for WebSocket replay
     /// * `kademlia_store` - Kademlia store (needed for Kademlia server)
     pub async fn build<T: KademliaRPC + Send + Sync + 'static>(
         api_servers: APIServers,
@@ -124,6 +125,7 @@ impl ServersInstances {
         node_discovery: Arc<dyn NodeDiscovery + Send + Sync>,
         block_report_api: Arc<casper::rust::api::block_report_api::BlockReportAPI>,
         event_stream: EventStream,
+        startup_events: shared::rust::shared::f1r3fly_events::StartupBuffer,
         kademlia_store: Arc<KademliaStore<T>>,
     ) -> eyre::Result<Self> {
         // Read current RPConf
@@ -257,6 +259,7 @@ impl ServersInstances {
             Arc::new(rp_connections),
             node_discovery.clone(),
             Arc::new(event_stream.new_subscribe()),
+            startup_events,
         );
 
         // Create HTTP server router

--- a/node/src/rust/web/events_info.rs
+++ b/node/src/rust/web/events_info.rs
@@ -9,14 +9,24 @@ use axum::{
 };
 use futures::StreamExt;
 use serde_json::{json, Value};
+use std::collections::HashSet;
 
-use shared::rust::shared::{f1r3fly_event::F1r3flyEvent, f1r3fly_events::EventStream};
+use shared::rust::shared::{
+    f1r3fly_event::F1r3flyEvent,
+    f1r3fly_events::{EventStream, StartupBuffer},
+};
 
 use crate::rust::web::shared_handlers::AppState;
 
-// TODO: This implementation differs from the Scala code in the main branch.
-// The main trade-off is that we are transforming events in every tokio task.
-// Instead it would be great if we could transform events in a single tokio task and then broadcast them to all websocket handlers.
+/// WebSocket event handler for /ws/events endpoint.
+///
+/// On client connect:
+/// 1. Sends a "started" handshake event
+/// 2. Replays buffered startup events (node-started, genesis ceremony, etc.)
+/// 3. Enters live stream from the broadcast channel
+///
+/// Startup events are deduplicated — events that were both buffered and
+/// received live are sent only once.
 pub struct EventsInfo;
 
 impl EventsInfo {
@@ -24,7 +34,11 @@ impl EventsInfo {
         Router::new().route("/", get(events_info_handler))
     }
 
-    async fn handle_websocket(mut socket: WebSocket, mut event_stream: EventStream) {
+    async fn handle_websocket(
+        mut socket: WebSocket,
+        mut event_stream: EventStream,
+        startup_buffer: StartupBuffer,
+    ) {
         // Send initial "started" event
         let started = json!({
             "event": "started",
@@ -34,31 +48,64 @@ impl EventsInfo {
             let _ = socket.send(Message::Text(msg.into())).await;
         }
 
+        // Replay buffered startup events.
+        // The broadcast subscription was created before we read the buffer,
+        // so events published between subscribe and buffer-read will appear
+        // in both. Track replayed event fingerprints to deduplicate.
+        let mut replayed: HashSet<String> = HashSet::new();
+        let buffered = startup_buffer
+            .lock()
+            .ok()
+            .and_then(|guard| guard.as_ref().cloned())
+            .unwrap_or_default();
+
+        for event in &buffered {
+            if let Ok(json) = Self::transform_f1r3fly_event(event) {
+                if let Ok(serialized) = serde_json::to_string(&json) {
+                    replayed.insert(serialized.clone());
+                    let message = Message::Text(serialized.into());
+                    if socket.send(message).await.is_err() {
+                        tracing::debug!("WebSocket client disconnected during startup replay");
+                        return;
+                    }
+                }
+            }
+        }
+
+        if !buffered.is_empty() {
+            tracing::debug!("Replayed {} startup events to WebSocket client", buffered.len());
+        }
+
+        // Live stream — skip events that were already replayed.
+        // Once the replayed set is drained, all events pass through.
         while let Some(event) = event_stream.next().await {
-            if let Err(e) = Self::send_event_to_websocket(&mut socket, &event).await {
-                tracing::debug!("WebSocket client disconnected: {}", e);
+            let json = match Self::transform_f1r3fly_event(&event) {
+                Ok(j) => j,
+                Err(e) => {
+                    tracing::debug!("Failed to transform event: {}", e);
+                    continue;
+                }
+            };
+
+            let serialized = match serde_json::to_string(&json) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::debug!("Failed to serialize event: {}", e);
+                    continue;
+                }
+            };
+
+            // Deduplicate against replayed startup events
+            if !replayed.is_empty() && replayed.remove(&serialized) {
+                continue;
+            }
+
+            let message = Message::Text(serialized.into());
+            if socket.send(message).await.is_err() {
+                tracing::debug!("WebSocket client disconnected");
                 break;
             }
         }
-    }
-
-    async fn send_event_to_websocket(
-        socket: &mut WebSocket,
-        event: &F1r3flyEvent,
-    ) -> Result<(), String> {
-        let json = Self::transform_f1r3fly_event(event)
-            .map_err(|e| format!("Failed to transform event: {}", e))?;
-
-        let message_str =
-            serde_json::to_string(&json).map_err(|e| format!("Failed to serialize JSON: {}", e))?;
-
-        let message = Message::Text(message_str.into());
-        socket
-            .send(message)
-            .await
-            .map_err(|e| format!("Failed to send message: {}", e))?;
-
-        Ok(())
     }
 
     // Transforms an F1r3flyEvent into a JSON structure matching the Scala implementation
@@ -103,8 +150,13 @@ pub async fn events_info_handler(
     ws: WebSocketUpgrade,
     State(app_state): State<AppState>,
 ) -> Response {
+    let startup_events = app_state.startup_events.clone();
     ws.on_upgrade(move |socket| {
-        EventsInfo::handle_websocket(socket, app_state.event_stream.new_subscribe())
+        EventsInfo::handle_websocket(
+            socket,
+            app_state.event_stream.new_subscribe(),
+            startup_events,
+        )
     })
 }
 

--- a/node/src/rust/web/events_info.rs
+++ b/node/src/rust/web/events_info.rs
@@ -73,7 +73,10 @@ impl EventsInfo {
         }
 
         if !buffered.is_empty() {
-            tracing::debug!("Replayed {} startup events to WebSocket client", buffered.len());
+            tracing::debug!(
+                "Replayed {} startup events to WebSocket client",
+                buffered.len()
+            );
         }
 
         // Live stream — skip events that were already replayed.

--- a/node/src/rust/web/shared_handlers.rs
+++ b/node/src/rust/web/shared_handlers.rs
@@ -16,7 +16,7 @@ use axum::{
 };
 use casper::rust::api::block_report_api::BlockReportAPI;
 use comm::rust::{discovery::node_discovery::NodeDiscovery, rp::connect::ConnectionsCell};
-use shared::rust::shared::f1r3fly_events::EventStream;
+use shared::rust::shared::f1r3fly_events::{EventStream, StartupBuffer};
 use tracing::warn;
 
 #[derive(Clone)]
@@ -28,6 +28,7 @@ pub struct AppState {
     pub connections_cell: Arc<ConnectionsCell>,
     pub node_discovery: Arc<dyn NodeDiscovery + Send + Sync + 'static>,
     pub event_stream: Arc<EventStream>,
+    pub startup_events: StartupBuffer,
 }
 
 impl AppState {
@@ -39,6 +40,7 @@ impl AppState {
         connections_cell: Arc<ConnectionsCell>,
         node_discovery: Arc<dyn NodeDiscovery + Send + Sync + 'static>,
         event_consumer: Arc<EventStream>,
+        startup_events: StartupBuffer,
     ) -> Self {
         Self {
             admin_web_api,
@@ -48,6 +50,7 @@ impl AppState {
             connections_cell,
             node_discovery,
             event_stream: event_consumer,
+            startup_events,
         }
     }
 }

--- a/shared/src/rust/shared/f1r3fly_event.rs
+++ b/shared/src/rust/shared/f1r3fly_event.rs
@@ -1,4 +1,5 @@
-// See shared/src/main/scala/coop/rchain/shared/RChainEvent.scala
+// F1r3flyEvent — node event types for WebSocket streaming.
+// Ported from shared/src/main/scala/coop/rchain/shared/RChainEvent.scala
 
 use serde::{Deserialize, Serialize};
 

--- a/shared/src/rust/shared/f1r3fly_events.rs
+++ b/shared/src/rust/shared/f1r3fly_events.rs
@@ -13,15 +13,16 @@ pub use super::f1r3fly_event::F1r3flyEvent;
 
 /// Shared startup event buffer type.
 /// `Some(vec)` during startup — events accumulate.
-/// `None` after `seal_startup()` — no more buffering.
+/// `Some(vec)` after `seal_startup()` — frozen for replay, no new appends.
 pub type StartupBuffer = Arc<Mutex<Option<Vec<F1r3flyEvent>>>>;
 
 /// Structure to publish and consume F1r3flyEvents.
 ///
 /// During startup, published events are buffered so that WebSocket clients
 /// connecting after startup can receive a replay of events they missed.
-/// Call `seal_startup()` once the node reaches Running state to stop
-/// buffering and free the memory.
+/// Call `seal_startup()` once the node reaches Running state to freeze
+/// the buffer. Events remain available for replay but no new events are
+/// appended.
 #[derive(Clone)]
 pub struct F1r3flyEvents {
     sender: broadcast::Sender<F1r3flyEvent>,
@@ -57,8 +58,9 @@ impl F1r3flyEvents {
         Ok(())
     }
 
-    /// Seal the startup buffer. After this call, no more events are
-    /// buffered and `publish()` skips the lock entirely.
+    /// Seal the startup buffer. After this call, no new events are
+    /// appended — `publish()` skips the lock entirely via the atomic flag.
+    /// Buffered events remain available for replay to late-connecting clients.
     /// Called once when the node transitions to Running state.
     pub fn seal_startup(&self) {
         self.startup_sealed.store(true, Ordering::Release);

--- a/shared/src/rust/shared/f1r3fly_events.rs
+++ b/shared/src/rust/shared/f1r3fly_events.rs
@@ -1,8 +1,9 @@
-// See node/src/main/scala/coop/rchain/node/effects/RchainEvents.scala
+// F1r3flyEvents — event publishing with startup replay buffer.
+// Ported from node/src/main/scala/coop/rchain/node/effects/RchainEvents.scala
 
 use futures::stream::Stream;
-use std::collections::VecDeque;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 use tokio::sync::broadcast;
@@ -10,75 +11,67 @@ use tokio_stream::wrappers::BroadcastStream;
 
 pub use super::f1r3fly_event::F1r3flyEvent;
 
-/// EventPublisher trait for publishing F1r3flyEvents
-pub trait EventPublisher: Send + Sync {
-    fn publish(&self, event: F1r3flyEvent) -> Result<(), String>;
-}
+/// Shared startup event buffer type.
+/// `Some(vec)` during startup — events accumulate.
+/// `None` after `seal_startup()` — no more buffering.
+pub type StartupBuffer = Arc<Mutex<Option<Vec<F1r3flyEvent>>>>;
 
-/// Factory for creating EventPublisher instances
-pub struct EventPublisherFactory;
-
-impl EventPublisherFactory {
-    pub fn noop() -> Box<dyn EventPublisher> {
-        Box::new(NoopEventPublisher)
-    }
-}
-
-/// No-op implementation of EventPublisher for testing
-struct NoopEventPublisher;
-
-impl EventPublisher for NoopEventPublisher {
-    fn publish(&self, _event: F1r3flyEvent) -> Result<(), String> {
-        // Do nothing - this is the no-op implementation
-        Ok(())
-    }
-}
-
-/// Structure to publish and consume F1r3flyEvents
+/// Structure to publish and consume F1r3flyEvents.
+///
+/// During startup, published events are buffered so that WebSocket clients
+/// connecting after startup can receive a replay of events they missed.
+/// Call `seal_startup()` once the node reaches Running state to stop
+/// buffering and free the memory.
 #[derive(Clone)]
 pub struct F1r3flyEvents {
-    queue: Arc<Mutex<VecDeque<F1r3flyEvent>>>, // TODO: this queue is not used by the consumer, so maybe it should be removed.
-    capacity: usize,
     sender: broadcast::Sender<F1r3flyEvent>,
+    startup_sealed: Arc<AtomicBool>,
+    startup_buffer: StartupBuffer,
 }
 
 impl F1r3flyEvents {
-    /// Create a new F1r3flyEvents with a circular buffer.
-    /// Default capacity is 100 to prevent event dropping.
-    pub fn new(capacity: Option<usize>) -> Self {
-        let capacity = capacity.unwrap_or(100);
+    /// Create a new F1r3flyEvents backed by a broadcast channel.
+    /// The startup buffer is active from creation until `seal_startup()`.
+    pub fn new() -> Self {
         let (sender, _) = broadcast::channel(100);
-
         F1r3flyEvents {
-            queue: Arc::new(Mutex::new(VecDeque::with_capacity(capacity))),
-            capacity,
             sender,
+            startup_sealed: Arc::new(AtomicBool::new(false)),
+            startup_buffer: Arc::new(Mutex::new(Some(Vec::new()))),
         }
     }
 
-    /// Create a new F1r3flyEvents with default capacity of 1
-    pub fn default() -> Self {
-        Self::new(None)
-    }
-
-    /// Publish an event
+    /// Publish an event to all active subscribers.
+    /// If the startup buffer is still open, the event is also buffered
+    /// for replay to late-connecting WebSocket clients.
     pub fn publish(&self, event: F1r3flyEvent) -> Result<(), String> {
-        let mut queue = match self.queue.lock() {
-            Ok(queue) => queue,
-            Err(_) => return Err("Failed to acquire lock on event queue".to_string()),
-        };
-
-        // If queue is full, remove oldest event (circular buffer behavior)
-        if queue.len() >= self.capacity {
-            queue.pop_front();
+        if !self.startup_sealed.load(Ordering::Acquire) {
+            if let Ok(mut guard) = self.startup_buffer.lock() {
+                if let Some(ref mut buf) = *guard {
+                    buf.push(event.clone());
+                }
+            }
         }
-
-        queue.push_back(event.clone());
-
-        // Broadcast to all consumers
-        let _ = self.sender.send(event);
-
+        let receivers = self.sender.send(event).unwrap_or(0);
+        tracing::trace!("Event published to {} receivers", receivers);
         Ok(())
+    }
+
+    /// Seal the startup buffer. After this call, no more events are
+    /// buffered and `publish()` skips the lock entirely.
+    /// Called once when the node transitions to Running state.
+    pub fn seal_startup(&self) {
+        self.startup_sealed.store(true, Ordering::Release);
+        if let Ok(guard) = self.startup_buffer.lock() {
+            let count = guard.as_ref().map_or(0, |v| v.len());
+            tracing::info!("Startup event buffer sealed ({} events)", count);
+        }
+    }
+
+    /// Get a shared reference to the startup buffer.
+    /// Pass this to AppState so the WebSocket handler can replay events.
+    pub fn startup_buffer(&self) -> StartupBuffer {
+        self.startup_buffer.clone()
     }
 
     /// Publish a noop event
@@ -92,12 +85,6 @@ impl F1r3flyEvents {
             sender: self.sender.clone(),
             inner: BroadcastStream::new(self.sender.subscribe()),
         }
-    }
-
-    /// Get all events currently in the queue.
-    /// NOTE: This is intended for testing purposes.
-    pub fn get_events(&self) -> Vec<F1r3flyEvent> {
-        self.queue.lock().unwrap().iter().cloned().collect()
     }
 }
 
@@ -140,6 +127,7 @@ impl Stream for EventStream {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
     use std::time::Duration;
 
     use super::super::f1r3fly_event::{BlockAdded, BlockCreated, BlockFinalised, DeployEvent};
@@ -194,7 +182,7 @@ mod tests {
         let start = std::time::Instant::now();
 
         let result = tokio::time::timeout(Duration::from_secs(2), async {
-            let events = Arc::new(F1r3flyEvents::new(Some(2)));
+            let events = Arc::new(F1r3flyEvents::new());
             let mut stream = events.consume();
 
             // Publish event AFTER a delay (from another task)
@@ -239,8 +227,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_circular_buffer_behavior() {
-        // Create events publisher with capacity 2
-        let events = F1r3flyEvents::new(Some(2));
+        let events = F1r3flyEvents::new();
 
         // Get stream first (before publishing)
         let mut stream = events.consume();
@@ -283,8 +270,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_default_capacity() {
-        let events = F1r3flyEvents::default();
+    async fn test_new() {
+        let events = F1r3flyEvents::new();
 
         // Get stream first (before publishing)
         let mut stream = events.consume();
@@ -319,7 +306,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_concurrent_publish_and_consume() {
-        let events = Arc::new(F1r3flyEvents::new(Some(10)));
+        let events = Arc::new(F1r3flyEvents::new());
         let mut handles = vec![];
 
         // Spawn multiple consumers first
@@ -361,5 +348,115 @@ mod tests {
 
         // Each consumer should get all 5 events
         assert_eq!(total_events, 15);
+    }
+
+    #[tokio::test]
+    async fn test_startup_buffer_captures_events() {
+        // Events published before any subscriber should be buffered
+        let events = F1r3flyEvents::new();
+
+        events.publish(create_block_finalised_event()).unwrap();
+        events.publish(create_block_created_event()).unwrap();
+
+        // Buffer should contain both events
+        let buf = events.startup_buffer();
+        let guard = buf.lock().unwrap();
+        let buffered = guard.as_ref().expect("Buffer should be Some");
+        assert_eq!(buffered.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_startup_buffer_survives_seal() {
+        // After seal, buffer data stays available for replay
+        let events = F1r3flyEvents::new();
+
+        events.publish(create_block_finalised_event()).unwrap();
+        events.publish(create_block_created_event()).unwrap();
+        events.seal_startup();
+
+        // Buffer should still contain the events (frozen, not cleared)
+        let buf = events.startup_buffer();
+        let guard = buf.lock().unwrap();
+        let buffered = guard.as_ref().expect("Buffer should be Some after seal");
+        assert_eq!(buffered.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_startup_buffer_stops_appending_after_seal() {
+        let events = F1r3flyEvents::new();
+
+        events.publish(create_block_finalised_event()).unwrap();
+        events.seal_startup();
+        events.publish(create_block_created_event()).unwrap();
+
+        // Only the event before seal should be in the buffer
+        let buf = events.startup_buffer();
+        let guard = buf.lock().unwrap();
+        let buffered = guard.as_ref().expect("Buffer should be Some after seal");
+        assert_eq!(buffered.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_startup_replay_scenario() {
+        // Simulates the full WebSocket startup replay scenario:
+        // 1. Events published during startup (no subscribers)
+        // 2. Subscriber connects and reads buffer
+        // 3. More events arrive via live stream
+        // 4. Seal happens
+        // 5. Late subscriber connects and reads buffer + live
+        let events = Arc::new(F1r3flyEvents::new());
+
+        // Phase 1: Startup events (no subscribers yet)
+        events.publish(create_block_finalised_event()).unwrap();
+
+        // Phase 2: First subscriber connects
+        let mut stream = events.consume();
+        let buf = events.startup_buffer();
+
+        // Read buffer (simulating WebSocket replay)
+        let guard = buf.lock().unwrap();
+        let buffered = guard.as_ref().expect("Buffer should be Some");
+        assert_eq!(buffered.len(), 1);
+        drop(guard);
+
+        // Phase 3: More events arrive — both buffered AND broadcast (pre-seal)
+        events.publish(create_block_created_event()).unwrap();
+        let live_event = stream.next().await.expect("Should receive live event");
+        match live_event {
+            F1r3flyEvent::BlockCreated(BlockCreated { block_hash, .. }) => {
+                assert_eq!(block_hash, "hash456");
+            }
+            _ => panic!("Expected BlockCreated from live stream"),
+        }
+
+        // Buffer now has both events (all pre-seal events are buffered)
+        let guard = buf.lock().unwrap();
+        let buffered = guard.as_ref().expect("Buffer should be Some");
+        assert_eq!(buffered.len(), 2, "Both pre-seal events should be buffered");
+        drop(guard);
+
+        // Phase 4: Seal startup
+        events.seal_startup();
+
+        // Buffer still has both events (frozen, not cleared)
+        let guard = buf.lock().unwrap();
+        let buffered = guard.as_ref().expect("Buffer should survive seal");
+        assert_eq!(buffered.len(), 2);
+        drop(guard);
+
+        // Phase 5: Post-seal events only go to broadcast, not buffer
+        events.publish(create_block_added_event()).unwrap();
+        let post_seal = stream.next().await.expect("Should receive post-seal event");
+        match post_seal {
+            F1r3flyEvent::BlockAdded(BlockAdded { block_hash, .. }) => {
+                assert_eq!(block_hash, "hash789");
+            }
+            _ => panic!("Expected BlockAdded from live stream"),
+        }
+
+        // Buffer still only has the 2 pre-seal events
+        let guard = buf.lock().unwrap();
+        let buffered = guard.as_ref().expect("Buffer should survive seal");
+        assert_eq!(buffered.len(), 2, "Post-seal events should not be buffered");
     }
 }


### PR DESCRIPTION
## Summary

- Buffer startup events and replay them to WebSocket clients on connect
- Fix genesis ceremony events never being published (was passing `None` as event_log)
- Remove dead code (EventPublisher trait, unused queue, stale comments)
- Add WebSocket events documentation

## Changes

### Startup event replay
New WebSocket clients connecting to `/ws/events` now receive all events that occurred during node startup, including `node-started`, genesis ceremony events, and `entered-running-state`. Events are buffered in `F1r3flyEvents` until the engine completes initialization, then frozen for replay. An `AtomicBool` fast-path skips the buffer lock in steady state.

### Bug fix: genesis ceremony events
`casper_launch.rs` was passing `None` for the `event_log` parameter when creating `ApproveBlockProtocolFactory`, so `sent-unapproved-block`, `block-approval-received`, and `sent-approved-block` were never published. Now passes `Some(self.event_publisher.clone())`.

### WebSocket dedup
Events that appear in both the startup buffer and the live broadcast stream are deduplicated — each event is sent to the client exactly once.

### Dead code removed
- `EventPublisher` trait, `EventPublisherFactory`, `NoopEventPublisher` (unused in production, replaced in tests)
- Unused `event_bus()` functions in test specs
- Pre-existing unused import (`ALLOCATOR_TRIM_TOTAL_METRIC`)

### Documentation
- New `docs/node/websocket-events.md` — all 9 event types, payload schemas, replay behavior
- Updated `docs/node/README.md`, `docs/README.md`, `docs/shared/README.md`
- Stale comments updated (`circular buffer` → broadcast channel, Scala references)

### CI
- Updated system-integration ref to include WebSocket integration tests
- Added `test_websocket.py` to integration test list

## Test plan

- [x] `cargo test --release -p shared` — 32 passed (includes 4 new startup buffer tests)
- [x] `cargo test --release -p casper` — 335 passed
- [x] `cargo test --release -p node` — 3 passed
- [x] Zero warnings with `RUSTFLAGS="-D warnings"`
- [x] Integration tests: all 9 event types received on boot + validator1 (system-integration `test_websocket.py`)
- [x] Smoke test: 30/30 pass on both Rust and Scala standalone nodes

Co-Authored-By: Claude <noreply@anthropic.com>