### PR TITLE
fix: correct hash_from_vec causing merge state loss

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,29 @@
 # TODO
 
+## Review: `compute_parents_post_state_regression_spec.rs`
+
+This test file needs review and cleanup:
+
+### Merge scope test (`visible_blocks_should_not_grow_unbounded_with_dag_depth`)
+
+The test at line 564 is marked `#[ignore]` with a comment saying `visible_blocks` grows to ~60 at round 20 instead of staying bounded at ~3 per round. The comment says the current code includes everything back to `ancestor_min_block_number` (effectively genesis when `max_parent_depth` is large). Need to:
+- [ ] Update test for async ISpace — currently uses manual thread spawn with sync runtime, needs migration to `#[tokio::test(flavor = "multi_thread")]`
+- [ ] Verify if this is still the case after recent merge optimizations (PR #473 conflict detection caching)
+- [ ] Determine if this is a correctness issue (too many blocks in scope = slower merge) or a bug (wrong blocks included = incorrect merge results)
+- [ ] Un-ignore and fix, or document why the current behavior is acceptable
+
+### Stack size env var (`F1R3_COMPUTE_PARENTS_REGRESSION_STACK_BYTES`)
+
+Three tests spawn threads with `F1R3_COMPUTE_PARENTS_REGRESSION_STACK_BYTES` (default 64MB) for deep recursion during genesis evaluation. This env var handling was removed from the rest of the codebase (replaced by `StackGrowingFuture` with `stacker::maybe_grow()`). Need to:
+- [ ] Update all three tests to use `#[tokio::test(flavor = "multi_thread")]` with async ISpace
+- [ ] Determine if 64MB is still necessary or if `StackGrowingFuture` covers these code paths in tests
+- [ ] If still needed, document the env var in the test file and CI config
+- [ ] If not needed, replace the manual thread spawn with standard `#[tokio::test]` using `StackGrowingFuture`
+
+## Regression Spec Genesis Needs Wallets
+
+`compute_parents_post_state_regression_spec.rs` creates its own minimal genesis without wallets. Tests that need deploy execution (bridge merge repro, deploy-level merge tests) can't run because precharge fails — deployer has no vault. Add wallets to the regression spec's `Genesis` struct or provide a shared `genesis_context()` variant that returns a genesis compatible with the DAG/block store infrastructure.
+
 ## RSpace Lock Granularity
 
 `event_log` and `produce_counter` in `rspace.rs` and `replay_rspace.rs` are always accessed together in `log_produce`/`log_consume` but use separate `Mutex` locks. Combining them into a single lock would reduce lock acquisitions per RSpace operation. Low priority — the critical sections are short and uncontended under per-channel locks, so overhead is ~5ns per extra lock.

--- a/casper/src/rust/merging/conflict_set_merger.rs
+++ b/casper/src/rust/merging/conflict_set_merger.rs
@@ -263,6 +263,10 @@ pub fn merge<
         "source" => crate::rust::metrics_constants::MERGING_METRICS_SOURCE
     ).record(combine_all_changes_time.as_secs_f64());
 
+    let combined_datums_count = all_changes.datums_changes.len();
+    let combined_conts_count = all_changes.cont_changes.len();
+    let combined_joins_count = all_changes.consume_channels_to_join_serialized_map.len();
+
     // Combine all mergeable channels (in sorted order)
     let mut all_mergeable_channels = NumberChannelsDiff::new();
     for item in &to_merge_items {
@@ -283,8 +287,8 @@ pub fn merge<
     let log_str = format!(
         "Merging done: late set size {}; actual set size {}; computed branches ({}) in {:?}; \
         conflicts map in {:?}; rejection options ({}) in {:?}; optimal rejection set size {}; \
-        rejected as late dependency {}; changes combined in {:?}; trie actions ({}) in {:?}; \
-        actions applied in {:?}",
+        rejected as late dependency {}; changes combined (datums={}, conts={}, joins={}) in {:?}; \
+        trie actions ({}) in {:?}; actions applied in {:?}",
         late_set.len(),
         actual_set.len(),
         branches_set.0.len(),
@@ -294,6 +298,9 @@ pub fn merge<
         rejection_options_time,
         optimal_rejection.0.len(),
         rejected_as_dependents.0.len(),
+        combined_datums_count,
+        combined_conts_count,
+        combined_joins_count,
         combine_all_changes_time,
         trie_actions.len(),
         compute_actions_time,

--- a/casper/src/rust/merging/dag_merger.rs
+++ b/casper/src/rust/merging/dag_merger.rs
@@ -116,6 +116,20 @@ pub fn merge(
     actual_set_vec.sort();
     late_set_vec.sort();
 
+    // Log state change details for debugging merge issues
+    for (i, chain) in actual_set_vec.iter().enumerate() {
+        tracing::debug!(
+            target: "f1r3fly.dag_merger.state_changes",
+            "deploy_chain[{}]: datums={}, conts={}, joins={}, deploys={}, cost={}",
+            i,
+            chain.state_changes.datums_changes.len(),
+            chain.state_changes.cont_changes.len(),
+            chain.state_changes.consume_channels_to_join_serialized_map.len(),
+            chain.deploys_with_cost.0.len(),
+            chain.deploys_with_cost.0.iter().map(|d| d.cost).sum::<u64>(),
+        );
+    }
+
     // Keep as Vec for deterministic processing (ConflictSetMerger expects sorted Vecs)
     let actual_seq = actual_set_vec;
     let late_seq = late_set_vec;

--- a/casper/src/rust/util/rholang/runtime_manager.rs
+++ b/casper/src/rust/util/rholang/runtime_manager.rs
@@ -1050,7 +1050,7 @@ impl RuntimeManager {
      * the time. For some situations, we can just use the value directly for better performance.
      */
     pub fn empty_state_hash_fixed() -> StateHash {
-        hex::decode("6fd88addb9708fdbd89156e23e305763d643f437079cef10a8ab00095c60a345")
+        hex::decode("852cc7a4a4e14a05574b9cd0779dbfb1f85489b606e75677f3ce3239dfec4e36")
             .unwrap()
             .into()
     }

--- a/casper/tests/util/rholang/runtime_manager_test.rs
+++ b/casper/tests/util/rholang/runtime_manager_test.rs
@@ -1672,6 +1672,235 @@ in {{
     );
 }
 
+/// Tests that bridge registry entries survive multi-parent DAG merge.
+///
+/// Deploys bridge.rho on block A (from genesis), creates empty block B (from
+/// genesis, sibling branch), merges [A, B] via compute_parents_post_state,
+/// then queries getNonce from the merged state.
+///
+/// Reproduces: system-integration docs/TODO.md "Contract query deploy returns
+/// empty deployId after finalization (intermittent)"
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn bridge_query_survives_multi_parent_merge() {
+    use block_storage::rust::key_value_block_store::KeyValueBlockStore;
+    use casper::rust::{
+        casper::{CasperShardConf, CasperSnapshot, OnChainCasperState},
+        util::{
+            proto_util,
+            rholang::interpreter_util::{compute_deploys_checkpoint, compute_parents_post_state},
+        },
+    };
+    use crate::util::rholang::resources::{
+        mk_test_rnode_store_manager_from_genesis, block_dag_storage_from_dyn,
+        mergeable_store_from_dyn,
+    };
+    use dashmap::{DashMap, DashSet};
+    use models::rust::{block_hash::BlockHash, block_implicits};
+    use rholang::rust::interpreter::external_services::ExternalServices;
+    use casper::rust::genesis::genesis::Genesis;
+
+    crate::init_logger();
+    let genesis_context = crate::util::rholang::resources::genesis_context()
+        .await
+        .unwrap();
+    let genesis_block = genesis_context.genesis_block.clone();
+    let genesis_hash = genesis_block.block_hash.clone();
+    let genesis_state = proto_util::post_state_hash(&genesis_block);
+    let genesis_bonds = genesis_block.body.state.bonds.clone();
+    let validator: prost::bytes::Bytes = genesis_context.validator_pks()[0].bytes.clone().into();
+    let shard_name = genesis_block.shard_id.clone();
+
+    // Create all stores from the same KVM (shared genesis scope)
+    let mut kvm = mk_test_rnode_store_manager_from_genesis(&genesis_context);
+
+    let rspace_store = kvm.r_space_stores().await.expect("rspace stores");
+    let mergeable_store = mergeable_store_from_dyn(&mut *kvm).await.expect("mergeable store");
+    let (mut rm, _) = RuntimeManager::create_with_history(
+        rspace_store, mergeable_store,
+        Genesis::non_negative_mergeable_tag_name(),
+        ExternalServices::noop(),
+    );
+
+    let mut block_store = KeyValueBlockStore::create_from_kvm(&mut *kvm)
+        .await
+        .expect("block store");
+    let dag_storage = block_dag_storage_from_dyn(&mut *kvm)
+        .await
+        .expect("dag storage");
+
+    block_store.put_block_message(&genesis_block).expect("store genesis");
+    dag_storage.insert(&genesis_block, false, true).expect("dag genesis");
+
+    let now_millis = || -> i64 {
+        SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_millis() as i64).unwrap_or(0)
+    };
+
+    let mk_snapshot = |lfb: &BlockHash| -> CasperSnapshot {
+        let mut snapshot = CasperSnapshot::new(dag_storage.get_representation());
+        snapshot.last_finalized_block = lfb.clone();
+        let max_seq_nums: DashMap<prost::bytes::Bytes, u64> = DashMap::new();
+        max_seq_nums.insert(validator.clone(), 0);
+        snapshot.max_seq_nums = max_seq_nums;
+        let mut shard_conf = CasperShardConf::new();
+        shard_conf.shard_name = shard_name.clone();
+        shard_conf.max_parent_depth = 0;
+        let mut bonds_map = HashMap::new();
+        bonds_map.insert(validator.clone(), 100);
+        snapshot.on_chain_state = OnChainCasperState {
+            shard_conf,
+            bonds_map,
+            active_validators: vec![validator.clone()],
+        };
+        snapshot.deploys_in_scope = std::sync::Arc::new(DashSet::new());
+        snapshot
+    };
+
+    let make_deploy_id_par = |sig: &[u8]| -> models::rhoapi::Par {
+        models::rhoapi::Par {
+            unforgeables: vec![models::rhoapi::GUnforgeable {
+                unf_instance: Some(
+                    models::rhoapi::g_unforgeable::UnfInstance::GDeployIdBody(
+                        models::rhoapi::GDeployId { sig: sig.to_vec() },
+                    ),
+                ),
+            }],
+            ..Default::default()
+        }
+    };
+
+    let bridge_rho = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/resources/bridge.rho"),
+    ).expect("Failed to read bridge.rho");
+
+    // --- Block A: bridge deploy from genesis ---
+    let bridge_deploy = construct_deploy::source_deploy_now_full(
+        bridge_rho, None, None, None, None, None,
+    ).unwrap();
+
+    let block_a_raw = block_implicits::get_random_block(
+        Some(1), Some(1), Some(genesis_state.clone()), Some(StateHash::default()),
+        Some(validator.clone()), Some(1), Some(now_millis()),
+        Some(vec![genesis_hash.clone()]), Some(Vec::new()),
+        Some(vec![ProcessedDeploy::empty(bridge_deploy)]),
+        Some(Vec::new()), Some(genesis_bonds.clone()), Some(shard_name.clone()), None,
+    );
+
+    let parents_a = vec![genesis_block.clone()];
+    let deploys_a = proto_util::deploys(&block_a_raw).into_iter().map(|d| d.deploy).collect();
+    let snapshot_a = mk_snapshot(&genesis_hash);
+    let (_, post_state_a, pd_a, _, sys_pd_a, bonds_a) = compute_deploys_checkpoint(
+        &mut block_store, parents_a, deploys_a,
+        Vec::<casper::rust::util::rholang::system_deploy_enum::SystemDeployEnum>::new(),
+        &snapshot_a, &mut rm,
+        BlockData::from_block(&block_a_raw), HashMap::new(),
+    ).await.expect("compute block A");
+
+    assert!(!pd_a[0].is_failed, "Bridge deploy failed: {:?}", pd_a[0].system_deploy_error);
+
+    let mut block_a = block_a_raw;
+    block_a.body.state.post_state_hash = post_state_a.clone();
+    block_a.body.deploys = pd_a.clone();
+    block_a.body.system_deploys = sys_pd_a;
+    block_a.body.state.bonds = bonds_a;
+    block_store.put_block_message(&block_a).expect("store A");
+    dag_storage.insert(&block_a, false, false).expect("dag A");
+
+    // Verify bridge wrote data and extract queryUri
+    let bridge_data = rm.get_data(post_state_a.clone(), &make_deploy_id_par(&pd_a[0].deploy.sig)).await.unwrap();
+    assert!(!bridge_data.is_empty(), "Bridge deploy wrote no data to deployId");
+
+    let uri_regex = regex::Regex::new(r"rho:id:[a-zA-Z0-9]+").unwrap();
+    let data_str = format!("{:?}", bridge_data);
+    let uris: Vec<String> = uri_regex.find_iter(&data_str).map(|m| m.as_str().to_string()).collect();
+    let mut unique_uris: Vec<String> = Vec::new();
+    for uri in &uris { if !unique_uris.contains(uri) { unique_uris.push(uri.clone()); } }
+    assert!(unique_uris.len() >= 2, "Expected at least 2 URIs, got: {:?}", unique_uris);
+    let query_uri = unique_uris[0].clone();
+
+    // --- Block B: empty block from genesis (sibling branch) ---
+    let block_b_raw = block_implicits::get_random_block(
+        Some(1), Some(2), Some(genesis_state.clone()), Some(StateHash::default()),
+        Some(validator.clone()), Some(1), Some(now_millis()),
+        Some(vec![genesis_hash.clone()]), Some(Vec::new()),
+        Some(Vec::new()), Some(Vec::new()),
+        Some(genesis_bonds.clone()), Some(shard_name.clone()), None,
+    );
+
+    let parents_b = vec![genesis_block.clone()];
+    let snapshot_b = mk_snapshot(&genesis_hash);
+    let (_, post_state_b, pd_b, _, sys_pd_b, bonds_b) = compute_deploys_checkpoint(
+        &mut block_store, parents_b, Vec::new(),
+        Vec::<casper::rust::util::rholang::system_deploy_enum::SystemDeployEnum>::new(),
+        &snapshot_b, &mut rm,
+        BlockData::from_block(&block_b_raw), HashMap::new(),
+    ).await.expect("compute block B");
+
+    let mut block_b = block_b_raw;
+    block_b.body.state.post_state_hash = post_state_b.clone();
+    block_b.body.deploys = pd_b;
+    block_b.body.system_deploys = sys_pd_b;
+    block_b.body.state.bonds = bonds_b;
+    block_store.put_block_message(&block_b).expect("store B");
+    dag_storage.insert(&block_b, false, false).expect("dag B");
+
+    // --- Merge [A, B] ---
+    let parents = vec![block_a.clone(), block_b.clone()];
+    let snapshot_merge = mk_snapshot(&genesis_hash);
+    let (merged_state, rejected) = compute_parents_post_state(
+        &block_store, parents, &snapshot_merge, &rm, None,
+    ).expect("merge parents");
+
+    assert!(rejected.is_empty(), "Merge rejected deploys: {:?}", rejected);
+
+    // --- Query getNonce from merged state ---
+    let get_nonce_rho = format!(r#"
+new deployId(`rho:system:deployId`),
+    lookup(`rho:registry:lookup`),
+    queryCh, ret
+in {{
+  lookup!(`{}`, *queryCh) |
+  for (query <- queryCh) {{
+    query!("getNonce", Nil, *ret) |
+    for (@result <- ret) {{ deployId!(result) }}
+  }}
+}}
+"#, query_uri);
+
+    let query_deploy = construct_deploy::source_deploy_now_full(
+        get_nonce_rho, None, None, None, None, None,
+    ).unwrap();
+
+    let query_block_raw = block_implicits::get_random_block(
+        Some(2), Some(3), Some(merged_state.clone()), Some(StateHash::default()),
+        Some(validator.clone()), Some(1), Some(now_millis()),
+        Some(vec![block_a.block_hash.clone(), block_b.block_hash.clone()]),
+        Some(Vec::new()),
+        Some(vec![ProcessedDeploy::empty(query_deploy)]),
+        Some(Vec::new()), Some(genesis_bonds.clone()), Some(shard_name.clone()), None,
+    );
+
+    let parents_q = vec![block_a.clone(), block_b.clone()];
+    let deploys_q = proto_util::deploys(&query_block_raw).into_iter().map(|d| d.deploy).collect();
+    let snapshot_q = mk_snapshot(&genesis_hash);
+    let (_, post_state_q, pd_q, _, _, _) = compute_deploys_checkpoint(
+        &mut block_store, parents_q, deploys_q,
+        Vec::<casper::rust::util::rholang::system_deploy_enum::SystemDeployEnum>::new(),
+        &snapshot_q, &mut rm,
+        BlockData::from_block(&query_block_raw), HashMap::new(),
+    ).await.expect("compute query block");
+
+    assert!(!pd_q[0].is_failed, "Query deploy failed: {:?}", pd_q[0].system_deploy_error);
+
+    let query_data = rm.get_data(post_state_q, &make_deploy_id_par(&pd_q[0].deploy.sig)).await.unwrap();
+
+    assert!(
+        !query_data.is_empty(),
+        "Bridge query returned empty deployId after multi-parent merge. \
+         The merge did not preserve the bridge's registry entries when \
+         combining a bridge branch with an empty sibling branch."
+    );
+}
+
 /// Reproduces the replay determinism issue seen with tokio::spawn.
 /// Deploys a contract with parallel composition, plays it, then replays it.
 /// If tokio::spawn introduces non-deterministic evaluation order, the replay

--- a/casper/tests/util/rholang/runtime_spec.rs
+++ b/casper/tests/util/rholang/runtime_spec.rs
@@ -82,7 +82,7 @@ async fn state_hash_after_fixed_rholang_term_execution_should_be_hash_fixed_with
 
     let checkpoint = runtime.create_checkpoint().await;
     let expected_hash = Blake2b256Hash::from_hex(
-        "eed0f1f8b051f73ac861cd49cbc9e0c177c2f8a0b2bde69e75875820eccc2917",
+        "5a17a1ed5ddcec2394d9d0b47d514eafeaec6fd78c3e38b70fcdfb43c4d96bfa",
     );
 
     assert_eq!(expected_hash, checkpoint.root);

--- a/docs/testing-tracing.md
+++ b/docs/testing-tracing.md
@@ -1,0 +1,39 @@
+# Tracing in Tests
+
+## Casper Tests
+
+The casper test suite (`casper/tests/mod.rs`) initializes tracing via `init_logger()` with a default filter of `ERROR`. This means `tracing::info!`, `tracing::debug!`, and `tracing::warn!` calls in tests are **silent by default**.
+
+To see tracing output, set `RUST_LOG`:
+
+```bash
+# All info-level output
+RUST_LOG=info cargo test -p casper --release --test mod -- my_test --nocapture
+
+# Targeted (less noise)
+RUST_LOG=casper=info cargo test -p casper --release --test mod -- my_test --nocapture
+
+# Debug level for a specific module
+RUST_LOG=casper::rust::rholang=debug cargo test -p casper --release --test mod -- my_test --nocapture
+```
+
+The `--nocapture` flag is required — without it, pytest/cargo captures stderr and the tracing output is hidden.
+
+## Rholang Tests
+
+Rholang tests do NOT have a shared `init_logger()`. To use tracing in rholang tests, add `tracing_subscriber` initialization in the test function:
+
+```rust
+let _ = tracing_subscriber::fmt()
+    .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+    .with_target(true)
+    .try_init();
+```
+
+Then run with `RUST_LOG=info` or `RUST_LOG=replay_debug=debug`.
+
+## Common Gotchas
+
+- **Release mode does NOT strip tracing** — the `tracing` crate in `Cargo.toml` has no `max_level_*` features set, so all levels compile in
+- **`try_init()` silently fails** if another subscriber is already set (e.g., another test in the same process initialized first). Use `try_init()` (not `init()`) to avoid panics
+- **JSON format** — casper's `init_logger` uses `.json()` format. Log lines look like `{"timestamp":"...","level":"INFO","message":"..."}`, not plain text

--- a/rspace++/src/rspace/hashing/stable_hash_provider.rs
+++ b/rspace++/src/rspace/hashing/stable_hash_provider.rs
@@ -9,7 +9,6 @@ pub fn hash<C: Serialize>(channel: &C) -> Blake2b256Hash {
     Blake2b256Hash::new(&bytes)
 }
 
-// TODO: Double check the sorting here against scala side
 pub fn hash_vec<C: Serialize>(channels: &Vec<C>) -> Vec<Blake2b256Hash> {
     let mut hashes: Vec<Blake2b256Hash> = channels
         .iter()
@@ -23,15 +22,10 @@ pub fn hash_vec<C: Serialize>(channels: &Vec<C>) -> Vec<Blake2b256Hash> {
 }
 
 pub fn hash_from_vec<C: Serialize>(channels: &Vec<C>) -> Blake2b256Hash {
-    if channels.len() == 1 {
-        return hash(channels.first().unwrap());
-    }
-
     let hashes = hash_vec(channels);
     hash_from_hashes(&hashes)
 }
 
-// TODO: Double check the sorting here against scala side
 pub fn hash_from_hashes(channels_hashes: &Vec<Blake2b256Hash>) -> Blake2b256Hash {
     let mut ord_refs: Vec<&Blake2b256Hash> = channels_hashes.iter().collect();
     ord_refs.sort();


### PR DESCRIPTION
## Summary

- **Root cause**: `hash_from_vec` had a single-element shortcut (`if len == 1 { return hash(ch) }`) that Scala's `StableHashProvider` does not have. This made the EXEC path store single-channel continuations at `H(serialize(ch))` while the MERGE path (via `hash_from_hashes`) looked them up at `H(H(serialize(ch)).bytes)` — different trie keys.
- **Effect**: `merge([bridge_block, empty_block])` produced `conts=0` in state changes, losing all installed contracts (persistent consumes). Bridge registry lookups failed after merge (~25% failure rate in integration tests depending on parent selection).
- **Fix**: Remove the single-element shortcut from `hash_from_vec` so it always goes through `hash_vec` → `hash_from_hashes`, matching Scala exactly. Update hardcoded empty state hash and test expected values.
- Adds `bridge_query_survives_multi_parent_merge` regression test
- Adds merge diagnostic logging (debug level) to `conflict_set_merger` and `dag_merger`
- Resolves TODOs in `stable_hash_provider.rs` (sorting verified against Scala)

## Test plan

- [x] `bridge_query_survives_multi_parent_merge` passes 3/3 runs
- [x] rspace++ full suite: 268 passed, 0 failed
- [x] rholang full suite: 675 passed, 0 failed
- [x] casper full suite: 397 passed, 0 failed (after updating hardcoded state hashes)

Co-Authored-By: Claude <noreply@anthropic.com>