### PR TITLE
fix: propagate exploratory deploy errors instead of swallowing

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,33 @@
 # TODO
 
+## Bug: Validator permanently stuck if initial bootstrap connection fails
+
+When a validator starts before the boot node's P2P listener is ready, the initial TCP connection to boot fails with "Connection refused." The validator discovers other validators via Kademlia, connects to them, but **never retries the connection to boot**. Since the genesis ceremony only broadcasts the UnapprovedBlock from boot, the validator never receives the genesis candidate and loops forever on "Casper engine present but Casper not initialized yet."
+
+**Root cause (confirmed via logs):**
+1. Validator1 starts at T+0, tries to connect to boot — "Connection refused (os error 111)"
+2. Boot starts listening at T+1, computes genesis, broadcasts UnapprovedBlock at T+10
+3. Validator2 and validator3 are connected to boot, receive genesis, approve it
+4. Boot gets 2/2 required signatures, transitions to Running
+5. Validator2 and validator3 request ApprovedBlock from boot, initialize successfully
+6. **Validator1 never reconnects to boot** — stuck permanently in "Casper not initialized yet" loop
+7. Validator1 connects to validator3 via discovery at T+20 but this doesn't help — genesis ceremony only comes from boot
+
+**Impact:** ~50% of integration test runs fail due to startup timeout. All 5 containers report healthy (Docker healthcheck passes) but the shard is non-functional.
+
+**Fix locations:**
+- `comm/src/rust/rp/connect.rs:325` — connection failure handling (should retry bootstrap peer)
+- `casper/src/rust/engine/casper_launch.rs:770` — genesis validator mode (should retry fetching approved block from any peer, not just boot)
+- `node/src/rust/runtime/node_runtime.rs:572` — "Waiting for first connection" (should have retry logic for bootstrap)
+
+**Fix options:**
+1. **Retry bootstrap connection**: After initial connection failure, retry boot peer with exponential backoff
+2. **Request ApprovedBlock from any peer**: If validator connects to other validators that already have the approved block, request it from them instead of waiting for boot's broadcast
+3. **Increase boot startup priority**: Use Docker `depends_on` with healthcheck to ensure boot is fully ready before validators start (integration test workaround only)
+
+- Location: `node/src/rust/runtime/setup.rs:677` (the warning loop)
+- Reproduction: `F1R3FLY_NODE_IMAGE=... pytest test_bridge_admin.py -v -s --keep-running` — fails ~50% of runs
+
 ## Review: `compute_parents_post_state_regression_spec.rs`
 
 This test file needs review and cleanup:

--- a/casper/src/rust/rholang/runtime.rs
+++ b/casper/src/rust/rholang/runtime.rs
@@ -885,13 +885,7 @@ impl RuntimeOps {
                 .await
         })();
 
-        match deploy_result.await {
-            Ok(result) => Ok(result),
-            Err(err) => {
-                tracing::error!("Error in play_exploratory_deploy: {:?}", err);
-                Ok((Vec::new(), 0))
-            }
-        }
+        deploy_result.await
     }
 
     async fn play_exploratory_par(

--- a/casper/tests/util/rholang/runtime_manager_test.rs
+++ b/casper/tests/util/rholang/runtime_manager_test.rs
@@ -1901,6 +1901,105 @@ in {{
     );
 }
 
+/// Verifies that exploratory deploy can query user-deployed contracts
+/// through the registry. The `contract` keyword is reserved in Rholang,
+/// so variable names in the query must not use it.
+///
+/// Also verifies that play_exploratory_deploy propagates errors (previously
+/// errors were silently swallowed, returning empty results).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn exploratory_deploy_async_contract_query() {
+    use crypto::rust::signatures::signatures_alg::SignaturesAlg;
+
+    with_runtime_manager(|runtime_manager, _genesis_context, genesis_block| async move {
+        let genesis_state = genesis_block.body.state.post_state_hash.clone();
+
+        // Deploy a contract with a persistent state channel + persistent consume
+        let contract_rho = r#"
+new return, stateCh, queryCh,
+    insertArbitrary(`rho:registry:insertArbitrary`)
+in {
+  stateCh!(42) |
+  contract queryCh(@method, ret) = {
+    for (@v <- stateCh) {
+      stateCh!(v) |
+      ret!(v)
+    }
+  } |
+  new uriCh in {
+    insertArbitrary!(bundle+{*queryCh}, *uriCh) |
+    for (@uri <- uriCh) {
+      return!(uri)
+    }
+  }
+}
+"#;
+
+        // Use a unique key to avoid GPrivate collision with exploratory deploy's DEFAULT_SEC
+        let (contract_key, _) = crypto::rust::signatures::secp256k1::Secp256k1.new_key_pair();
+        let deploy = construct_deploy::source_deploy(
+            contract_rho.to_string(), 0, Some(500_000_000), None, Some(contract_key), None, None,
+        ).unwrap();
+
+        // Deploy and read URI via capture_results
+        let uri_pars = runtime_manager
+            .capture_results(&genesis_state, &deploy)
+            .await
+            .expect("deploy contract");
+        assert!(!uri_pars.is_empty(), "Contract deploy returned no URI");
+
+        let uri_str = format!("{:?}", uri_pars[0]);
+        let uri_regex = regex::Regex::new(r"rho:id:[a-zA-Z0-9]+").unwrap();
+        let uri = uri_regex.find(&uri_str).expect("No rho:id URI found").as_str().to_string();
+
+        // Checkpoint via a fresh runtime so exploratory deploy can see the state
+        let runtime = runtime_manager.spawn_runtime().await;
+        let mut runtime_ops = RuntimeOps::new(runtime);
+        runtime_ops.runtime
+            .reset(&Blake2b256Hash::from_bytes_prost(&genesis_state)).await
+            .expect("reset");
+        let eval_result = runtime_ops.evaluate(&deploy).await.expect("evaluate");
+        assert!(eval_result.errors.is_empty(), "Deploy errors: {:?}", eval_result.errors);
+        let checkpoint = runtime_ops.runtime.create_checkpoint().await;
+        let post_state: StateHash = checkpoint.root.to_bytes_prost().into();
+        tracing::info!("Contract at {}, post_state={}", uri, hex::encode(&post_state[..8]));
+
+        // Query with correct variable names (NOT using reserved word 'contract')
+        let query_term = format!(
+            r#"new ret, lookup(`rho:registry:lookup`), ch in {{
+                lookup!(`{}`, *ch) |
+                for (c <- ch) {{
+                    c!("get", *ret)
+                }}
+            }}"#, uri
+        );
+        let (query_result, _) = runtime_manager
+            .play_exploratory_deploy(query_term, &post_state)
+            .await
+            .expect("query exploratory deploy");
+        tracing::info!("Query with correct var name: {} pars", query_result.len());
+        assert_eq!(query_result.len(), 1, "Query should return 1 par (the value 42)");
+
+        // Verify play_exploratory_deploy propagates parse errors (not swallows them)
+        let bad_term = format!(
+            r#"new ret, lookup(`rho:registry:lookup`), ch in {{
+                lookup!(`{}`, *ch) |
+                for (contract <- ch) {{
+                    contract!("get", *ret)
+                }}
+            }}"#, uri
+        );
+        let bad_result = runtime_manager
+            .play_exploratory_deploy(bad_term, &post_state)
+            .await;
+        assert!(bad_result.is_err(),
+            "Using reserved word 'contract' as var name should return Err, not empty Ok");
+    })
+    .await
+    .unwrap();
+}
+
+
 /// Reproduces the replay determinism issue seen with tokio::spawn.
 /// Deploys a contract with parallel composition, plays it, then replays it.
 /// If tokio::spawn introduces non-deterministic evaluation order, the replay

--- a/docs/node/exploratory-deploy.md
+++ b/docs/node/exploratory-deploy.md
@@ -1,0 +1,78 @@
+# Exploratory Deploy
+
+Exploratory deploy executes Rholang code in a read-only context against a specific block's post-state. No block is created, no phlo is consumed. Available only on readonly nodes.
+
+## Return Channel Convention
+
+The runtime reads results from the **first unforgeable name** created by the deploy's RNG (`GPrivate`), NOT from `rho:system:deployId` (`GDeployId`). This is by design in both Scala and Rust (see `RuntimeSyntax.scala:517-518`).
+
+The return channel must be:
+- The **first name** in the `new` binding list
+- **Without** a URI binding (plain `new ret`, not `` new ret(`rho:system:deployId`) ``)
+
+### Correct
+
+```rholang
+new ret, lookup(`rho:registry:lookup`), ch in {
+  lookup!(`rho:id:...`, *ch) |
+  for (val <- ch) { ret!(val) }
+}
+```
+
+### Wrong (returns 0 pars)
+
+```rholang
+new ret(`rho:system:deployId`), lookup(`rho:registry:lookup`), ch in {
+  lookup!(`rho:id:...`, *ch) |
+  for (val <- ch) { ret!(val) }
+}
+```
+
+## Reserved Keywords
+
+Rholang's tree-sitter grammar reserves several keywords that cannot be used as variable names. The most common pitfall is `contract`:
+
+### Wrong (parse error, silently returns empty before error propagation fix)
+
+```rholang
+new ret, lookup(`rho:registry:lookup`), ch in {
+  lookup!(`rho:id:...`, *ch) |
+  for (contract <- ch) {        // ERROR: 'contract' is a reserved keyword
+    contract!("method", *ret)
+  }
+}
+```
+
+### Correct
+
+```rholang
+new ret, lookup(`rho:registry:lookup`), ch in {
+  lookup!(`rho:id:...`, *ch) |
+  for (c <- ch) {
+    c!("method", *ret)
+  }
+}
+```
+
+Reserved keywords in the Rholang grammar include: `contract`, `new`, `in`, `for`, `match`, `if`, `else`, `bundle`, `select`, `Nil`, `true`, `false`, `not`, `and`, `or`. See `rholang-rs/rholang-tree-sitter/grammar.js` for the full list.
+
+## Error Propagation
+
+`play_exploratory_deploy` now propagates errors to the caller. Previously, all errors (including parse errors) were silently swallowed and empty results were returned. This made it impossible to distinguish "no data" from "invalid Rholang" at the client level.
+
+The gRPC `exploratoryDeploy` endpoint returns errors in the `ExploratoryDeployResponse.Error` message field, which pyf1r3fly surfaces as `F1r3flyClientException`.
+
+## Block Hash Parameter
+
+When calling exploratory deploy, always pass an explicit block hash (typically the LFB hash) to ensure you're querying the expected state. Passing an empty string may resolve to a state that doesn't include recent deploys.
+
+```python
+lfb = node.last_finalized_block().blockInfo
+result = node.exploratory_deploy(rholang_code, lfb.blockHash)
+```
+
+## Implementation
+
+- `casper/src/rust/rholang/runtime.rs:858` -- `play_exploratory_deploy`
+- `casper/src/rust/api/block_api.rs:1405` -- `exploratory_deploy` API handler
+- `casper/src/rust/rholang/runtime.rs:1035` -- `capture_results_with_errors` (reset, evaluate, read)


### PR DESCRIPTION
## Summary

- **`play_exploratory_deploy`** silently swallowed all errors (parse errors, evaluation errors) and returned `Ok((Vec::new(), 0))`. Clients received empty results with no error indication, making debugging impossible.
- Now errors propagate to the caller. The gRPC `exploratoryDeploy` endpoint already handles errors correctly via `ExploratoryDeployResponse.Error`.
- Root cause of all previous "exploratory deploy doesn't work for contract queries" reports: pyf1r3fly's `registry_query` helper used `contract` as a Rholang variable name — a reserved keyword in the tree-sitter grammar. The parse error was silently swallowed. Fixed in pyf1r3fly (F1R3FLY-io/pyf1r3fly@ea57480).
- Adds `docs/node/exploratory-deploy.md` documenting return channel convention and reserved keyword pitfalls.
- Adds `exploratory_deploy_async_contract_query` code-level test.

## Test plan

- [x] `exploratory_deploy_async_contract_query` passes (correct var name returns result, reserved keyword returns Err)
- [x] Integration test `test_exploratory_deploy_invalid_syntax_returns_error` passes (invalid Rholang returns error to client)
- [x] Integration test `test_bridge_api_exploratory` passes (bridge queries via exploratory deploy on readonly)
- [x] Full integration suite: 16/16 passed, 2 consecutive runs stable

Co-Authored-By: Claude <noreply@anthropic.com>