### PR TITLE
feat(heartbeat): expose tuning constants as configurable parameters

### DIFF
--- a/casper/src/rust/casper_conf.rs
+++ b/casper/src/rust/casper_conf.rs
@@ -294,7 +294,7 @@ pub struct GenesisCeremony {
     pub ceremony_master_mode: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct HeartbeatConf {
     pub enabled: bool,
     #[serde(rename = "check-interval", deserialize_with = "de_duration")]
@@ -307,10 +307,110 @@ pub struct HeartbeatConf {
         default = "default_self_propose_cooldown"
     )]
     pub self_propose_cooldown: Duration,
+    /// Minimum age of LFB/frontier before stale-recovery, leader-recovery,
+    /// and pending-deploy backstop are allowed to fire. Debounces empty-block
+    /// churn when the cluster is healthy.
+    #[serde(
+        rename = "stale-recovery-min-interval",
+        deserialize_with = "de_duration",
+        default = "default_stale_recovery_min_interval"
+    )]
+    pub stale_recovery_min_interval: Duration,
+    /// When pending deploys land, opens a grace window during which lag caps
+    /// relax to `advanced.deploy_recovery_max_lag` and self-propose-cooldown
+    /// is bypassable. Burst-tolerance budget.
+    #[serde(
+        rename = "deploy-finalization-grace",
+        deserialize_with = "de_duration",
+        default = "default_deploy_finalization_grace"
+    )]
+    pub deploy_finalization_grace: Duration,
+    /// EXPERIMENTAL tuning knobs. See [`HeartbeatAdvancedConf`].
+    #[serde(default)]
+    pub advanced: HeartbeatAdvancedConf,
+}
+
+impl Default for HeartbeatConf {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            check_interval: Duration::from_secs(5),
+            max_lfb_age: Duration::from_secs(5),
+            self_propose_cooldown: default_self_propose_cooldown(),
+            stale_recovery_min_interval: default_stale_recovery_min_interval(),
+            deploy_finalization_grace: default_deploy_finalization_grace(),
+            advanced: HeartbeatAdvancedConf::default(),
+        }
+    }
 }
 
 fn default_self_propose_cooldown() -> Duration {
     Duration::from_secs(15)
+}
+
+fn default_stale_recovery_min_interval() -> Duration {
+    Duration::from_secs(12)
+}
+
+fn default_deploy_finalization_grace() -> Duration {
+    Duration::from_secs(25)
+}
+
+/// EXPERIMENTAL: tuning knobs for the heartbeat proposer's lag caps.
+///
+/// These thresholds bound DAG width relative to replay cost in lieu of
+/// adaptive backpressure. Treat as unstable API; field names may change.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HeartbeatAdvancedConf {
+    /// When this validator is already ahead of LFB, how many blocks of lag
+    /// tolerate before "frontier-follow" proposing is throttled. `0` =
+    /// never frontier-chase while ahead unless deploy recovery is active
+    /// (which raises this dynamically).
+    #[serde(
+        rename = "frontier-chase-max-lag",
+        default = "default_frontier_chase_max_lag"
+    )]
+    pub frontier_chase_max_lag: i64,
+    /// If the validator has pending deploys but is already > N blocks
+    /// ahead of LFB, suppress pending-deploy proposing. Prevents lag
+    /// amplification: more deploys → more blocks → wider DAG → slower
+    /// finalization → still "ahead" → keeps proposing forever. Lower →
+    /// harder load-relief valve.
+    #[serde(
+        rename = "pending-deploy-max-lag",
+        default = "default_pending_deploy_max_lag"
+    )]
+    pub pending_deploy_max_lag: i64,
+    /// During an active deploy-finalization grace window, the lag cap
+    /// widens to this value. The "absolute safe lag during recovery"
+    /// ceiling.
+    #[serde(
+        rename = "deploy-recovery-max-lag",
+        default = "default_deploy_recovery_max_lag"
+    )]
+    pub deploy_recovery_max_lag: i64,
+}
+
+impl Default for HeartbeatAdvancedConf {
+    fn default() -> Self {
+        Self {
+            frontier_chase_max_lag: default_frontier_chase_max_lag(),
+            pending_deploy_max_lag: default_pending_deploy_max_lag(),
+            deploy_recovery_max_lag: default_deploy_recovery_max_lag(),
+        }
+    }
+}
+
+fn default_frontier_chase_max_lag() -> i64 {
+    0
+}
+
+fn default_pending_deploy_max_lag() -> i64 {
+    20
+}
+
+fn default_deploy_recovery_max_lag() -> i64 {
+    64
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/casper/src/rust/casper_conf.rs
+++ b/casper/src/rust/casper_conf.rs
@@ -360,6 +360,12 @@ fn default_deploy_finalization_grace() -> Duration {
 ///
 /// These thresholds bound DAG width relative to replay cost in lieu of
 /// adaptive backpressure. Treat as unstable API; field names may change.
+///
+/// All three fields must be non-negative; HOCON values < 0 are rejected
+/// at deserialization time. The proposer treats these as caps on a
+/// non-negative lag count (`lfb_lag_blocks`), so a negative value would
+/// silently disable the corresponding code path (e.g. `lag <= cap` where
+/// `cap < 0` is never true, leaving pending deploys unproposed).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct HeartbeatAdvancedConf {
     /// When this validator is already ahead of LFB, how many blocks of lag
@@ -368,6 +374,7 @@ pub struct HeartbeatAdvancedConf {
     /// (which raises this dynamically).
     #[serde(
         rename = "frontier-chase-max-lag",
+        deserialize_with = "de_non_negative_i64",
         default = "default_frontier_chase_max_lag"
     )]
     pub frontier_chase_max_lag: i64,
@@ -378,14 +385,22 @@ pub struct HeartbeatAdvancedConf {
     /// harder load-relief valve.
     #[serde(
         rename = "pending-deploy-max-lag",
+        deserialize_with = "de_non_negative_i64",
         default = "default_pending_deploy_max_lag"
     )]
     pub pending_deploy_max_lag: i64,
     /// During an active deploy-finalization grace window, the lag cap
     /// widens to this value. The "absolute safe lag during recovery"
     /// ceiling.
+    ///
+    /// Invariant: must be `>= pending_deploy_max_lag` to take effect.
+    /// The proposer computes the recovery cap as
+    /// `max(pending_deploy_max_lag, deploy_recovery_max_lag)`, so a
+    /// value below `pending_deploy_max_lag` collapses to that floor and
+    /// the knob has no effect.
     #[serde(
         rename = "deploy-recovery-max-lag",
+        deserialize_with = "de_non_negative_i64",
         default = "default_deploy_recovery_max_lag"
     )]
     pub deploy_recovery_max_lag: i64,
@@ -492,4 +507,21 @@ where
             Ok(Duration::from_secs_f64(f))
         }
     }
+}
+
+/// Reject negative `i64` values at deserialization time. The lag-cap
+/// fields on `HeartbeatAdvancedConf` are typed as `i64` to match the
+/// proposer's comparison sites, but a negative value silently disables
+/// the corresponding code path — fail fast instead.
+fn de_non_negative_i64<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error as _;
+    use serde::Deserialize;
+    let v = i64::deserialize(deserializer)?;
+    if v < 0 {
+        return Err(D::Error::custom(format!("value must be >= 0, got {}", v)));
+    }
+    Ok(v)
 }

--- a/docs/node/README.md
+++ b/docs/node/README.md
@@ -74,7 +74,7 @@ The following boolean flags override HOCON configuration at startup. CLI flags a
 | `--heartbeat-disabled` | `casper.heartbeat_conf.enabled = false` | Disable heartbeat proposing (takes precedence over `--heartbeat-enabled`) |
 | `--heartbeat-check-interval` | `casper.heartbeat_conf.check_interval` | How often the heartbeat loop wakes to evaluate its decision tree |
 | `--heartbeat-max-lfb-age` | `casper.heartbeat_conf.max_lfb_age` | LFB age threshold above which stale-LFB recovery may fire |
-| `--heartbeat-stale-recovery-interval` | `casper.heartbeat_conf.stale_recovery_min_interval` | Minimum LFB/frontier age before stale-recovery, leader-recovery, and pending-deploy backstop are allowed to fire |
+| `--heartbeat-stale-recovery-min-interval` | `casper.heartbeat_conf.stale_recovery_min_interval` | Minimum LFB/frontier age before stale-recovery, leader-recovery, and pending-deploy backstop are allowed to fire |
 | `--heartbeat-deploy-finalization-grace` | `casper.heartbeat_conf.deploy_finalization_grace` | Grace window opened when pending deploys land; relaxes lag caps and bypasses self-propose-cooldown |
 | `--heartbeat-advanced-frontier-chase-max-lag` | `casper.heartbeat_conf.advanced.frontier_chase_max_lag` | EXPERIMENTAL. Max lag tolerated for frontier-chase proposals while ahead of LFB |
 | `--heartbeat-advanced-pending-deploy-max-lag` | `casper.heartbeat_conf.advanced.pending_deploy_max_lag` | EXPERIMENTAL. Lag threshold above which pending-deploy proposals throttle |
@@ -364,7 +364,7 @@ These values are hardcoded (previously configurable via `F1R3_*` env vars, remov
 | `heartbeat.deploy-finalization-grace` | 25s | Grace window opened when pending deploys land; relaxes lag caps |
 | `heartbeat.advanced.frontier-chase-max-lag` | 0 | EXPERIMENTAL. Max lag for frontier-chase proposals while ahead of LFB |
 | `heartbeat.advanced.pending-deploy-max-lag` | 20 | EXPERIMENTAL. Lag threshold above which pending-deploy proposals throttle |
-| `heartbeat.advanced.deploy-recovery-max-lag` | 64 | EXPERIMENTAL. Wider lag cap during the deploy-finalization grace window |
+| `heartbeat.advanced.deploy-recovery-max-lag` | 64 | EXPERIMENTAL. Wider lag cap during the deploy-finalization grace window. Must be >= `pending-deploy-max-lag` to take effect (else collapses to that floor). |
 
 **Deploy grace window**: When a deploy is proposed or finalization-critical parents observed, a grace window opens (default 25s) that allows proposals which would normally be blocked by cooldown/interval constraints.
 

--- a/docs/node/README.md
+++ b/docs/node/README.md
@@ -72,6 +72,13 @@ The following boolean flags override HOCON configuration at startup. CLI flags a
 | `--disable-mergeable-channel-gc` | `casper.enable_mergeable_channel_gc = false` | Disable mergeable channel GC (takes precedence over `--enable-mergeable-channel-gc`) |
 | `--heartbeat-enabled` | `casper.heartbeat_conf.enabled = true` | Enable heartbeat block proposing for liveness |
 | `--heartbeat-disabled` | `casper.heartbeat_conf.enabled = false` | Disable heartbeat proposing (takes precedence over `--heartbeat-enabled`) |
+| `--heartbeat-check-interval` | `casper.heartbeat_conf.check_interval` | How often the heartbeat loop wakes to evaluate its decision tree |
+| `--heartbeat-max-lfb-age` | `casper.heartbeat_conf.max_lfb_age` | LFB age threshold above which stale-LFB recovery may fire |
+| `--heartbeat-stale-recovery-interval` | `casper.heartbeat_conf.stale_recovery_min_interval` | Minimum LFB/frontier age before stale-recovery, leader-recovery, and pending-deploy backstop are allowed to fire |
+| `--heartbeat-deploy-finalization-grace` | `casper.heartbeat_conf.deploy_finalization_grace` | Grace window opened when pending deploys land; relaxes lag caps and bypasses self-propose-cooldown |
+| `--heartbeat-advanced-frontier-chase-max-lag` | `casper.heartbeat_conf.advanced.frontier_chase_max_lag` | EXPERIMENTAL. Max lag tolerated for frontier-chase proposals while ahead of LFB |
+| `--heartbeat-advanced-pending-deploy-max-lag` | `casper.heartbeat_conf.advanced.pending_deploy_max_lag` | EXPERIMENTAL. Lag threshold above which pending-deploy proposals throttle |
+| `--heartbeat-advanced-deploy-recovery-max-lag` | `casper.heartbeat_conf.advanced.deploy_recovery_max_lag` | EXPERIMENTAL. Wider lag cap during the deploy-finalization grace window |
 | `--native-token-name` | `casper.genesis_block_data.native_token_name` | Native token display name (genesis-locked) |
 | `--native-token-symbol` | `casper.genesis_block_data.native_token_symbol` | Native token ticker symbol (genesis-locked) |
 | `--native-token-decimals` | `casper.genesis_block_data.native_token_decimals` | Native token decimal places, 0-18 (genesis-locked) |
@@ -345,15 +352,19 @@ These values are hardcoded (previously configurable via `F1R3_*` env vars, remov
 
 **`ProposerInstance`** -- Dequeues proposal requests. Non-blocking locking (try_lock). 5-minute timeout for stuck proposals. Min-interval between proposals is 250ms (hardcoded).
 
-**`HeartbeatProposer`** -- Periodic proposals for network liveness. Operator-tunable heartbeat settings (enabled, check-interval, max-lfb-age, self-propose-cooldown) are in `defaults.conf` under the `casper.heartbeat` section. The following behavioral parameters are hardcoded:
+**`HeartbeatProposer`** -- Periodic proposals for network liveness. All heartbeat settings live in `defaults.conf` under the `casper.heartbeat` section and accept CLI overrides. Stable knobs are at the top level; experimental tuning knobs are nested under `advanced.*` and may change shape in a future release.
 
-| Parameter | Value | Purpose |
-|-----------|-------|---------|
-| Frontier chase max lag | 0 | Max lag permitting frontier-chase proposals |
-| Pending deploy max lag | 20 | Lag threshold above which pending deploy proposals throttle |
-| Deploy recovery max lag | 64 | Lag threshold for deploy recovery mode |
-| Stale recovery min interval | 12000ms | Min interval for stale-LFB recovery proposals |
-| Deploy finalization grace | 25000ms | Grace period bypassing min-interval during deploy finalization |
+| HOCON key | Default | Purpose |
+|-----------|--------:|---------|
+| `heartbeat.enabled` | `false` | Enable the heartbeat proposer |
+| `heartbeat.check-interval` | 5s | How often the loop evaluates its decision tree |
+| `heartbeat.max-lfb-age` | 5s | LFB age threshold above which stale-LFB recovery may fire |
+| `heartbeat.self-propose-cooldown` | 15s | Min interval between self-proposals |
+| `heartbeat.stale-recovery-min-interval` | 12s | Min LFB/frontier age before stale/leader/backstop recovery may fire |
+| `heartbeat.deploy-finalization-grace` | 25s | Grace window opened when pending deploys land; relaxes lag caps |
+| `heartbeat.advanced.frontier-chase-max-lag` | 0 | EXPERIMENTAL. Max lag for frontier-chase proposals while ahead of LFB |
+| `heartbeat.advanced.pending-deploy-max-lag` | 20 | EXPERIMENTAL. Lag threshold above which pending-deploy proposals throttle |
+| `heartbeat.advanced.deploy-recovery-max-lag` | 64 | EXPERIMENTAL. Wider lag cap during the deploy-finalization grace window |
 
 **Deploy grace window**: When a deploy is proposed or finalization-critical parents observed, a grace window opens (default 25s) that allows proposals which would normally be blocked by cooldown/interval constraints.
 

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -397,6 +397,43 @@ casper {
     # Minimum time between heartbeat self-proposals.
     # Controls proposal rate to prevent flooding the network.
     self-propose-cooldown = 15 seconds
+
+    # Minimum age of LFB/frontier before stale-recovery, leader-recovery,
+    # and pending-deploy backstop are allowed to fire. Debounces empty-block
+    # churn when the cluster is healthy. Lower → more responsive recovery
+    # but more empty heartbeat blocks; higher → slower recovery, fewer
+    # blocks per minute.
+    stale-recovery-min-interval = 12 seconds
+
+    # When pending deploys land, opens a grace window during which lag caps
+    # relax (advanced.deploy-recovery-max-lag instead of advanced.pending-
+    # deploy-max-lag) and self-propose-cooldown is bypassable. Burst-tolerance
+    # budget. Higher → more sustained burst capacity; lower → quicker return
+    # to idle steady state.
+    deploy-finalization-grace = 25 seconds
+
+    # EXPERIMENTAL tuning knobs for the proposer's lag caps. They bound
+    # DAG width relative to replay cost in lieu of adaptive backpressure.
+    # Treat as unstable API.
+    advanced {
+      # When this validator is already ahead of LFB, how many blocks of
+      # lag tolerate before "frontier-follow" proposing is throttled.
+      # 0 = never frontier-chase while ahead unless deploy recovery is
+      # active (which raises this dynamically).
+      frontier-chase-max-lag = 0
+
+      # If the validator has pending deploys but is already > N blocks
+      # ahead of LFB, suppress pending-deploy proposing. Prevents lag
+      # amplification: more deploys → more blocks → wider DAG → slower
+      # finalization → still "ahead" → keeps proposing forever.
+      # Lower → harder load-relief valve.
+      pending-deploy-max-lag = 20
+
+      # During an active deploy-finalization grace window, the lag cap
+      # widens to this value. The "absolute safe lag during recovery"
+      # ceiling.
+      deploy-recovery-max-lag = 64
+    }
   }
 
   # Finalizer configuration — controls how the node finds and confirms finalized blocks.

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -431,7 +431,10 @@ casper {
 
       # During an active deploy-finalization grace window, the lag cap
       # widens to this value. The "absolute safe lag during recovery"
-      # ceiling.
+      # ceiling. Should be >= pending-deploy-max-lag to take effect:
+      # the proposer uses max(pending-deploy-max-lag, deploy-recovery-
+      # max-lag), so values below collapse to the pending floor and the
+      # knob has no effect (a startup warning fires in that case).
       deploy-recovery-max-lag = 64
     }
   }

--- a/node/src/rust/configuration/commandline/config_mapper.rs
+++ b/node/src/rust/configuration/commandline/config_mapper.rs
@@ -38,14 +38,8 @@ impl ConfigMapper<Options> for NodeConf {
             // to keep them in sync at load time, but by this point the
             // substitution has already resolved, so overriding only
             // protocol_server leaves the client stuck on the HOCON default.
-            Self::try_override_value(
-                &mut self.protocol_server.network_id,
-                run.network_id.clone(),
-            );
-            Self::try_override_value(
-                &mut self.protocol_client.network_id,
-                run.network_id,
-            );
+            Self::try_override_value(&mut self.protocol_server.network_id, run.network_id.clone());
+            Self::try_override_value(&mut self.protocol_client.network_id, run.network_id);
             Self::try_override_option(&mut self.protocol_server.host, run.host);
             Self::try_override_bool(
                 &mut self.protocol_server.use_random_ports,
@@ -347,6 +341,26 @@ impl ConfigMapper<Options> for NodeConf {
                 &mut self.casper.heartbeat_conf.max_lfb_age,
                 run.heartbeat_max_lfb_age,
             );
+            Self::try_override_value(
+                &mut self.casper.heartbeat_conf.stale_recovery_min_interval,
+                run.heartbeat_stale_recovery_interval,
+            );
+            Self::try_override_value(
+                &mut self.casper.heartbeat_conf.deploy_finalization_grace,
+                run.heartbeat_deploy_finalization_grace,
+            );
+            Self::try_override_value(
+                &mut self.casper.heartbeat_conf.advanced.frontier_chase_max_lag,
+                run.heartbeat_advanced_frontier_chase_max_lag,
+            );
+            Self::try_override_value(
+                &mut self.casper.heartbeat_conf.advanced.pending_deploy_max_lag,
+                run.heartbeat_advanced_pending_deploy_max_lag,
+            );
+            Self::try_override_value(
+                &mut self.casper.heartbeat_conf.advanced.deploy_recovery_max_lag,
+                run.heartbeat_advanced_deploy_recovery_max_lag,
+            );
         }
     }
 
@@ -463,7 +477,12 @@ mod tests {
         "--heartbeat-enabled",
         "--heartbeat-disabled",
         "--heartbeat-check-interval=111111seconds",
-        "--heartbeat-max-lfb-age=222222seconds"
+        "--heartbeat-max-lfb-age=222222seconds",
+        "--heartbeat-stale-recovery-interval=333333seconds",
+        "--heartbeat-deploy-finalization-grace=444444seconds",
+        "--heartbeat-advanced-frontier-chase-max-lag=111",
+        "--heartbeat-advanced-pending-deploy-max-lag=222",
+        "--heartbeat-advanced-deploy-recovery-max-lag=333"
         ];
 
         let res = Options::try_parse_from(argv);
@@ -606,6 +625,11 @@ mod tests {
                 heartbeat_disabled: true,
                 heartbeat_check_interval: Some(Duration::from_secs(111111)),
                 heartbeat_max_lfb_age: Some(Duration::from_secs(222222)),
+                heartbeat_stale_recovery_interval: Some(Duration::from_secs(333333)),
+                heartbeat_deploy_finalization_grace: Some(Duration::from_secs(444444)),
+                heartbeat_advanced_frontier_chase_max_lag: Some(111),
+                heartbeat_advanced_pending_deploy_max_lag: Some(222),
+                heartbeat_advanced_deploy_recovery_max_lag: Some(333),
             })),
         };
 
@@ -721,6 +745,7 @@ mod tests {
                     check_interval: Duration::from_secs(30),
                     max_lfb_age: Duration::from_secs(60),
                     self_propose_cooldown: Duration::from_secs(15),
+                    ..casper::rust::casper_conf::HeartbeatConf::default()
                 },
                 disable_late_block_filtering: true,
                 enable_mergeable_channel_gc: false,
@@ -933,6 +958,44 @@ mod tests {
         assert_eq!(
             default_config.casper.heartbeat_conf.max_lfb_age,
             Duration::from_secs(222222)
+        );
+        assert_eq!(
+            default_config
+                .casper
+                .heartbeat_conf
+                .stale_recovery_min_interval,
+            Duration::from_secs(333333)
+        );
+        assert_eq!(
+            default_config
+                .casper
+                .heartbeat_conf
+                .deploy_finalization_grace,
+            Duration::from_secs(444444)
+        );
+        assert_eq!(
+            default_config
+                .casper
+                .heartbeat_conf
+                .advanced
+                .frontier_chase_max_lag,
+            111
+        );
+        assert_eq!(
+            default_config
+                .casper
+                .heartbeat_conf
+                .advanced
+                .pending_deploy_max_lag,
+            222
+        );
+        assert_eq!(
+            default_config
+                .casper
+                .heartbeat_conf
+                .advanced
+                .deploy_recovery_max_lag,
+            333
         );
 
         // Round robin dispatcher fields

--- a/node/src/rust/configuration/commandline/config_mapper.rs
+++ b/node/src/rust/configuration/commandline/config_mapper.rs
@@ -343,7 +343,7 @@ impl ConfigMapper<Options> for NodeConf {
             );
             Self::try_override_value(
                 &mut self.casper.heartbeat_conf.stale_recovery_min_interval,
-                run.heartbeat_stale_recovery_interval,
+                run.heartbeat_stale_recovery_min_interval,
             );
             Self::try_override_value(
                 &mut self.casper.heartbeat_conf.deploy_finalization_grace,
@@ -478,7 +478,7 @@ mod tests {
         "--heartbeat-disabled",
         "--heartbeat-check-interval=111111seconds",
         "--heartbeat-max-lfb-age=222222seconds",
-        "--heartbeat-stale-recovery-interval=333333seconds",
+        "--heartbeat-stale-recovery-min-interval=333333seconds",
         "--heartbeat-deploy-finalization-grace=444444seconds",
         "--heartbeat-advanced-frontier-chase-max-lag=111",
         "--heartbeat-advanced-pending-deploy-max-lag=222",
@@ -521,6 +521,31 @@ mod tests {
             assert!(run.heartbeat_enabled);
         } else {
             panic!("Expected run subcommand");
+        }
+    }
+
+    #[test]
+    fn test_parse_args_negative_advanced_lag_rejected() {
+        // The three advanced lag-cap flags use a value_parser that
+        // rejects negative integers; a negative cap would silently
+        // disable the corresponding code path in the proposer.
+        for flag in &[
+            "--heartbeat-advanced-frontier-chase-max-lag",
+            "--heartbeat-advanced-pending-deploy-max-lag",
+            "--heartbeat-advanced-deploy-recovery-max-lag",
+        ] {
+            let arg = format!("{flag}=-1");
+            let argv = vec!["rnode", "run", &arg];
+            match Options::try_parse_from(&argv) {
+                Ok(_) => panic!("{flag}=-1 should fail clap parse, got Ok"),
+                Err(e) => {
+                    let err = e.to_string();
+                    assert!(
+                        err.contains("value must be >= 0"),
+                        "clap error for {flag} should mention non-negative requirement, got: {err}"
+                    );
+                }
+            }
         }
     }
 
@@ -625,7 +650,7 @@ mod tests {
                 heartbeat_disabled: true,
                 heartbeat_check_interval: Some(Duration::from_secs(111111)),
                 heartbeat_max_lfb_age: Some(Duration::from_secs(222222)),
-                heartbeat_stale_recovery_interval: Some(Duration::from_secs(333333)),
+                heartbeat_stale_recovery_min_interval: Some(Duration::from_secs(333333)),
                 heartbeat_deploy_finalization_grace: Some(Duration::from_secs(444444)),
                 heartbeat_advanced_frontier_chase_max_lag: Some(111),
                 heartbeat_advanced_pending_deploy_max_lag: Some(222),

--- a/node/src/rust/configuration/commandline/options.rs
+++ b/node/src/rust/configuration/commandline/options.rs
@@ -476,6 +476,44 @@ pub struct RunOptions {
     /// Maximum age of last finalized block before triggering heartbeat
     #[arg(long = "heartbeat-max-lfb-age", value_parser = ValueParser::new(parse_duration))]
     pub heartbeat_max_lfb_age: Option<Duration>,
+
+    /// Minimum age of LFB/frontier before stale-recovery, leader-recovery,
+    /// and pending-deploy backstop are allowed to fire. Debounces empty-block
+    /// churn when the cluster is healthy.
+    #[arg(long = "heartbeat-stale-recovery-interval", value_parser = ValueParser::new(parse_duration))]
+    pub heartbeat_stale_recovery_interval: Option<Duration>,
+
+    /// When pending deploys land, opens a grace window during which lag caps
+    /// relax to advanced.deploy-recovery-max-lag and self-propose-cooldown
+    /// is bypassable. Burst-tolerance budget.
+    #[arg(long = "heartbeat-deploy-finalization-grace", value_parser = ValueParser::new(parse_duration))]
+    pub heartbeat_deploy_finalization_grace: Option<Duration>,
+
+    /// EXPERIMENTAL: when this validator is already ahead of LFB, blocks of
+    /// lag tolerated before "frontier-follow" proposing is throttled.
+    #[arg(
+        long = "heartbeat-advanced-frontier-chase-max-lag",
+        hide_short_help = true
+    )]
+    pub heartbeat_advanced_frontier_chase_max_lag: Option<i64>,
+
+    /// EXPERIMENTAL: if validator has pending deploys but is > N blocks
+    /// ahead of LFB, suppress pending-deploy proposing. Lower → harder
+    /// load-relief valve.
+    #[arg(
+        long = "heartbeat-advanced-pending-deploy-max-lag",
+        hide_short_help = true
+    )]
+    pub heartbeat_advanced_pending_deploy_max_lag: Option<i64>,
+
+    /// EXPERIMENTAL: during an active deploy-finalization grace window,
+    /// the lag cap widens to this value. The "absolute safe lag during
+    /// recovery" ceiling.
+    #[arg(
+        long = "heartbeat-advanced-deploy-recovery-max-lag",
+        hide_short_help = true
+    )]
+    pub heartbeat_advanced_deploy_recovery_max_lag: Option<i64>,
 }
 
 /// Keygen subcommand - Generates a public/private key pair

--- a/node/src/rust/configuration/commandline/options.rs
+++ b/node/src/rust/configuration/commandline/options.rs
@@ -16,6 +16,21 @@ use super::converters::{PrivateKeyConverter, PublicKeyConverter, VecNameConverte
 pub const GRPC_INTERNAL_PORT: u16 = 40402;
 pub const GRPC_EXTERNAL_PORT: u16 = 40401;
 
+/// Parse an `i64` from CLI text, rejecting negative values.
+///
+/// Used for the heartbeat lag-cap flags whose downstream comparison
+/// sites assume the cap is non-negative (`lag <= cap`); a negative
+/// value would silently disable the corresponding code path.
+fn parse_non_negative_i64(s: &str) -> Result<i64, String> {
+    let v: i64 = s
+        .parse()
+        .map_err(|e: std::num::ParseIntError| e.to_string())?;
+    if v < 0 {
+        return Err(format!("value must be >= 0, got {}", v));
+    }
+    Ok(v)
+}
+
 /// F1r3fly node command-line interface
 #[derive(Parser)]
 #[command(
@@ -480,8 +495,8 @@ pub struct RunOptions {
     /// Minimum age of LFB/frontier before stale-recovery, leader-recovery,
     /// and pending-deploy backstop are allowed to fire. Debounces empty-block
     /// churn when the cluster is healthy.
-    #[arg(long = "heartbeat-stale-recovery-interval", value_parser = ValueParser::new(parse_duration))]
-    pub heartbeat_stale_recovery_interval: Option<Duration>,
+    #[arg(long = "heartbeat-stale-recovery-min-interval", value_parser = ValueParser::new(parse_duration))]
+    pub heartbeat_stale_recovery_min_interval: Option<Duration>,
 
     /// When pending deploys land, opens a grace window during which lag caps
     /// relax to advanced.deploy-recovery-max-lag and self-propose-cooldown
@@ -491,26 +506,32 @@ pub struct RunOptions {
 
     /// EXPERIMENTAL: when this validator is already ahead of LFB, blocks of
     /// lag tolerated before "frontier-follow" proposing is throttled.
+    /// Must be >= 0; negative values are rejected at parse time.
     #[arg(
         long = "heartbeat-advanced-frontier-chase-max-lag",
+        value_parser = ValueParser::new(parse_non_negative_i64),
         hide_short_help = true
     )]
     pub heartbeat_advanced_frontier_chase_max_lag: Option<i64>,
 
     /// EXPERIMENTAL: if validator has pending deploys but is > N blocks
     /// ahead of LFB, suppress pending-deploy proposing. Lower → harder
-    /// load-relief valve.
+    /// load-relief valve. Must be >= 0; negative values are rejected.
     #[arg(
         long = "heartbeat-advanced-pending-deploy-max-lag",
+        value_parser = ValueParser::new(parse_non_negative_i64),
         hide_short_help = true
     )]
     pub heartbeat_advanced_pending_deploy_max_lag: Option<i64>,
 
     /// EXPERIMENTAL: during an active deploy-finalization grace window,
     /// the lag cap widens to this value. The "absolute safe lag during
-    /// recovery" ceiling.
+    /// recovery" ceiling. Should be >= heartbeat-advanced-pending-deploy-
+    /// max-lag to take effect; values below collapse to the pending
+    /// floor and the knob has no effect. Must be >= 0.
     #[arg(
         long = "heartbeat-advanced-deploy-recovery-max-lag",
+        value_parser = ValueParser::new(parse_non_negative_i64),
         hide_short_help = true
     )]
     pub heartbeat_advanced_deploy_recovery_max_lag: Option<i64>,

--- a/node/src/rust/configuration/mod.rs
+++ b/node/src/rust/configuration/mod.rs
@@ -141,6 +141,31 @@ pub mod builder {
             .validate_native_token()
             .map_err(|e| eyre::eyre!("native token config invalid: {}", e))?;
 
+        // The proposer computes its recovery cap as
+        // `max(pending_deploy_max_lag, deploy_recovery_max_lag)`. When
+        // deploy_recovery is set below pending_deploy, the recovery knob
+        // collapses to the pending floor and has no effect — warn the
+        // operator instead of letting the misconfiguration sit silently.
+        let pending_deploy_max_lag = node_conf
+            .casper
+            .heartbeat_conf
+            .advanced
+            .pending_deploy_max_lag;
+        let deploy_recovery_max_lag = node_conf
+            .casper
+            .heartbeat_conf
+            .advanced
+            .deploy_recovery_max_lag;
+        if deploy_recovery_max_lag < pending_deploy_max_lag {
+            tracing::warn!(
+                "casper.heartbeat.advanced.deploy-recovery-max-lag ({}) is less than \
+                pending-deploy-max-lag ({}); the recovery knob has no effect under this \
+                configuration. Set deploy-recovery-max-lag >= pending-deploy-max-lag.",
+                deploy_recovery_max_lag,
+                pending_deploy_max_lag,
+            );
+        }
+
         Ok(())
     }
 
@@ -211,12 +236,14 @@ mod heartbeat_conf_hocon_tests {
     use std::time::Duration;
 
     fn parse_heartbeat(hocon_text: &str) -> HeartbeatConf {
+        try_parse_heartbeat(hocon_text).expect("HOCON should deserialize into HeartbeatConf")
+    }
+
+    fn try_parse_heartbeat(hocon_text: &str) -> Result<HeartbeatConf, String> {
         let loader = hocon::HoconLoader::new()
             .load_str(hocon_text)
-            .expect("HOCON should parse");
-        loader
-            .resolve()
-            .expect("HOCON should deserialize into HeartbeatConf")
+            .map_err(|e| format!("hocon load: {e}"))?;
+        loader.resolve().map_err(|e| format!("hocon resolve: {e}"))
     }
 
     #[test]
@@ -285,5 +312,40 @@ mod heartbeat_conf_hocon_tests {
         assert_eq!(cfg.advanced.frontier_chase_max_lag, 0);
         assert_eq!(cfg.advanced.pending_deploy_max_lag, 7);
         assert_eq!(cfg.advanced.deploy_recovery_max_lag, 64);
+    }
+
+    #[test]
+    fn negative_advanced_lag_values_are_rejected() {
+        // Negative caps would silently disable the corresponding code
+        // path in the proposer (e.g. `lag <= cap` where cap < 0 is
+        // never true). Each of the three advanced fields rejects at
+        // deserialization time.
+        for field in &[
+            "frontier-chase-max-lag",
+            "pending-deploy-max-lag",
+            "deploy-recovery-max-lag",
+        ] {
+            let hocon = format!(
+                r#"
+                enabled = false
+                check-interval = 5 seconds
+                max-lfb-age = 5 seconds
+                advanced {{
+                  {field} = -1
+                }}
+                "#
+            );
+            let result = try_parse_heartbeat(&hocon);
+            assert!(
+                result.is_err(),
+                "negative {field} should fail HOCON deserialization, got Ok({:?})",
+                result.ok()
+            );
+            let err = result.unwrap_err();
+            assert!(
+                err.contains("value must be >= 0"),
+                "error for {field} should mention non-negative requirement, got: {err}"
+            );
+        }
     }
 }

--- a/node/src/rust/configuration/mod.rs
+++ b/node/src/rust/configuration/mod.rs
@@ -32,9 +32,7 @@ pub mod builder {
     ///
     /// # Returns
     /// * `Result<(NodeConf, Profile, Option<PathBuf>)>` - Configuration tuple
-    pub fn build(
-        options: Options,
-    ) -> eyre::Result<(NodeConf, Profile, Option<PathBuf>)> {
+    pub fn build(options: Options) -> eyre::Result<(NodeConf, Profile, Option<PathBuf>)> {
         let profile = options
             .profile
             .as_ref()
@@ -200,3 +198,92 @@ pub mod builder {
 
 // Re-export commonly used types
 pub use builder::build;
+
+#[cfg(test)]
+mod heartbeat_conf_hocon_tests {
+    //! Targeted HOCON deserialization tests for the heartbeat tuning fields.
+    //!
+    //! Lives here (rather than in `casper::casper_conf`) because the `hocon`
+    //! crate is a `node` dependency, not a `casper` dependency. Exercises
+    //! the same `serde::Deserialize` path the production binary uses.
+
+    use casper::rust::casper_conf::{HeartbeatAdvancedConf, HeartbeatConf};
+    use std::time::Duration;
+
+    fn parse_heartbeat(hocon_text: &str) -> HeartbeatConf {
+        let loader = hocon::HoconLoader::new()
+            .load_str(hocon_text)
+            .expect("HOCON should parse");
+        loader
+            .resolve()
+            .expect("HOCON should deserialize into HeartbeatConf")
+    }
+
+    #[test]
+    fn full_block_with_advanced_round_trips() {
+        let cfg = parse_heartbeat(
+            r#"
+            enabled = true
+            check-interval = 7 seconds
+            max-lfb-age = 8 seconds
+            self-propose-cooldown = 9 seconds
+            stale-recovery-min-interval = 11 seconds
+            deploy-finalization-grace = 22 seconds
+            advanced {
+              frontier-chase-max-lag = 1
+              pending-deploy-max-lag = 33
+              deploy-recovery-max-lag = 99
+            }
+            "#,
+        );
+
+        assert!(cfg.enabled);
+        assert_eq!(cfg.check_interval, Duration::from_secs(7));
+        assert_eq!(cfg.max_lfb_age, Duration::from_secs(8));
+        assert_eq!(cfg.self_propose_cooldown, Duration::from_secs(9));
+        assert_eq!(cfg.stale_recovery_min_interval, Duration::from_secs(11));
+        assert_eq!(cfg.deploy_finalization_grace, Duration::from_secs(22));
+        assert_eq!(cfg.advanced.frontier_chase_max_lag, 1);
+        assert_eq!(cfg.advanced.pending_deploy_max_lag, 33);
+        assert_eq!(cfg.advanced.deploy_recovery_max_lag, 99);
+    }
+
+    #[test]
+    fn missing_new_fields_fall_back_to_defaults() {
+        // A HOCON config that omits the new keys must still parse and use
+        // the defaults declared on HeartbeatConf / HeartbeatAdvancedConf.
+        let cfg = parse_heartbeat(
+            r#"
+            enabled = false
+            check-interval = 5 seconds
+            max-lfb-age = 5 seconds
+            "#,
+        );
+
+        assert_eq!(cfg.self_propose_cooldown, Duration::from_secs(15));
+        assert_eq!(cfg.stale_recovery_min_interval, Duration::from_secs(12));
+        assert_eq!(cfg.deploy_finalization_grace, Duration::from_secs(25));
+        // Advanced block absent → all three fields default.
+        assert_eq!(cfg.advanced, HeartbeatAdvancedConf::default());
+    }
+
+    #[test]
+    fn partial_advanced_block_defaults_remaining_fields() {
+        // A partial advanced block fills missing fields with defaults
+        // rather than failing to parse.
+        let cfg = parse_heartbeat(
+            r#"
+            enabled = false
+            check-interval = 5 seconds
+            max-lfb-age = 5 seconds
+            advanced {
+              pending-deploy-max-lag = 7
+            }
+            "#,
+        );
+
+        assert_eq!(cfg.advanced.frontier_chase_max_lag, 0);
+        assert_eq!(cfg.advanced.pending_deploy_max_lag, 7);
+        assert_eq!(cfg.advanced.deploy_recovery_max_lag, 64);
+    }
+}

--- a/node/src/rust/configuration/model.rs
+++ b/node/src/rust/configuration/model.rs
@@ -213,7 +213,11 @@ pub struct Metrics {
 
     /// How often the metric reporters poll and emit. Drives the InfluxDB
     /// HTTP/UDP and Sigar (system-metrics) reporters.
-    #[serde(rename = "tick-interval", default = "default_tick_interval", with = "duration_secs")]
+    #[serde(
+        rename = "tick-interval",
+        default = "default_tick_interval",
+        with = "duration_secs"
+    )]
     pub tick_interval: Duration,
 
     /// Endpoint settings for the InfluxDB reporters (HTTP and UDP). Both
@@ -255,7 +259,9 @@ mod duration_secs {
         if parts.len() != 2 {
             return Err(format!("invalid duration: {}", s));
         }
-        let n: u64 = parts[0].parse().map_err(|_| format!("invalid number: {}", parts[0]))?;
+        let n: u64 = parts[0]
+            .parse()
+            .map_err(|_| format!("invalid number: {}", parts[0]))?;
         let mult = match parts[1].to_lowercase().as_str() {
             "second" | "seconds" | "s" => 1,
             "minute" | "minutes" | "m" => 60,

--- a/node/src/rust/diagnostics/tests.rs
+++ b/node/src/rust/diagnostics/tests.rs
@@ -70,6 +70,7 @@ mod tests {
                 check_interval: Duration::from_secs(60),
                 max_lfb_age: Duration::from_secs(300),
                 self_propose_cooldown: Duration::from_secs(15),
+                ..HeartbeatConf::default()
             },
             disable_late_block_filtering: true,
             enable_mergeable_channel_gc: false,

--- a/node/src/rust/instances/heartbeat_proposer.rs
+++ b/node/src/rust/instances/heartbeat_proposer.rs
@@ -37,12 +37,6 @@ impl HeartbeatSignal for NotifyHeartbeatSignal {
 /// needs to be proposed to maintain liveness.
 pub struct HeartbeatProposer;
 
-const FRONTIER_CHASE_MAX_LAG: i64 = 0;
-const PENDING_DEPLOY_MAX_LAG: i64 = 20;
-const DEPLOY_RECOVERY_MAX_LAG: i64 = 64;
-const STALE_RECOVERY_MIN_INTERVAL_MS: u128 = 12_000;
-const DEPLOY_FINALIZATION_GRACE_MS: u128 = 25_000;
-
 #[derive(Debug, Clone, Copy, Default)]
 struct HeartbeatCheckResult {
     bug_failure: bool,
@@ -190,7 +184,7 @@ impl HeartbeatProposer {
                     {
                         Ok(outcome) => {
                             if outcome.refresh_deploy_grace_window {
-                                let grace_ms = DEPLOY_FINALIZATION_GRACE_MS;
+                                let grace_ms = config.deploy_finalization_grace.as_millis();
                                 let grace_duration = Duration::from_millis(std::cmp::min(
                                     grace_ms,
                                     u128::from(u64::MAX),
@@ -303,6 +297,13 @@ async fn check_lfb_and_propose(
     standalone: bool,
     deploy_grace_active: bool,
 ) -> Result<HeartbeatCheckResult, casper::rust::errors::CasperError> {
+    // Tuning thresholds for lag caps and recovery timing. Read once into
+    // locals to keep the predicate sites below readable.
+    let frontier_chase_max_lag = config.advanced.frontier_chase_max_lag;
+    let pending_deploy_max_lag = config.advanced.pending_deploy_max_lag;
+    let advanced_deploy_recovery_max_lag = config.advanced.deploy_recovery_max_lag;
+    let stale_recovery_min_interval_ms = config.stale_recovery_min_interval.as_millis();
+
     // Check if we have pending user deploys in storage (not yet included in blocks)
     let has_pending_deploys = casper
         .has_pending_deploys_in_storage_for_snapshot(&snapshot)
@@ -406,10 +407,8 @@ async fn check_lfb_and_propose(
     // Keeping grace-only mode out of this hint avoids prolonged frontier-chase churn
     // once deploy pressure is gone.
     let deploy_recovery_hint = has_pending_deploys || has_new_parent_with_user_deploys;
-    let deploy_recovery_max_lag = std::cmp::max(
-        PENDING_DEPLOY_MAX_LAG,
-        DEPLOY_RECOVERY_MAX_LAG,
-    );
+    let deploy_recovery_max_lag =
+        std::cmp::max(pending_deploy_max_lag, advanced_deploy_recovery_max_lag);
 
     // Under active deploy-finalization recovery, allow a wider bounded chase window so
     // validators can keep up with fast parent growth without stalling on tight lag caps.
@@ -420,15 +419,11 @@ async fn check_lfb_and_propose(
         2
     };
     let effective_frontier_chase_cap = if deploy_recovery_hint {
-        std::cmp::max(
-            FRONTIER_CHASE_MAX_LAG,
-            deploy_recovery_frontier_chase_cap,
-        )
+        std::cmp::max(frontier_chase_max_lag, deploy_recovery_frontier_chase_cap)
     } else {
-        FRONTIER_CHASE_MAX_LAG
+        frontier_chase_max_lag
     };
-    let stale_recovery_interval_elapsed =
-        frontier_age_ms >= STALE_RECOVERY_MIN_INTERVAL_MS;
+    let stale_recovery_interval_elapsed = frontier_age_ms >= stale_recovery_min_interval_ms;
     let stale_recovery_window_open = stale_recovery_interval_elapsed || deploy_recovery_hint;
 
     // Proposal logic:
@@ -447,7 +442,7 @@ async fn check_lfb_and_propose(
     let can_propose_pending_deploys_while_ahead = if deploy_grace_active {
         lfb_lag_blocks <= deploy_recovery_max_lag
     } else {
-        lfb_lag_blocks <= PENDING_DEPLOY_MAX_LAG
+        lfb_lag_blocks <= pending_deploy_max_lag
     };
     let pending_deploys_due =
         has_pending_deploys && (!self_recently_proposed || can_propose_pending_deploys_while_ahead);
@@ -457,9 +452,7 @@ async fn check_lfb_and_propose(
         && self_recently_proposed
         && !can_propose_pending_deploys_while_ahead
         && self_latest_block_timestamp_ms
-            .map(|timestamp_ms| {
-                now.saturating_sub(timestamp_ms) >= STALE_RECOVERY_MIN_INTERVAL_MS
-            })
+            .map(|timestamp_ms| now.saturating_sub(timestamp_ms) >= stale_recovery_min_interval_ms)
             .unwrap_or(true)
         && (!self_proposed_too_recently || deploy_grace_active);
     let can_follow_frontier_without_pending_deploys =
@@ -485,7 +478,7 @@ async fn check_lfb_and_propose(
         && stale_recovery_window_open
         && (!self_recently_proposed || can_chase_frontier_while_ahead || deploy_grace_active);
     let lag_recovery_leader = is_lag_recovery_leader(&snapshot, validator_identity);
-    let lag_recovery_threshold = PENDING_DEPLOY_MAX_LAG;
+    let lag_recovery_threshold = pending_deploy_max_lag;
     let moderate_lag_recovery_threshold = std::cmp::max(1, lag_recovery_threshold / 2);
     let stale_lfb_leader_recovery_due = lfb_is_stale
         && (frontier_is_stale || lfb_lag_blocks > moderate_lag_recovery_threshold)
@@ -526,15 +519,15 @@ async fn check_lfb_and_propose(
                 if deploy_grace_active {
                     deploy_recovery_max_lag
                 } else {
-                    PENDING_DEPLOY_MAX_LAG
+                    pending_deploy_max_lag
                 },
-                STALE_RECOVERY_MIN_INTERVAL_MS
+                stale_recovery_min_interval_ms
             )
         } else if has_pending_deploys && !pending_deploys_due {
             format!(
                 "pending deploys exist but lag={} exceeds pending-deploy cap={} while already ahead of finalized (throttling)",
                 lfb_lag_blocks,
-                PENDING_DEPLOY_MAX_LAG
+                pending_deploy_max_lag
             )
         } else if has_pending_deploys {
             "pending user deploys in storage".to_string()
@@ -549,7 +542,7 @@ async fn check_lfb_and_propose(
                 effective_frontier_chase_cap,
                 has_new_parent_with_user_deploys,
                 deploy_grace_active,
-                STALE_RECOVERY_MIN_INTERVAL_MS
+                stale_recovery_min_interval_ms
             )
         } else if stale_lfb_leader_recovery_due {
             format!(
@@ -559,7 +552,7 @@ async fn check_lfb_and_propose(
                 frontier_is_stale,
                 moderate_lag_recovery_threshold,
                 deploy_grace_active,
-                STALE_RECOVERY_MIN_INTERVAL_MS
+                stale_recovery_min_interval_ms
             )
         } else if convergence_recovery_due {
             format!(
@@ -574,7 +567,7 @@ async fn check_lfb_and_propose(
                 lfb_lag_blocks,
                 lag_recovery_threshold,
                 deploy_grace_active,
-                STALE_RECOVERY_MIN_INTERVAL_MS
+                stale_recovery_min_interval_ms
             )
         } else if self_recently_proposed && has_new_parents && !can_chase_frontier_while_ahead {
             format!(
@@ -654,7 +647,7 @@ async fn check_lfb_and_propose(
             {
                 let pending_backstop_remaining_ms = self_latest_block_timestamp_ms
                     .map(|timestamp_ms| {
-                        STALE_RECOVERY_MIN_INTERVAL_MS
+                        stale_recovery_min_interval_ms
                             .saturating_sub(now.saturating_sub(timestamp_ms))
                     })
                     .unwrap_or(0);
@@ -664,7 +657,7 @@ async fn check_lfb_and_propose(
                     if deploy_grace_active {
                         deploy_recovery_max_lag
                     } else {
-                        PENDING_DEPLOY_MAX_LAG
+                        pending_deploy_max_lag
                     },
                     pending_backstop_remaining_ms
                 )
@@ -681,7 +674,7 @@ async fn check_lfb_and_propose(
                 format!(
                     "frontier-follow throttled by stale-recovery cadence: frontier_age_ms={}, min_interval_ms={}, user_deploy_parent={}, deploy_grace_active={}",
                     frontier_age_ms,
-                    STALE_RECOVERY_MIN_INTERVAL_MS,
+                    stale_recovery_min_interval_ms,
                     has_new_parent_with_user_deploys,
                     deploy_grace_active
                 )
@@ -716,7 +709,7 @@ async fn check_lfb_and_propose(
             format!(
                 "LFB is stale but stale-recovery cadence gate is active: frontier_age_ms={}, min_interval_ms={}, user_deploy_parent={}, deploy_grace_active={}",
                 frontier_age_ms,
-                STALE_RECOVERY_MIN_INTERVAL_MS,
+                stale_recovery_min_interval_ms,
                 has_new_parent_with_user_deploys,
                 deploy_grace_active
             )
@@ -900,6 +893,7 @@ mod tests {
             check_interval: Duration::from_secs(10),
             max_lfb_age: Duration::from_secs(60),
             self_propose_cooldown: Duration::from_secs(15),
+            ..HeartbeatConf::default()
         };
         let validator = create_test_validator_identity();
         let heartbeat_signal_ref = new_heartbeat_signal_ref();
@@ -931,6 +925,7 @@ mod tests {
             check_interval: Duration::from_secs(10),
             max_lfb_age: Duration::from_secs(60),
             self_propose_cooldown: Duration::from_secs(15),
+            ..HeartbeatConf::default()
         };
         let validator = create_test_validator_identity();
         let heartbeat_signal_ref = new_heartbeat_signal_ref();
@@ -963,6 +958,7 @@ mod tests {
             check_interval: Duration::from_secs(1),
             max_lfb_age: Duration::from_secs(60),
             self_propose_cooldown: Duration::from_secs(15),
+            ..HeartbeatConf::default()
         };
         let validator = create_test_validator_identity();
         let heartbeat_signal_ref = new_heartbeat_signal_ref();
@@ -1064,6 +1060,7 @@ mod tests {
                 check_interval: Duration::from_secs(1),
                 max_lfb_age: Duration::from_secs(10),
                 self_propose_cooldown: Duration::from_secs(15),
+                ..HeartbeatConf::default()
             };
 
             // Call do_heartbeat_check directly (standalone=false for multi-node test)
@@ -1109,6 +1106,7 @@ mod tests {
                 check_interval: Duration::from_secs(1),
                 max_lfb_age: Duration::from_secs(1),
                 self_propose_cooldown: Duration::from_secs(15),
+                ..HeartbeatConf::default()
             };
 
             // Call do_heartbeat_check directly (standalone=false for multi-node test)
@@ -1148,6 +1146,7 @@ mod tests {
                 check_interval: Duration::from_secs(1),
                 max_lfb_age: Duration::from_secs(1),
                 self_propose_cooldown: Duration::from_secs(15),
+                ..HeartbeatConf::default()
             };
 
             // Call do_heartbeat_check directly (standalone=false for multi-node test)
@@ -1193,6 +1192,7 @@ mod tests {
                 check_interval: Duration::from_secs(1),
                 max_lfb_age: Duration::from_secs(10),
                 self_propose_cooldown: Duration::from_secs(15),
+                ..HeartbeatConf::default()
             };
 
             // Call do_heartbeat_check directly (standalone=false for multi-node test)
@@ -1241,6 +1241,7 @@ mod tests {
                 check_interval: Duration::from_secs(1),
                 max_lfb_age: Duration::from_secs(10),
                 self_propose_cooldown: Duration::from_secs(15),
+                ..HeartbeatConf::default()
             };
 
             // Call do_heartbeat_check directly (standalone=false for multi-node test)


### PR DESCRIPTION
Closes #498.

Lifts the 5 hardcoded heartbeat-proposer constants into HOCON keys + clap CLI flags, split into stable and experimental tiers.

| Tier | HOCON path | CLI flag | Default |
|---|---|---|---|
| Stable | `casper.heartbeat.stale-recovery-min-interval` | `--heartbeat-stale-recovery-interval` | `12 seconds` |
| Stable | `casper.heartbeat.deploy-finalization-grace` | `--heartbeat-deploy-finalization-grace` | `25 seconds` |
| Experimental | `casper.heartbeat.advanced.frontier-chase-max-lag` | `--heartbeat-advanced-frontier-chase-max-lag` | `0` |
| Experimental | `casper.heartbeat.advanced.pending-deploy-max-lag` | `--heartbeat-advanced-pending-deploy-max-lag` | `20` |
| Experimental | `casper.heartbeat.advanced.deploy-recovery-max-lag` | `--heartbeat-advanced-deploy-recovery-max-lag` | `64` |

The advanced trio is namespaced separately so it can be replaced in the future without breaking configs that reference the stable namespace. The corresponding CLI flags use clap's `hide_short_help` — visible in `--help`, hidden from `-h`.

Defaults match the previous hardcoded values exactly. A node started with no overrides reproduces today's behavior bit-for-bit.

## Test plan

- [x] `cargo build --release -p node`
- [x] `cargo test --release -p node heartbeat` (13/13: 10 proposer + 3 new HOCON tests)
- [x] `cargo test --release -p node config_map` (4/4 override-defaults, all 5 new flags covered)
- [x] `--help` shows all 5 new flags; `-h` hides the experimental trio
- [ ] Reviewer: confirm `default_*` fn values match the previous constants (`0 / 20 / 64 / 12s / 25s`)

Co-Authored-By: Claude <noreply@anthropic.com>