### PR TITLE
feat(lfs): joiner-side coverage + orchestrator multi-root pagination fix for multi-bonded shards

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -251,29 +251,98 @@ jobs:
           name: artifacts-docker-${{ matrix.arch }}
           path: /tmp/rust-node-docker.tar.gz
 
-  # Integration tests on OCI self-hosted runners (one runner per arch).
-  # All tests run in a single pytest invocation per arch, matching local dev
-  # workflow. The static shard boots once and stays up for all shard tests;
-  # custom shard tests boot/teardown their own shards per-test.
+  # Launch the ephemeral OCI VMs that will pick up the integration-tests
+  # matrix jobs. Runs in parallel with build_rust_docker_image so the
+  # ~1-minute launch overhead overlaps with the ~7-minute Docker build.
+  # Each launched VM boots from a baked image, registers itself as a
+  # GitHub Actions runner with f1r3fly-rust-ci-ephemeral labels, picks up
+  # exactly one matrix job, then self-terminates. See
+  # F1R3FLY-io/system-integration ci/oci-runners/ for the full lifecycle.
+  launch_ephemeral_runners:
+    name: Launch Ephemeral Runners
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write  # needed for gh api ... actions/runners/registration-token
+    timeout-minutes: 10
+    steps:
+      - name: Clone system-integration
+        uses: actions/checkout@v4
+        with:
+          repository: F1R3FLY-io/system-integration
+          ref: refactor/integration-test-framework
+          path: system-integration
+
+      - name: Install OCI CLI
+        shell: bash -ex {0}
+        run: |
+          bash -c "$(curl -L https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh)" -- \
+            --accept-all-defaults --install-dir /opt/oci-cli --exec-dir /usr/local/bin
+          oci --version
+
+      - name: Configure OCI auth from secrets
+        shell: bash -ex {0}
+        env:
+          OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
+          OCI_USER_OCID: ${{ secrets.OCI_USER_OCID }}
+          OCI_REGION: ${{ secrets.OCI_REGION }}
+          OCI_FINGERPRINT: ${{ secrets.OCI_FINGERPRINT }}
+          OCI_PRIVATE_KEY: ${{ secrets.OCI_PRIVATE_KEY }}
+        run: |
+          mkdir -p ~/.oci
+          printf '%s\n' "$OCI_PRIVATE_KEY" > ~/.oci/oci_api_key.pem
+          chmod 600 ~/.oci/oci_api_key.pem
+          cat > ~/.oci/config <<EOF
+          [DEFAULT]
+          user=$OCI_USER_OCID
+          fingerprint=$OCI_FINGERPRINT
+          tenancy=$OCI_TENANCY_OCID
+          region=$OCI_REGION
+          key_file=$HOME/.oci/oci_api_key.pem
+          EOF
+          chmod 600 ~/.oci/config
+          oci iam region list >/dev/null && echo "OCI auth OK"
+
+      - name: Launch 5 amd64 + 5 arm64 ephemeral runners
+        shell: bash -ex {0}
+        env:
+          # The default GITHUB_TOKEN can't mint runner registration tokens
+          # even with permissions: actions: write — that endpoint requires
+          # admin-on-repo scope. RELEASE_PAT is already provisioned with the
+          # repo scope (used by the release job) so reuse it here.
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          SUPPRESS_LABEL_WARNING: "True"
+        run: |
+          cd system-integration/ci/oci-runners
+          # Launch in parallel; each script exits as soon as the OCI launch
+          # API call returns (the VM continues booting in the background and
+          # registers itself via cloud-init).
+          for _ in $(seq 1 5); do ./launch-runner.sh amd64 & done
+          for _ in $(seq 1 5); do ./launch-runner.sh arm64 & done
+          wait
+          echo "All 10 ephemeral runner VMs submitted."
+
+  # Integration tests run on ephemeral OCI runners — one fresh VM per matrix
+  # job, self-terminating after the job completes. 5 amd64 + 5 arm64 = 10
+  # parallel jobs against the Docker image artifact from build_rust_docker_image.
   required_rust_integration_tests:
-    name: Integration Tests (${{ matrix.arch }})
-    needs: build_rust_docker_image
+    name: Integration Tests (${{ matrix.arch }}-${{ matrix.slot }})
+    needs: [build_rust_docker_image, launch_ephemeral_runners]
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - arch: amd64
-            runner: [self-hosted, Linux, X64, f1r3fly-rust-ci]
-          - arch: arm64
-            runner: [self-hosted, Linux, ARM64, f1r3fly-rust-ci]
+          - { arch: amd64, slot: 1, runner: [self-hosted, linux, x64,   f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: amd64, slot: 2, runner: [self-hosted, linux, x64,   f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: amd64, slot: 3, runner: [self-hosted, linux, x64,   f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: amd64, slot: 4, runner: [self-hosted, linux, x64,   f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: amd64, slot: 5, runner: [self-hosted, linux, x64,   f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: arm64, slot: 1, runner: [self-hosted, linux, arm64, f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: arm64, slot: 2, runner: [self-hosted, linux, arm64, f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: arm64, slot: 3, runner: [self-hosted, linux, arm64, f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: arm64, slot: 4, runner: [self-hosted, linux, arm64, f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: arm64, slot: 5, runner: [self-hosted, linux, arm64, f1r3fly-rust-ci-ephemeral, oracle-cloud] }
     steps:
-      - name: Clean self-hosted runner state
-        shell: bash {0}
-        run: |
-          sudo rm -rf system-integration/integration-tests/data
-          rm -f /tmp/rust-node-docker.tar.gz /tmp/*.log
-
       - name: Clone Repository
         uses: actions/checkout@v4
 
@@ -281,22 +350,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: F1R3FLY-io/system-integration
-          ref: 2ace29f4f45b26418749edb9477ec2a310be9c6c
+          ref: refactor/integration-test-framework
           path: system-integration
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-          cache: 'pip'
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: 1.8.5
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-
-      - name: Load Docker Image
+      - name: Load Docker Image (from build_rust_docker_image artifact)
         uses: actions/download-artifact@v4
         with:
           name: artifacts-docker-${{ matrix.arch }}
@@ -306,25 +363,17 @@ jobs:
         shell: bash -ex {0}
         run: |
           zcat /tmp/rust-node-docker.tar.gz | docker image load
-          docker tag f1r3flyindustries/f1r3fly-rust-node:${{ matrix.arch }} f1r3flyindustries/f1r3fly-rust-node
+          docker tag f1r3flyindustries/f1r3fly-rust-node:${{ matrix.arch }} f1r3flyindustries/f1r3fly-rust-node:latest
 
-      - name: Install docker-compose
+      - name: Extract rnode binary from image (for subprocess provider)
         shell: bash -ex {0}
         run: |
-          if ! command -v docker-compose &>/dev/null; then
-            sudo curl -L "https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-            sudo chmod +x /usr/local/bin/docker-compose
-          fi
-          docker-compose --version
-
-      - name: Reset Docker networking
-        shell: bash {0}
-        run: |
-          docker rm -f $(docker ps -aq) 2>/dev/null || true
-          docker network prune -f 2>/dev/null || true
-          echo "Restarting Docker daemon to clear any TIME_WAIT sockets from previous runs"
-          sudo systemctl restart docker
-          sleep 3
+          docker create --name extract-rnode f1r3flyindustries/f1r3fly-rust-node:latest
+          docker cp extract-rnode:/opt/docker/bin/node /tmp/rnode
+          chmod +x /tmp/rnode
+          docker rm extract-rnode
+          /tmp/rnode --version 2>/dev/null || true
+          ldd /tmp/rnode
 
       - name: Install system-integration dependencies
         shell: bash -ex {0}
@@ -333,10 +382,11 @@ jobs:
           poetry lock --no-update
           poetry install --with integration
 
-      - name: Run Integration Tests
+      - name: Run Integration Tests (subprocess provider)
         shell: bash -ex {0}
         env:
-          DEFAULT_IMAGE: f1r3flyindustries/f1r3fly-rust-node
+          F1R3FLY_NODE_BINARY: /tmp/rnode
+          F1R3FLY_NODE_DEFAULTS_CONF: ${{ github.workspace }}/node/src/main/resources/defaults.conf
         run: |
           cd system-integration
           SCALE_FLAG=""
@@ -344,56 +394,27 @@ jobs:
             SCALE_FLAG="--timeout-scale=1.5"
           fi
           poetry run pytest \
-            integration-tests/test/test_web_api.py \
-            integration-tests/test/test_wallets.py \
-            integration-tests/test/test_heartbeat.py \
-            integration-tests/test/test_deployment.py \
-            integration-tests/test/test_storage.py \
-            integration-tests/test/test_genesis_ceremony.py \
-            integration-tests/test/test_dag_correctness.py \
-            integration-tests/test/test_finalization.py \
-            integration-tests/test/test_propose.py \
-            integration-tests/test/test_replay_correctness.py \
-            integration-tests/test/test_convergence.py \
-            integration-tests/test/test_bridge_admin.py \
-            integration-tests/test/test_shard_degradation.py \
-            integration-tests/test/test_consensus_health.py \
-            integration-tests/test/test_websocket.py \
-            integration-tests/test/test_synchrony_constraint.py \
-            integration-tests/test/test_asymmetric_bonds.py \
-            integration-tests/test/test_bonding_validators.py \
-            integration-tests/test/test_trim_state.py \
-            -v --tb=short --log-cli-level=WARNING \
-            -n 3 --dist=loadgroup \
-            --deselect=integration-tests/test/test_convergence.py::test_network_converges_after_slow_deploy \
-            --startup-timeout=600 --command-timeout=300 --timeout=1200 $SCALE_FLAG
+            integration-tests/test/tests/shared/ \
+            integration-tests/test/tests/custom/ \
+            integration-tests/test/tests/standalone/ \
+            --deselect integration-tests/test/tests/custom/test_load.py \
+            --deselect integration-tests/test/tests/shared/test_convergence.py::test_network_converges_after_slow_deploy \
+            --deselect integration-tests/test/tests/custom/test_asymmetric_bonds.py::test_finalization_asymmetric_bonds \
+            --deselect integration-tests/test/tests/shared/test_convergence.py::test_ft_convergence \
+            --deselect integration-tests/test/tests/shared/test_bonding_validators.py \
+            --deselect integration-tests/test/tests/custom/test_joiner_self_proposes_at_epoch_boundary.py \
+            --deselect integration-tests/test/tests/shared/test_observer_lfs_sync.py \
+            --provider=subprocess \
+            -v --tb=short --instafail \
+            -n auto --dist=loadgroup --timeout=1200 $SCALE_FLAG
 
       - name: Upload Integration Test Logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: integration-logs-${{ matrix.arch }}
+          name: integration-logs-${{ matrix.arch }}-slot${{ matrix.slot }}-run${{ github.run_id }}-attempt${{ github.run_attempt }}
           path: system-integration/integration-tests/
           retention-days: 7
-
-      - name: Upload Docker Logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: docker-logs-${{ matrix.arch }}
-          path: /tmp/*.log
-          if-no-files-found: ignore
-          retention-days: 7
-
-      - name: Clean Docker state
-        if: always()
-        shell: bash {0}
-        run: |
-          docker rm -f rnode.bootstrap rnode.validator1 rnode.validator2 rnode.validator3 rnode.readonly \
-            rnode.standalone rnode.custom.boot rnode.custom.validator1 rnode.custom.validator2 \
-            rnode.custom.validator3 rnode.custom.joiner 2>/dev/null
-          docker network rm f1r3fly-shard_f1r3fly-test-shard f1r3fly-standalone_f1r3fly-test-standalone f1r3fly-custom_f1r3fly-test-custom 2>/dev/null
-          sudo rm -rf system-integration/integration-tests/data
 
   # ===========================================================================
   # Smoke Tests — verify README startup instructions work

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -302,7 +302,7 @@ jobs:
           chmod 600 ~/.oci/config
           oci iam region list >/dev/null && echo "OCI auth OK"
 
-      - name: Launch 5 amd64 + 5 arm64 ephemeral runners
+      - name: Launch 10 amd64 + 10 arm64 ephemeral runners
         shell: bash -ex {0}
         env:
           # The default GITHUB_TOKEN can't mint runner registration tokens
@@ -315,33 +315,51 @@ jobs:
           cd system-integration/ci/oci-runners
           # Launch in parallel; each script exits as soon as the OCI launch
           # API call returns (the VM continues booting in the background and
-          # registers itself via cloud-init).
-          for _ in $(seq 1 5); do ./launch-runner.sh amd64 & done
-          for _ in $(seq 1 5); do ./launch-runner.sh arm64 & done
+          # registers itself via cloud-init). 10 amd64 + 10 arm64 feeds the
+          # 20-job dual-provider matrix (docker × {amd64,arm64} × 5 slots +
+          # subprocess × {amd64,arm64} × 5 slots).
+          for _ in $(seq 1 10); do ./launch-runner.sh amd64 & done
+          for _ in $(seq 1 10); do ./launch-runner.sh arm64 & done
           wait
-          echo "All 10 ephemeral runner VMs submitted."
+          echo "All 20 ephemeral runner VMs submitted."
 
   # Integration tests run on ephemeral OCI runners — one fresh VM per matrix
-  # job, self-terminating after the job completes. 5 amd64 + 5 arm64 = 10
-  # parallel jobs against the Docker image artifact from build_rust_docker_image.
+  # job, self-terminating after the job completes. The matrix runs the same
+  # test suite against TWO node-spawn backends (docker provider, subprocess
+  # provider) on each arch — 20 jobs total. Each arch's 10 jobs share its 10
+  # ephemeral runners (provider is a pytest flag, not a runner concern).
   required_rust_integration_tests:
-    name: Integration Tests (${{ matrix.arch }}-${{ matrix.slot }})
+    name: Integration Tests (${{ matrix.arch }}-${{ matrix.provider }}-${{ matrix.slot }})
     needs: [build_rust_docker_image, launch_ephemeral_runners]
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { arch: amd64, slot: 1, runner: [self-hosted, linux, x64,   f1r3fly-rust-ci-ephemeral, oracle-cloud] }
-          - { arch: amd64, slot: 2, runner: [self-hosted, linux, x64,   f1r3fly-rust-ci-ephemeral, oracle-cloud] }
-          - { arch: amd64, slot: 3, runner: [self-hosted, linux, x64,   f1r3fly-rust-ci-ephemeral, oracle-cloud] }
-          - { arch: amd64, slot: 4, runner: [self-hosted, linux, x64,   f1r3fly-rust-ci-ephemeral, oracle-cloud] }
-          - { arch: amd64, slot: 5, runner: [self-hosted, linux, x64,   f1r3fly-rust-ci-ephemeral, oracle-cloud] }
-          - { arch: arm64, slot: 1, runner: [self-hosted, linux, arm64, f1r3fly-rust-ci-ephemeral, oracle-cloud] }
-          - { arch: arm64, slot: 2, runner: [self-hosted, linux, arm64, f1r3fly-rust-ci-ephemeral, oracle-cloud] }
-          - { arch: arm64, slot: 3, runner: [self-hosted, linux, arm64, f1r3fly-rust-ci-ephemeral, oracle-cloud] }
-          - { arch: arm64, slot: 4, runner: [self-hosted, linux, arm64, f1r3fly-rust-ci-ephemeral, oracle-cloud] }
-          - { arch: arm64, slot: 5, runner: [self-hosted, linux, arm64, f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          # ── amd64 × docker × 5 ───────────────────────────────────────────────
+          - { arch: amd64, provider: docker,     slot: 1, runner: [self-hosted, linux, x64,   f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: amd64, provider: docker,     slot: 2, runner: [self-hosted, linux, x64,   f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: amd64, provider: docker,     slot: 3, runner: [self-hosted, linux, x64,   f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: amd64, provider: docker,     slot: 4, runner: [self-hosted, linux, x64,   f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: amd64, provider: docker,     slot: 5, runner: [self-hosted, linux, x64,   f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          # ── amd64 × subprocess × 5 ───────────────────────────────────────────
+          - { arch: amd64, provider: subprocess, slot: 1, runner: [self-hosted, linux, x64,   f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: amd64, provider: subprocess, slot: 2, runner: [self-hosted, linux, x64,   f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: amd64, provider: subprocess, slot: 3, runner: [self-hosted, linux, x64,   f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: amd64, provider: subprocess, slot: 4, runner: [self-hosted, linux, x64,   f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: amd64, provider: subprocess, slot: 5, runner: [self-hosted, linux, x64,   f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          # ── arm64 × docker × 5 ───────────────────────────────────────────────
+          - { arch: arm64, provider: docker,     slot: 1, runner: [self-hosted, linux, arm64, f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: arm64, provider: docker,     slot: 2, runner: [self-hosted, linux, arm64, f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: arm64, provider: docker,     slot: 3, runner: [self-hosted, linux, arm64, f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: arm64, provider: docker,     slot: 4, runner: [self-hosted, linux, arm64, f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: arm64, provider: docker,     slot: 5, runner: [self-hosted, linux, arm64, f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          # ── arm64 × subprocess × 5 ───────────────────────────────────────────
+          - { arch: arm64, provider: subprocess, slot: 1, runner: [self-hosted, linux, arm64, f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: arm64, provider: subprocess, slot: 2, runner: [self-hosted, linux, arm64, f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: arm64, provider: subprocess, slot: 3, runner: [self-hosted, linux, arm64, f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: arm64, provider: subprocess, slot: 4, runner: [self-hosted, linux, arm64, f1r3fly-rust-ci-ephemeral, oracle-cloud] }
+          - { arch: arm64, provider: subprocess, slot: 5, runner: [self-hosted, linux, arm64, f1r3fly-rust-ci-ephemeral, oracle-cloud] }
     steps:
       - name: Clone Repository
         uses: actions/checkout@v4
@@ -365,7 +383,8 @@ jobs:
           zcat /tmp/rust-node-docker.tar.gz | docker image load
           docker tag f1r3flyindustries/f1r3fly-rust-node:${{ matrix.arch }} f1r3flyindustries/f1r3fly-rust-node:latest
 
-      - name: Extract rnode binary from image (for subprocess provider)
+      - name: Extract rnode binary from image (subprocess provider only)
+        if: matrix.provider == 'subprocess'
         shell: bash -ex {0}
         run: |
           docker create --name extract-rnode f1r3flyindustries/f1r3fly-rust-node:latest
@@ -382,9 +401,12 @@ jobs:
           poetry lock --no-update
           poetry install --with integration
 
-      - name: Run Integration Tests (subprocess provider)
+      - name: Run Integration Tests (${{ matrix.provider }} provider)
         shell: bash -ex {0}
         env:
+          # Both env vars are set unconditionally — the framework's resolver
+          # honors whichever matches `--provider`. Setting the other is harmless.
+          F1R3FLY_NODE_IMAGE: f1r3flyindustries/f1r3fly-rust-node:latest
           F1R3FLY_NODE_BINARY: /tmp/rnode
           F1R3FLY_NODE_DEFAULTS_CONF: ${{ github.workspace }}/node/src/main/resources/defaults.conf
         run: |
@@ -404,7 +426,7 @@ jobs:
             --deselect integration-tests/test/tests/shared/test_bonding_validators.py \
             --deselect integration-tests/test/tests/custom/test_joiner_self_proposes_at_epoch_boundary.py \
             --deselect integration-tests/test/tests/shared/test_observer_lfs_sync.py \
-            --provider=subprocess \
+            --provider=${{ matrix.provider }} \
             -v --tb=short --instafail \
             -n auto --dist=loadgroup --timeout=1200 $SCALE_FLAG
 
@@ -412,7 +434,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: integration-logs-${{ matrix.arch }}-slot${{ matrix.slot }}-run${{ github.run_id }}-attempt${{ github.run_attempt }}
+          name: integration-logs-${{ matrix.arch }}-${{ matrix.provider }}-slot${{ matrix.slot }}-run${{ github.run_id }}-attempt${{ github.run_attempt }}
           path: system-integration/integration-tests/
           retention-days: 7
 

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -281,7 +281,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: F1R3FLY-io/system-integration
-          ref: 2ace29f4f45b26418749edb9477ec2a310be9c6c
+          ref: refactor/integration-test-framework
           path: system-integration
 
       - uses: actions/setup-python@v5
@@ -344,29 +344,19 @@ jobs:
             SCALE_FLAG="--timeout-scale=1.5"
           fi
           poetry run pytest \
-            integration-tests/test/test_web_api.py \
-            integration-tests/test/test_wallets.py \
-            integration-tests/test/test_heartbeat.py \
-            integration-tests/test/test_deployment.py \
-            integration-tests/test/test_storage.py \
-            integration-tests/test/test_genesis_ceremony.py \
-            integration-tests/test/test_dag_correctness.py \
-            integration-tests/test/test_finalization.py \
-            integration-tests/test/test_propose.py \
-            integration-tests/test/test_replay_correctness.py \
-            integration-tests/test/test_convergence.py \
-            integration-tests/test/test_bridge_admin.py \
-            integration-tests/test/test_shard_degradation.py \
-            integration-tests/test/test_consensus_health.py \
-            integration-tests/test/test_websocket.py \
-            integration-tests/test/test_synchrony_constraint.py \
-            integration-tests/test/test_asymmetric_bonds.py \
-            integration-tests/test/test_bonding_validators.py \
-            integration-tests/test/test_trim_state.py \
-            -v --tb=short --log-cli-level=WARNING \
-            -n 3 --dist=loadgroup \
-            --deselect=integration-tests/test/test_convergence.py::test_network_converges_after_slow_deploy \
-            --startup-timeout=600 --command-timeout=300 --timeout=1200 $SCALE_FLAG
+            integration-tests/test/tests/shared/ \
+            integration-tests/test/tests/custom/ \
+            integration-tests/test/tests/standalone/ \
+            --deselect integration-tests/test/tests/custom/test_load.py \
+            --deselect integration-tests/test/tests/shared/test_convergence.py::test_network_converges_after_slow_deploy \
+            --deselect integration-tests/test/tests/custom/test_asymmetric_bonds.py::test_finalization_asymmetric_bonds \
+            --deselect integration-tests/test/tests/shared/test_convergence.py::test_ft_convergence \
+            --deselect integration-tests/test/tests/shared/test_bonding_validators.py \
+            --deselect integration-tests/test/tests/shared/test_contract_lifecycle.py \
+            --deselect integration-tests/test/tests/custom/test_joiner_self_proposes_at_epoch_boundary.py \
+            --deselect integration-tests/test/tests/shared/test_observer_lfs_sync.py \
+            -v --tb=short --instafail --maxfail=10 \
+            -n auto --dist=loadgroup --timeout=1200 $SCALE_FLAG
 
       - name: Upload Integration Test Logs
         if: always()

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -352,7 +352,6 @@ jobs:
             --deselect integration-tests/test/tests/custom/test_asymmetric_bonds.py::test_finalization_asymmetric_bonds \
             --deselect integration-tests/test/tests/shared/test_convergence.py::test_ft_convergence \
             --deselect integration-tests/test/tests/shared/test_bonding_validators.py \
-            --deselect integration-tests/test/tests/shared/test_contract_lifecycle.py \
             --deselect integration-tests/test/tests/custom/test_joiner_self_proposes_at_epoch_boundary.py \
             --deselect integration-tests/test/tests/shared/test_observer_lfs_sync.py \
             -v --tb=short --instafail --maxfail=10 \

--- a/casper/src/rust/engine/engine.rs
+++ b/casper/src/rust/engine/engine.rs
@@ -13,7 +13,8 @@ use comm::rust::transport::transport_layer::{Blob, TransportLayer};
 use models::rust::block_hash::BlockHash;
 use models::rust::casper::pretty_printer::PrettyPrinter;
 use models::rust::casper::protocol::casper_message::{
-    ApprovedBlock, BlockMessage, CasperMessage, NoApprovedBlockAvailable, StoreItemsMessage,
+    ApprovedBlock, BlockMessage, CasperMessage, MergeableEntryResponse, NoApprovedBlockAvailable,
+    StoreItemsMessage,
 };
 use models::rust::casper::protocol::packet_type_tag::ToPacket;
 use shared::rust::shared::f1r3fly_event::F1r3flyEvent;
@@ -297,9 +298,11 @@ pub async fn transition_to_initializing<U: TransportLayer + Send + Sync + Clone 
     heartbeat_signal_ref: &crate::rust::heartbeat_signal::HeartbeatSignalRef,
 ) -> Result<(), CasperError> {
     // Create bounded channels and return senders so caller can feed LFS responses (Scala: expose queues).
-    // Scala uses size-50 bounded queues in both cases.
+    // Scala uses size-50 bounded queues; we add a third for the
+    // mergeable-channels store sync.
     let (block_tx, block_rx) = mpsc::channel::<BlockMessage>(50);
     let (tuple_tx, tuple_rx) = mpsc::channel::<StoreItemsMessage>(50);
+    let (mergeable_tx, mergeable_rx) = mpsc::channel::<MergeableEntryResponse>(50);
 
     // RuntimeManager is now Arc<Mutex<RuntimeManager>>, so we clone the Arc instead of taking
     let runtime_manager = runtime_manager_arc.clone();
@@ -324,6 +327,8 @@ pub async fn transition_to_initializing<U: TransportLayer + Send + Sync + Clone 
         block_rx,
         tuple_tx.clone(),
         tuple_rx,
+        mergeable_tx.clone(),
+        mergeable_rx,
         trim_state,
         disable_state_exporter,
         event_publisher.clone(),

--- a/casper/src/rust/engine/initializing.rs
+++ b/casper/src/rust/engine/initializing.rs
@@ -28,12 +28,16 @@ use comm::rust::{
     rp::{connect::ConnectionsCell, rp_conf::RPConf},
     transport::transport_layer::TransportLayer,
 };
-use models::rust::casper::protocol::casper_message::StoreItemsMessageRequest;
+use models::rust::casper::protocol::casper_message::{
+    MergeableEntryRequest, StoreItemsMessageRequest,
+};
 use models::rust::{
     block_hash::BlockHash,
     casper::{
         pretty_printer::PrettyPrinter,
-        protocol::casper_message::{ApprovedBlock, BlockMessage, CasperMessage, StoreItemsMessage},
+        protocol::casper_message::{
+            ApprovedBlock, BlockMessage, CasperMessage, MergeableEntryResponse, StoreItemsMessage,
+        },
     },
 };
 use rspace_plus_plus::rspace::history::Either;
@@ -43,8 +47,8 @@ use rspace_plus_plus::rspace::{
     hashing::blake2b256_hash::Blake2b256Hash, state::rspace_importer::RSpaceImporter,
 };
 use shared::rust::{
-    shared::{f1r3fly_event::F1r3flyEvent, f1r3fly_events::F1r3flyEvents},
     ByteString,
+    shared::{f1r3fly_event::F1r3flyEvent, f1r3fly_events::F1r3flyEvents},
 };
 
 use crate::rust::block_status::ValidBlock;
@@ -62,8 +66,8 @@ use crate::rust::{
     engine::{
         block_retriever::BlockRetriever,
         engine::{
-            log_no_approved_block_available, send_no_approved_block_available,
-            transition_to_running, Engine,
+            Engine, log_no_approved_block_available, send_no_approved_block_available,
+            transition_to_running,
         },
         engine_cell::EngineCell,
         lfs_block_requester::{self, BlockRequesterOps},
@@ -102,9 +106,13 @@ pub struct Initializing<T: TransportLayer + Send + Sync + Clone + 'static> {
     >,
     block_message_rx: Arc<Mutex<Option<mpsc::Receiver<BlockMessage>>>>,
     tuple_space_rx: Arc<Mutex<Option<mpsc::Receiver<StoreItemsMessage>>>>,
+    /// Receives `MergeableEntryResponse` routed from `handle_message_recv`.
+    /// Drained by `lfs_block_requester::stream` during `request_approved_state`.
+    mergeable_message_rx: Arc<Mutex<Option<mpsc::Receiver<MergeableEntryResponse>>>>,
     // Senders to enqueue messages from `handle` (producer side)
     pub block_message_tx: Arc<Mutex<Option<mpsc::Sender<BlockMessage>>>>,
     pub tuple_space_tx: Arc<Mutex<Option<mpsc::Sender<StoreItemsMessage>>>>,
+    pub mergeable_message_tx: Arc<Mutex<Option<mpsc::Sender<MergeableEntryResponse>>>>,
     block_message_queue_pending: Arc<AtomicUsize>,
     tuple_space_queue_pending: Arc<AtomicUsize>,
     trim_state: bool,
@@ -155,6 +163,8 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
         block_message_rx: mpsc::Receiver<BlockMessage>,
         tuple_space_tx: mpsc::Sender<StoreItemsMessage>,
         tuple_space_rx: mpsc::Receiver<StoreItemsMessage>,
+        mergeable_message_tx: mpsc::Sender<MergeableEntryResponse>,
+        mergeable_message_rx: mpsc::Receiver<MergeableEntryResponse>,
         trim_state: bool,
         disable_state_exporter: bool,
         event_publisher: F1r3flyEvents,
@@ -182,8 +192,10 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
             the_init,
             block_message_rx: Arc::new(Mutex::new(Some(block_message_rx))),
             tuple_space_rx: Arc::new(Mutex::new(Some(tuple_space_rx))),
+            mergeable_message_rx: Arc::new(Mutex::new(Some(mergeable_message_rx))),
             block_message_tx: Arc::new(Mutex::new(Some(block_message_tx))),
             tuple_space_tx: Arc::new(Mutex::new(Some(tuple_space_tx))),
+            mergeable_message_tx: Arc::new(Mutex::new(Some(mergeable_message_tx))),
             block_message_queue_pending: Arc::new(AtomicUsize::new(0)),
             tuple_space_queue_pending: Arc::new(AtomicUsize::new(0)),
             trim_state,
@@ -353,6 +365,23 @@ impl<T: TransportLayer + Send + Sync + Clone + 'static> Engine for Initializing<
                 } else {
                     tracing::warn!(
                         "block_message_tx sender is None; block message channel not available (message not enqueued)"
+                    );
+                }
+                Ok(())
+            }
+            CasperMessage::MergeableEntryResponse(resp) => {
+                // Forward to the channel drained by lfs_block_requester::stream.
+                let sender = self.mergeable_message_tx.lock().unwrap().as_ref().cloned();
+                if let Some(tx) = sender {
+                    if let Err(e) = tx.send(resp).await {
+                        tracing::warn!(
+                            "Failed to enqueue MergeableEntryResponse into mergeable channel: {:?}",
+                            e
+                        );
+                    }
+                } else {
+                    tracing::warn!(
+                        "mergeable_message_tx sender is None; mergeable channel not available (message dropped)"
                     );
                 }
                 Ok(())
@@ -542,6 +571,17 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
                     CasperError::RuntimeError("Block message receiver not available".to_string())
                 })?;
 
+        let mergeable_response_rx = self
+            .mergeable_message_rx
+            .lock()
+            .unwrap()
+            .take()
+            .ok_or_else(|| {
+                CasperError::RuntimeError(
+                    "Mergeable-entry response receiver not available".to_string(),
+                )
+            })?;
+
         // Create block requester wrapper with needed components and stream
         let mut block_requester = BlockRequesterWrapper::new(
             &self.transport_layer,
@@ -549,7 +589,8 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
             &self.rp_conf_ask,
             self.block_store.clone(),
             Box::new(|block| self.validate_block(block)),
-        );
+        )
+        .with_runtime_manager(self.runtime_manager.clone());
 
         // Create empty queue for block requester (must be created outside tokio::join! for lifetime reasons)
         let empty_queue = VecDeque::new(); // Empty queue since we drained it above
@@ -572,6 +613,7 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
                 &empty_queue,
                 response_message_rx,
                 self.block_message_queue_pending.clone(),
+                mergeable_response_rx,
                 min_block_number_for_deploy_lifespan,
                 lfs_request_timeout,
                 &mut block_requester,
@@ -631,14 +673,6 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
                 "request_approved_state: block_request_stream returned no final state (None)"
             );
         }
-
-        // Replay blocks to populate mergeable channel cache
-        // This is needed for multi-parent block validation
-        self.replay_blocks_for_mergeable_channels(
-            approved_block,
-            min_block_number_for_deploy_lifespan,
-        )
-        .await?;
 
         // Transition to Running state
         tracing::info!("request_approved_state: transitioning to Running");
@@ -733,172 +767,6 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
         Ok(())
     }
 
-    /// Replay blocks in topological order to populate the mergeable channel cache.
-    /// This is necessary for multi-parent block validation, which requires mergeable
-    /// channel data from parent blocks to compute merged state.
-    ///
-    /// The LFS sync transfers the RSpace trie but not the mergeable channel store,
-    /// so we must regenerate it by replaying blocks.
-    async fn replay_blocks_for_mergeable_channels(
-        &self,
-        _approved_block: &ApprovedBlock,
-        min_block_number: i64,
-    ) -> Result<(), CasperError> {
-        tracing::info!("Replaying blocks to populate mergeable channel cache...");
-
-        // Get DAG representation for traversal
-        let dag = self.block_dag_storage.get_representation();
-
-        // Get all blocks in the DAG that need replay (from minBlockNumber to LFB)
-        // We process in topological order (by block number, then by hash for determinism)
-        let all_blocks = dag.topo_sort(min_block_number, None)?;
-        let blocks_to_replay: Vec<BlockHash> = all_blocks.into_iter().flatten().collect();
-
-        tracing::info!(
-            "Found {} blocks to replay for mergeable channel cache.",
-            blocks_to_replay.len()
-        );
-
-        // Replay each block to populate mergeable channels
-        for block_hash in blocks_to_replay {
-            let block = self.block_store.get_unsafe(&block_hash);
-            let parents = &block.header.parents_hash_list;
-
-            if parents.is_empty() {
-                // Genesis block - replay from empty state
-                self.replay_genesis_block(&block).await?;
-            } else {
-                self.replay_single_block(&block).await?;
-            }
-        }
-
-        tracing::info!("Mergeable channel cache populated successfully.");
-        Ok(())
-    }
-
-    /// Replay genesis block to populate its mergeable channel cache entry.
-    /// Genesis is special because it starts from empty state.
-    async fn replay_genesis_block(&self, block: &BlockMessage) -> Result<(), CasperError> {
-        let block_hash = &block.block_hash;
-        let block_number = proto_util::block_number(block);
-
-        tracing::debug!(
-            "Replaying genesis block #{} ({})",
-            block_number,
-            PrettyPrinter::build_string_bytes(block_hash)
-        );
-
-        let deploys = proto_util::deploys(block);
-        let system_deploys = proto_util::system_deploys(block);
-        let block_data = rholang::rust::interpreter::system_processes::BlockData::from_block(block);
-
-        // Genesis starts from empty state
-        let pre_state_hash = RuntimeManager::empty_state_hash_fixed();
-
-        // Replay genesis - this will save mergeable channels to the store
-        let result = self
-            .runtime_manager
-            .replay_compute_state(
-                &pre_state_hash,
-                deploys,
-                system_deploys,
-                &block_data,
-                None, // No invalid blocks for genesis
-                true, // isGenesis = true
-            )
-            .await;
-
-        match result {
-            Ok(computed_post_state) => {
-                let expected_post_state = &block.body.state.post_state_hash;
-                if computed_post_state == *expected_post_state {
-                    tracing::debug!("Genesis block replayed successfully.");
-                } else {
-                    tracing::warn!(
-                        "Genesis block replay state mismatch: computed={}, expected={}",
-                        PrettyPrinter::build_string_bytes(&computed_post_state),
-                        PrettyPrinter::build_string_bytes(expected_post_state)
-                    );
-                }
-            }
-            Err(e) => {
-                tracing::warn!("Genesis block replay error: {:?}", e);
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Replay a single block to populate its mergeable channel cache entry.
-    async fn replay_single_block(&self, block: &BlockMessage) -> Result<(), CasperError> {
-        let block_hash = &block.block_hash;
-        let block_number = proto_util::block_number(block);
-        let parents = &block.header.parents_hash_list;
-
-        // For single-parent blocks, use parent's post-state
-        // For multi-parent blocks, we need the pre-state from the block itself
-        // (by the time we reach a multi-parent block, all its parents have been replayed)
-        let pre_state_hash = if parents.len() == 1 {
-            let parent_block = self.block_store.get_unsafe(&parents[0]);
-            parent_block.body.state.post_state_hash.clone()
-        } else {
-            // Multi-parent: use the block's recorded pre-state
-            // This works because we're replaying in topological order
-            block.body.state.pre_state_hash.clone()
-        };
-
-        let deploys = proto_util::deploys(block);
-        let system_deploys = proto_util::system_deploys(block);
-        let block_data = rholang::rust::interpreter::system_processes::BlockData::from_block(block);
-        let is_genesis = parents.is_empty();
-
-        // Get invalid blocks map for replay
-        let dag = self.block_dag_storage.get_representation();
-        let invalid_blocks_map = dag.invalid_blocks_map()?;
-
-        tracing::debug!(
-            "Replaying block #{} ({}) with {} deploys, {} parents",
-            block_number,
-            PrettyPrinter::build_string_bytes(block_hash),
-            deploys.len(),
-            parents.len()
-        );
-
-        // Replay the block - this will save mergeable channels to the store
-        let result = self
-            .runtime_manager
-            .replay_compute_state(
-                &pre_state_hash,
-                deploys,
-                system_deploys,
-                &block_data,
-                Some(invalid_blocks_map),
-                is_genesis,
-            )
-            .await;
-
-        match result {
-            Ok(computed_post_state) => {
-                let expected_post_state = &block.body.state.post_state_hash;
-                if computed_post_state == *expected_post_state {
-                    tracing::debug!("Block #{} replayed successfully.", block_number);
-                } else {
-                    tracing::warn!(
-                        "Block #{} replay state mismatch: computed={}, expected={}",
-                        block_number,
-                        PrettyPrinter::build_string_bytes(&computed_post_state),
-                        PrettyPrinter::build_string_bytes(expected_post_state)
-                    );
-                }
-            }
-            Err(e) => {
-                tracing::warn!("Block #{} replay error: {:?}", block_number, e);
-            }
-        }
-
-        Ok(())
-    }
-
     /// **Scala equivalent**: `private def createCasperAndTransitionToRunning(approvedBlock: ApprovedBlock): F[Unit]`
     async fn create_casper_and_transition_to_running(
         &self,
@@ -907,7 +775,7 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
         let ab = approved_block.candidate.block.clone();
         let genesis_post_state_hash = ab.body.state.post_state_hash.clone();
 
-        // RuntimeManager is now Arc<Mutex<RuntimeManager>>, so we clone the Arc
+        // RuntimeManager is lock-free Arc<RuntimeManager>; clone the Arc.
         let runtime_manager = self.runtime_manager.clone();
 
         let estimator = self
@@ -917,7 +785,7 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
             .take()
             .ok_or_else(|| CasperError::RuntimeError("Estimator not available".to_string()))?;
 
-        // Pass Arc<Mutex<RuntimeManager>> directly to hash_set_casper
+        // Pass Arc<RuntimeManager> directly to hash_set_casper
         let casper = crate::rust::casper::hash_set_casper(
             self.block_retriever.clone(),
             self.event_publisher.clone(),
@@ -1032,6 +900,44 @@ impl<T: TransportLayer + Send + Sync> BlockRequesterOps for BlockRequesterWrappe
     fn validate_block(&self, block: &BlockMessage) -> bool {
         (self.validate_block_fn)(block)
     }
+
+    async fn request_for_mergeable_entry(&self, block_hash: &BlockHash) -> Result<(), CasperError> {
+        let req = MergeableEntryRequest {
+            block_hash: block_hash.clone(),
+        };
+        self.transport_layer
+            .send_message_to_peers(
+                &self.connections_cell,
+                &self.rp_conf_ask,
+                Arc::new(req.to_proto()),
+                None,
+            )
+            .await
+            .map_err(|e| CasperError::RuntimeError(e.to_string()))?;
+        Ok(())
+    }
+
+    fn put_mergeable_entry(
+        &self,
+        block_hash: &BlockHash,
+        serialized_entry: &[u8],
+    ) -> Result<(), CasperError> {
+        if serialized_entry.is_empty() {
+            return Ok(());
+        }
+        // Look up the block to compute the local mergeable_key (must match
+        // the server's key exactly; both sides derive it from the block's
+        // post_state/sender/seq).
+        let block = self.block_store.get_unsafe(block_hash);
+        let key_bytes = RuntimeManager::mergeable_key_bytes_for_block(&block)?;
+        let runtime_manager = self.runtime_manager.as_ref().ok_or_else(|| {
+            CasperError::RuntimeError(
+                "BlockRequesterWrapper missing runtime_manager (mergeable-entry import)"
+                    .to_string(),
+            )
+        })?;
+        runtime_manager.put_mergeable_entry_raw(key_bytes, serialized_entry.to_vec())
+    }
 }
 
 /// Wrapper struct for block request operations
@@ -1041,6 +947,10 @@ pub struct BlockRequesterWrapper<'a, T: TransportLayer> {
     rp_conf_ask: &'a RPConf,
     block_store: KeyValueBlockStore,
     validate_block_fn: Box<dyn Fn(&BlockMessage) -> bool + Send + Sync + 'a>,
+    /// Optional runtime_manager handle for the mergeable-channels store
+    /// import path. Required in production; optional for tests that don't
+    /// exercise the mergeable path.
+    runtime_manager: Option<Arc<RuntimeManager>>,
 }
 
 impl<'a, T: TransportLayer> BlockRequesterWrapper<'a, T> {
@@ -1057,7 +967,18 @@ impl<'a, T: TransportLayer> BlockRequesterWrapper<'a, T> {
             rp_conf_ask,
             block_store,
             validate_block_fn,
+            runtime_manager: None,
         }
+    }
+
+    /// Attach a `RuntimeManager` so the wrapper can import mergeable-channel
+    /// entries.
+    pub fn with_runtime_manager(
+        mut self,
+        runtime_manager: Arc<RuntimeManager>,
+    ) -> Self {
+        self.runtime_manager = Some(runtime_manager);
+        self
     }
 }
 

--- a/casper/src/rust/engine/initializing.rs
+++ b/casper/src/rust/engine/initializing.rs
@@ -550,36 +550,18 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
         // Starting minimum block height. When latest blocks are downloaded new minimum will be calculated.
         let block = &approved_block.candidate.block;
         let start_block_number = proto_util::block_number(block);
-        let min_block_number_for_deploy_lifespan = std::cmp::max(
-            0,
-            start_block_number - self.casper_shard_conf.deploy_lifespan,
-        );
-        // Forward-horizon lower bound: also fetch every block reachable as a
-        // parent of any block within `max_parent_depth + depth_buffer` of LFB.
-        // Without this, lfs_block_requester rejects side-branch blocks below
-        // `deploy_lifespan` (default 50) even though they're still legitimate
-        // parents of upcoming proposals. After Running, gossip blocks
-        // referencing those rejected ancestors trigger
-        // `DAG storage is missing hash` (KvStoreError) and
-        // `validateAndSetCurrentRoot FAILED ... not in roots store`
-        // (RootRepositoryDivergence) on the joiner.
-        let max_parent_depth = self.casper_shard_conf.max_parent_depth as i64;
-        let depth_buffer = self
-            .casper_shard_conf
-            .mergeable_channels_gc_depth_buffer as i64;
-        let min_block_number_for_horizon = if max_parent_depth >= i32::MAX as i64 {
-            // Disabled depth check → no horizon clamping needed. Caller can
-            // opt into full replay (`disable-lfs = true`) for that scenario.
-            min_block_number_for_deploy_lifespan
-        } else {
-            std::cmp::max(0, start_block_number - max_parent_depth - depth_buffer)
-        };
-        // Take the LOWER of the two so LFS covers both the deploy-lifespan
-        // window AND the parent-merge horizon.
-        let min_block_number_for_deploy_lifespan = std::cmp::min(
-            min_block_number_for_deploy_lifespan,
-            min_block_number_for_horizon,
-        );
+        // Compute the LFS lower bound: take the lower (= older floor) of
+        // (a) deploy_lifespan window and (b) forward-horizon parent reach.
+        // See `rspace_history_horizon::lfs_min_block_number` for the rule
+        // and `casper/tests/util/rspace_history_horizon_test.rs` plus the
+        // module's `#[cfg(test)] mod tests` for the spec.
+        let min_block_number_for_deploy_lifespan =
+            crate::rust::util::rspace_history_horizon::lfs_min_block_number(
+                start_block_number,
+                self.casper_shard_conf.deploy_lifespan,
+                self.casper_shard_conf.max_parent_depth,
+                self.casper_shard_conf.mergeable_channels_gc_depth_buffer,
+            );
 
         tracing::info!(
             "request_approved_state: start (block {}, min_height {})",
@@ -744,10 +726,13 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
                     &self.transport_layer,
                     &self.rp_conf_ask,
                 );
+                let rm_for_has_root = self.runtime_manager.clone();
+                let has_root: crate::rust::engine::lfs_horizon_requester::HasRootFn =
+                    Arc::new(move |root| rm_for_has_root.has_root(root));
                 let horizon_stream =
                     crate::rust::engine::lfs_horizon_requester::stream(
                         horizon_roots,
-                        self.runtime_manager.clone(),
+                        has_root,
                         self.rspace_state_manager.importer.clone(),
                         horizon_requester,
                         horizon_rx,

--- a/casper/src/rust/engine/initializing.rs
+++ b/casper/src/rust/engine/initializing.rs
@@ -554,6 +554,32 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
             0,
             start_block_number - self.casper_shard_conf.deploy_lifespan,
         );
+        // Forward-horizon lower bound: also fetch every block reachable as a
+        // parent of any block within `max_parent_depth + depth_buffer` of LFB.
+        // Without this, lfs_block_requester rejects side-branch blocks below
+        // `deploy_lifespan` (default 50) even though they're still legitimate
+        // parents of upcoming proposals. After Running, gossip blocks
+        // referencing those rejected ancestors trigger
+        // `DAG storage is missing hash` (KvStoreError) and
+        // `validateAndSetCurrentRoot FAILED ... not in roots store`
+        // (RootRepositoryDivergence) on the joiner.
+        let max_parent_depth = self.casper_shard_conf.max_parent_depth as i64;
+        let depth_buffer = self
+            .casper_shard_conf
+            .mergeable_channels_gc_depth_buffer as i64;
+        let min_block_number_for_horizon = if max_parent_depth >= i32::MAX as i64 {
+            // Disabled depth check → no horizon clamping needed. Caller can
+            // opt into full replay (`disable-lfs = true`) for that scenario.
+            min_block_number_for_deploy_lifespan
+        } else {
+            std::cmp::max(0, start_block_number - max_parent_depth - depth_buffer)
+        };
+        // Take the LOWER of the two so LFS covers both the deploy-lifespan
+        // window AND the parent-merge horizon.
+        let min_block_number_for_deploy_lifespan = std::cmp::min(
+            min_block_number_for_deploy_lifespan,
+            min_block_number_for_horizon,
+        );
 
         tracing::info!(
             "request_approved_state: start (block {}, min_height {})",

--- a/casper/src/rust/engine/initializing.rs
+++ b/casper/src/rust/engine/initializing.rs
@@ -47,8 +47,8 @@ use rspace_plus_plus::rspace::{
     hashing::blake2b256_hash::Blake2b256Hash, state::rspace_importer::RSpaceImporter,
 };
 use shared::rust::{
-    ByteString,
     shared::{f1r3fly_event::F1r3flyEvent, f1r3fly_events::F1r3flyEvents},
+    ByteString,
 };
 
 use crate::rust::block_status::ValidBlock;
@@ -66,8 +66,8 @@ use crate::rust::{
     engine::{
         block_retriever::BlockRetriever,
         engine::{
-            Engine, log_no_approved_block_available, send_no_approved_block_available,
-            transition_to_running,
+            log_no_approved_block_available, send_no_approved_block_available,
+            transition_to_running, Engine,
         },
         engine_cell::EngineCell,
         lfs_block_requester::{self, BlockRequesterOps},
@@ -692,13 +692,14 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
         // check in `validate::parents`.
         {
             let dag = self.block_dag_storage.get_representation();
-            let horizon_roots = crate::rust::util::rspace_history_horizon::compute_forward_horizon_roots(
-                &dag,
-                &self.block_store,
-                &approved_block.candidate.block,
-                &self.casper_shard_conf,
-            )
-            .map_err(|e| CasperError::KvStoreError(e))?;
+            let horizon_roots =
+                crate::rust::util::rspace_history_horizon::compute_forward_horizon_roots(
+                    &dag,
+                    &self.block_store,
+                    &approved_block.candidate.block,
+                    &self.casper_shard_conf,
+                )
+                .map_err(|e| CasperError::KvStoreError(e))?;
 
             if !horizon_roots.is_empty() {
                 // Phase 1's tuple_space_message_receiver was consumed by
@@ -722,23 +723,20 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
                 // drive to completion, then check the final ST.is_finished()
                 // to detect incomplete sync.
                 use futures::StreamExt;
-                let horizon_requester = HorizonRequester::new(
-                    &self.transport_layer,
-                    &self.rp_conf_ask,
-                );
+                let horizon_requester =
+                    HorizonRequester::new(&self.transport_layer, &self.rp_conf_ask);
                 let rm_for_has_root = self.runtime_manager.clone();
                 let has_root: crate::rust::engine::lfs_horizon_requester::HasRootFn =
                     Arc::new(move |root| rm_for_has_root.has_root(root));
-                let horizon_stream =
-                    crate::rust::engine::lfs_horizon_requester::stream(
-                        horizon_roots,
-                        has_root,
-                        self.rspace_state_manager.importer.clone(),
-                        horizon_requester,
-                        horizon_rx,
-                        request_timeout,
-                    )
-                    .await;
+                let horizon_stream = crate::rust::engine::lfs_horizon_requester::stream(
+                    horizon_roots,
+                    has_root,
+                    self.rspace_state_manager.importer.clone(),
+                    horizon_requester,
+                    horizon_rx,
+                    request_timeout,
+                )
+                .await;
 
                 // Drop the temporary sender so subsequent StoreItemsMessages
                 // (none expected once Running) don't queue indefinitely.
@@ -1082,10 +1080,7 @@ impl<'a, T: TransportLayer> BlockRequesterWrapper<'a, T> {
 
     /// Attach a `RuntimeManager` so the wrapper can import mergeable-channel
     /// entries.
-    pub fn with_runtime_manager(
-        mut self,
-        runtime_manager: Arc<RuntimeManager>,
-    ) -> Self {
+    pub fn with_runtime_manager(mut self, runtime_manager: Arc<RuntimeManager>) -> Self {
         self.runtime_manager = Some(runtime_manager);
         self
     }
@@ -1169,8 +1164,7 @@ impl<'a, T: TransportLayer> HorizonRequester<'a, T> {
 
 #[async_trait]
 impl<T: TransportLayer + Send + Sync>
-    crate::rust::engine::lfs_horizon_requester::HorizonRequesterOps
-    for HorizonRequester<'_, T>
+    crate::rust::engine::lfs_horizon_requester::HorizonRequesterOps for HorizonRequester<'_, T>
 {
     async fn request_for_horizon_chunk(
         &self,

--- a/casper/src/rust/engine/initializing.rs
+++ b/casper/src/rust/engine/initializing.rs
@@ -674,6 +674,104 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
             );
         }
 
+        // Forward-horizon rspace history sync — ship rspace post-state for
+        // every block within `max_parent_depth + depth_buffer` of LFB so
+        // subsequent block validation never hits `UnknownRootError`. See
+        // `casper/src/rust/util/rspace_history_horizon.rs` for the
+        // reachability calc and `casper/src/rust/engine/lfs_horizon_requester.rs`
+        // for the orchestrator. Companion to the proposer-side
+        // `Estimator::filterDeepParents` and the validator-side parent-depth
+        // check in `validate::parents`.
+        {
+            let dag = self.block_dag_storage.get_representation();
+            let horizon_roots = crate::rust::util::rspace_history_horizon::compute_forward_horizon_roots(
+                &dag,
+                &self.block_store,
+                &approved_block.candidate.block,
+                &self.casper_shard_conf,
+            )
+            .map_err(|e| CasperError::KvStoreError(e))?;
+
+            if !horizon_roots.is_empty() {
+                // Phase 1's tuple_space_message_receiver was consumed by
+                // lfs_tuple_space_requester::stream. Install a fresh
+                // (tx, rx) pair on `tuple_space_tx` so handle_message_recv
+                // routes incoming `StoreItemsMessage`s to the orchestrator.
+                let (horizon_tx, horizon_rx) = mpsc::channel::<StoreItemsMessage>(50);
+                {
+                    let mut sender_slot = self.tuple_space_tx.lock().unwrap();
+                    *sender_slot = Some(horizon_tx);
+                }
+
+                let request_timeout = Duration::from_secs(30);
+                tracing::info!(
+                    "LFS forward-horizon: requesting {} ancestor rspace roots below LFB",
+                    horizon_roots.len()
+                );
+
+                // Consume the streaming-parallel orchestrator the same way
+                // `lfs_tuple_space_requester::stream` is consumed above:
+                // drive to completion, then check the final ST.is_finished()
+                // to detect incomplete sync.
+                use futures::StreamExt;
+                let horizon_requester = HorizonRequester::new(
+                    &self.transport_layer,
+                    &self.rp_conf_ask,
+                );
+                let horizon_stream =
+                    crate::rust::engine::lfs_horizon_requester::stream(
+                        horizon_roots,
+                        self.runtime_manager.clone(),
+                        self.rspace_state_manager.importer.clone(),
+                        horizon_requester,
+                        horizon_rx,
+                        request_timeout,
+                    )
+                    .await;
+
+                // Drop the temporary sender so subsequent StoreItemsMessages
+                // (none expected once Running) don't queue indefinitely.
+                let final_horizon_state = match horizon_stream {
+                    Ok(stream) => {
+                        let mut stream = Box::pin(stream);
+                        let mut final_state = None;
+                        while let Some(st) = stream.next().await {
+                            final_state = Some(st);
+                        }
+                        Ok(final_state)
+                    }
+                    Err(e) => Err(e),
+                };
+                {
+                    let mut sender_slot = self.tuple_space_tx.lock().unwrap();
+                    *sender_slot = None;
+                }
+
+                // Loud failure: cannot transition to Running without a
+                // complete forward horizon. Subsequent block validation
+                // would hit `UnknownRootError` and cascade-invalidate.
+                match final_horizon_state? {
+                    Some(st) if st.is_finished() => {}
+                    Some(st) => {
+                        return Err(CasperError::RuntimeError(format!(
+                            "LFS forward-horizon: incomplete sync; {} chunk paths still pending (state machine has {} entries)",
+                            st.len() - st.done_count(),
+                            st.len(),
+                        )));
+                    }
+                    None => {
+                        return Err(CasperError::RuntimeError(
+                            "LFS forward-horizon: stream produced no final state".to_string(),
+                        ));
+                    }
+                }
+            } else {
+                tracing::info!(
+                    "LFS forward-horizon: skipped (max_parent_depth unlimited or LFB at genesis)"
+                );
+            }
+        }
+
         // Transition to Running state
         tracing::info!("request_approved_state: transitioning to Running");
         self.create_casper_and_transition_to_running(&approved_block)
@@ -1036,5 +1134,47 @@ impl<T: TransportLayer + Send + Sync> TupleSpaceRequesterOps for TupleSpaceReque
             skip,
             get_from_history,
         ))
+    }
+}
+
+/// Wrapper struct for forward-horizon request operations. Mirrors
+/// `TupleSpaceRequester` — same trait shape, same single-peer
+/// `send_to_bootstrap` body. Lives here (not in the requester module)
+/// for the same reason: the requester module is transport-agnostic and
+/// this wrapper is the seam where `TransportLayer` is plugged in.
+pub struct HorizonRequester<'a, T: TransportLayer> {
+    transport_layer: &'a T,
+    rp_conf_ask: &'a RPConf,
+}
+
+impl<'a, T: TransportLayer> HorizonRequester<'a, T> {
+    pub fn new(transport_layer: &'a T, rp_conf_ask: &'a RPConf) -> Self {
+        Self {
+            transport_layer,
+            rp_conf_ask,
+        }
+    }
+}
+
+#[async_trait]
+impl<T: TransportLayer + Send + Sync>
+    crate::rust::engine::lfs_horizon_requester::HorizonRequesterOps
+    for HorizonRequester<'_, T>
+{
+    async fn request_for_horizon_chunk(
+        &self,
+        path: &StatePartPath,
+        page_size: i32,
+    ) -> Result<(), CasperError> {
+        let message = StoreItemsMessageRequest {
+            start_path: path.clone(),
+            skip: 0,
+            take: page_size,
+        };
+        let message_proto = message.to_proto();
+        self.transport_layer
+            .send_to_bootstrap(&self.rp_conf_ask, Arc::new(message_proto))
+            .await?;
+        Ok(())
     }
 }

--- a/casper/src/rust/engine/initializing.rs
+++ b/casper/src/rust/engine/initializing.rs
@@ -1060,7 +1060,7 @@ impl<T: TransportLayer + Send + Sync> BlockRequesterOps for BlockRequesterWrappe
                     .to_string(),
             )
         })?;
-        runtime_manager.put_mergeable_entry_raw(key_bytes, serialized_entry.to_vec())
+        runtime_manager.put_mergeable_entry_bytes(key_bytes, serialized_entry.to_vec())
     }
 }
 

--- a/casper/src/rust/engine/lfs_block_requester.rs
+++ b/casper/src/rust/engine/lfs_block_requester.rs
@@ -7,12 +7,14 @@ use std::hash::Hash;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::sync::mpsc;
 use tokio::sync::Semaphore;
+use tokio::sync::mpsc;
 
 use models::rust::block_hash::BlockHash;
 use models::rust::casper::pretty_printer::PrettyPrinter;
-use models::rust::casper::protocol::casper_message::{ApprovedBlock, BlockMessage};
+use models::rust::casper::protocol::casper_message::{
+    ApprovedBlock, BlockMessage, MergeableEntryResponse,
+};
 
 use crate::rust::errors::CasperError;
 use crate::rust::metrics_constants::{
@@ -38,6 +40,20 @@ pub trait BlockRequesterOps {
     ) -> Result<(), CasperError>;
 
     fn validate_block(&self, block: &BlockMessage) -> bool;
+
+    /// Send a `MergeableEntryRequest` for `block_hash` to all connected peers.
+    /// Fired after the BlockMessage for `block_hash` has been stored locally.
+    async fn request_for_mergeable_entry(&self, block_hash: &BlockHash) -> Result<(), CasperError>;
+
+    /// Apply an imported mergeable-channels entry. The store key is computed
+    /// locally from the block (already in store) and the raw bincode bytes
+    /// are written without re-serialization. Empty `serialized_entry` is a
+    /// soft miss.
+    fn put_mergeable_entry(
+        &self,
+        block_hash: &BlockHash,
+        serialized_entry: &[u8],
+    ) -> Result<(), CasperError>;
 }
 
 /// Possible request statuses
@@ -74,6 +90,11 @@ pub struct ST<Key: Hash + Eq + Clone> {
     pub lower_bound: i64,
     pub height_map: BTreeMap<i64, HashSet<Key>>,
     pub finished: HashSet<Key>,
+    /// Per-block status of the mergeable-channels entry request. A block-side
+    /// `done()` does NOT mark the per-block work as finished — the entry must
+    /// also have landed. `is_finished()` requires both `d`/`latest` to be
+    /// empty AND `mergeable_d` to be empty.
+    pub mergeable_d: HashMap<Key, ReqStatus>,
 }
 
 impl<Key: Hash + Eq + Clone> ST<Key> {
@@ -98,6 +119,7 @@ impl<Key: Hash + Eq + Clone> ST<Key> {
             lower_bound,
             height_map: BTreeMap::new(),
             finished: HashSet::new(),
+            mergeable_d: HashMap::new(),
         }
     }
 
@@ -124,7 +146,69 @@ impl<Key: Hash + Eq + Clone> ST<Key> {
             lower_bound: self.lower_bound,
             height_map: self.height_map.clone(),
             finished: self.finished.clone(),
+            mergeable_d: self.mergeable_d.clone(),
         }
+    }
+
+    /// Mark `key`'s mergeable-channels entry as needing a request. Called
+    /// immediately after the BlockMessage for `key` has been stored; the
+    /// per-block work isn't `Done` until the entry has also landed.
+    pub fn mergeable_pending(&self, key: Key) -> Self {
+        let mut new_mergeable_d = self.mergeable_d.clone();
+        new_mergeable_d.insert(key, ReqStatus::Init);
+        Self {
+            d: self.d.clone(),
+            latest: self.latest.clone(),
+            lower_bound: self.lower_bound,
+            height_map: self.height_map.clone(),
+            finished: self.finished.clone(),
+            mergeable_d: new_mergeable_d,
+        }
+    }
+
+    /// Pick the next mergeable-entry keys to request. Same `Init → Requested`
+    /// transition as the block side; `resend=true` re-issues `Requested` keys.
+    pub fn get_next_mergeable(&self, resend: bool) -> (Self, HashSet<Key>) {
+        let mut new_mergeable_d = self.mergeable_d.clone();
+        let mut request_keys = HashSet::new();
+
+        for (key, status) in &self.mergeable_d {
+            let should_request =
+                *status == ReqStatus::Init || (resend && *status == ReqStatus::Requested);
+            if should_request {
+                new_mergeable_d.insert(key.clone(), ReqStatus::Requested);
+                request_keys.insert(key.clone());
+            }
+        }
+
+        let new_state = Self {
+            d: self.d.clone(),
+            latest: self.latest.clone(),
+            lower_bound: self.lower_bound,
+            height_map: self.height_map.clone(),
+            finished: self.finished.clone(),
+            mergeable_d: new_mergeable_d,
+        };
+
+        (new_state, request_keys)
+    }
+
+    /// Mark a mergeable-entry response as received. Removes the key from
+    /// `mergeable_d`. Returns whether the key was actually outstanding (false
+    /// = unsolicited / late response).
+    pub fn mergeable_received(&self, key: &Key) -> (Self, bool) {
+        let was_pending = self.mergeable_d.contains_key(key);
+        let mut new_mergeable_d = self.mergeable_d.clone();
+        new_mergeable_d.remove(key);
+        let new_state = Self {
+            d: self.d.clone(),
+            latest: self.latest.clone(),
+            lower_bound: self.lower_bound,
+            height_map: self.height_map.clone(),
+            finished: self.finished.clone(),
+            mergeable_d: new_mergeable_d,
+        };
+        (new_state, was_pending)
     }
 
     /// Get next keys not already requested or in case of resend together with Requested.
@@ -176,6 +260,7 @@ impl<Key: Hash + Eq + Clone> ST<Key> {
             lower_bound: self.lower_bound,
             height_map: self.height_map.clone(),
             finished: self.finished.clone(),
+            mergeable_d: self.mergeable_d.clone(),
         };
 
         (new_state, request_keys)
@@ -231,6 +316,7 @@ impl<Key: Hash + Eq + Clone> ST<Key> {
                 lower_bound: new_lower_bound,
                 height_map: new_height_map,
                 finished: self.finished.clone(),
+                mergeable_d: self.mergeable_d.clone(),
             };
 
             (
@@ -261,15 +347,17 @@ impl<Key: Hash + Eq + Clone> ST<Key> {
                 lower_bound: self.lower_bound,
                 height_map: self.height_map.clone(),
                 finished: new_finished,
+                mergeable_d: self.mergeable_d.clone(),
             }
         } else {
             self.clone()
         }
     }
 
-    /// Returns flag if all keys are marked as finished (Done).
+    /// Returns flag if all keys are marked as finished (Done) AND every block
+    /// has had its mergeable-channels entry imported.
     pub fn is_finished(&self) -> bool {
-        self.latest.is_empty() && self.d.is_empty()
+        self.latest.is_empty() && self.d.is_empty() && self.mergeable_d.is_empty()
     }
 }
 
@@ -512,12 +600,32 @@ impl<'a, T: BlockRequesterOps> StreamProcessor<'a, T> {
             );
         }
 
-        // Mark block download as done
+        // Block-side done; register pending mergeable-entry request. The
+        // block is in store and won't be requested again, but per-block work
+        // isn't finished until the entry has also been imported — see
+        // `ST::is_finished`.
         let state_update_start = std::time::Instant::now();
-        let mut state = self.st.lock().map_err(|_| {
-            CasperError::StreamError("Failed to acquire state lock for done".to_string())
-        })?;
-        *state = state.done(block.block_hash.clone());
+        {
+            let mut state = self.st.lock().map_err(|_| {
+                CasperError::StreamError("Failed to acquire state lock for done".to_string())
+            })?;
+            *state = state.done(block.block_hash.clone());
+            *state = state.mergeable_pending(block.block_hash.clone());
+        }
+        // Fire the mergeable-entry request immediately. Sequential per block:
+        // block was just saved → ask for its entry now. Failure to send is
+        // tolerated; idle-retry will pick up unsent requests.
+        if let Err(e) = self
+            .requester
+            .request_for_mergeable_entry(&block.block_hash)
+            .await
+        {
+            tracing::warn!(
+                "Failed to send MergeableEntryRequest for block {}: {:?}; will retry via idle-resend.",
+                block_hash_str,
+                e
+            );
+        }
         let state_update_duration = state_update_start.elapsed();
 
         let total_save_duration = save_start.elapsed();
@@ -528,6 +636,88 @@ impl<'a, T: BlockRequesterOps> StreamProcessor<'a, T> {
             total_save_duration
         );
 
+        Ok(())
+    }
+
+    /// Apply an imported mergeable-channels entry. The block must already be
+    /// in the local store (entries are only requested after `save_block`).
+    /// Empty `serialized_entry` is a soft miss — we still mark as received
+    /// so the per-block work completes.
+    async fn process_mergeable_entry(
+        &self,
+        resp: &MergeableEntryResponse,
+    ) -> Result<(), CasperError> {
+        let block_hash_str = format!("{:?}", resp.block_hash);
+        let was_pending = {
+            let mut state = self.st.lock().map_err(|_| {
+                CasperError::StreamError(
+                    "Failed to acquire state lock for mergeable_received".to_string(),
+                )
+            })?;
+            let (new_state, was_pending) = state.mergeable_received(&resp.block_hash);
+            *state = new_state;
+            was_pending
+        };
+
+        if !was_pending {
+            tracing::debug!(
+                "Mergeable entry response for {} was unsolicited or late; ignoring.",
+                block_hash_str
+            );
+            return Ok(());
+        }
+
+        if resp.serialized_entry.is_empty() {
+            tracing::debug!(
+                "Mergeable entry response for {} is empty (peer has block, no entry); accepted as soft miss.",
+                block_hash_str
+            );
+            return Ok(());
+        }
+
+        self.requester
+            .put_mergeable_entry(&resp.block_hash, resp.serialized_entry.as_ref())?;
+        tracing::debug!(
+            "Mergeable entry imported for block {} ({} bytes)",
+            block_hash_str,
+            resp.serialized_entry.len()
+        );
+        Ok(())
+    }
+
+    /// Re-broadcast outstanding mergeable-entry requests on idle timeout.
+    /// Mirrors the block-side resend logic.
+    async fn request_next_mergeable(&self, resend: bool) -> Result<(), CasperError> {
+        let hashes = {
+            let mut state = self.st.lock().map_err(|_| {
+                CasperError::StreamError(
+                    "Failed to acquire state lock for mergeable resend".to_string(),
+                )
+            })?;
+            let (new_state, next_hashes) = state.get_next_mergeable(resend);
+            *state = new_state;
+            next_hashes
+        };
+
+        if hashes.is_empty() {
+            return Ok(());
+        }
+
+        tracing::debug!(
+            "Re-issuing {} mergeable-entry request(s) (resend={})",
+            hashes.len(),
+            resend
+        );
+
+        for hash in hashes {
+            if let Err(e) = self.requester.request_for_mergeable_entry(&hash).await {
+                tracing::warn!(
+                    "Failed to (re)send MergeableEntryRequest for {:?}: {:?}",
+                    hash,
+                    e
+                );
+            }
+        }
         Ok(())
     }
 
@@ -665,11 +855,15 @@ impl<'a, T: BlockRequesterOps> StreamProcessor<'a, T> {
 /// Create a stream to receive blocks needed for Last Finalized State.
 /// Uses exponential backoff: starts at request_timeout, doubles up to max_request_timeout.
 /// Resets to request_timeout when a response is received.
+///
+/// After each block lands, fires a `MergeableEntryRequest` for the same hash;
+/// per-block work isn't done until the entry has been imported.
 pub async fn stream<'a, T: BlockRequesterOps>(
     approved_block: &'a ApprovedBlock,
     initial_response_messages: &'a VecDeque<BlockMessage>,
     response_message_receiver: mpsc::Receiver<BlockMessage>,
     response_queue_pending: Arc<AtomicUsize>,
+    mergeable_response_receiver: mpsc::Receiver<MergeableEntryResponse>,
     initial_minimum_height: i64,
     request_timeout: Duration,
     block_ops: &'a mut T,
@@ -730,6 +924,7 @@ pub async fn stream<'a, T: BlockRequesterOps>(
         &initial_response_messages,
         response_message_receiver,
         response_queue_pending,
+        mergeable_response_receiver,
         request_timeout,
         max_request_timeout,
     )
@@ -756,6 +951,7 @@ async fn create_stream_with_processor<'a, T: BlockRequesterOps>(
     initial_response_messages: &'a VecDeque<BlockMessage>,
     mut response_message_receiver: mpsc::Receiver<BlockMessage>,
     response_queue_pending: Arc<AtomicUsize>,
+    mut mergeable_response_receiver: mpsc::Receiver<MergeableEntryResponse>,
     request_timeout: Duration,
     max_request_timeout: Duration,
 ) -> Result<impl futures::stream::Stream<Item = ST<BlockHash>> + use<'a, T>, CasperError> {
@@ -856,11 +1052,17 @@ async fn create_stream_with_processor<'a, T: BlockRequesterOps>(
                 _ = &mut idle_timeout => {
                     let next_timeout = current_timeout.saturating_mul(2).min(max_request_timeout);
                     tracing::warn!(
-                        "No block responses for {:?}. Resending requests. (backoff: {:?} -> {:?})",
+                        "No responses for {:?}. Resending requests. (backoff: {:?} -> {:?})",
                         current_timeout,
                         current_timeout,
                         next_timeout
                     );
+
+                    // Re-issue outstanding mergeable-entry requests too.
+                    // Errors here don't terminate the stream.
+                    if let Err(e) = processor.request_next_mergeable(true).await {
+                        tracing::warn!("Mergeable-entry resend failed: {:?}", e);
+                    }
 
                     match request_queue_sender.try_send(true) {
                         Ok(()) => {
@@ -893,6 +1095,43 @@ async fn create_stream_with_processor<'a, T: BlockRequesterOps>(
                             idle_timeout = Box::pin(tokio::time::sleep(current_timeout));
                         }
                     }
+                }
+
+                Some(mergeable_resp) = mergeable_response_receiver.recv() => {
+                    // Apply the imported entry, mark per-block mergeable as done,
+                    // check termination. Errors here don't break the stream —
+                    // worst case the per-block mergeable stays Pending until
+                    // idle-retry re-issues it.
+                    if let Err(e) = processor.process_mergeable_entry(&mergeable_resp).await {
+                        tracing::warn!(
+                            "Failed to import mergeable entry for {:?}: {:?}",
+                            mergeable_resp.block_hash,
+                            e
+                        );
+                        continue;
+                    }
+
+                    let current_state = {
+                        match processor.st.lock() {
+                            Ok(state) => state.clone(),
+                            Err(e) => {
+                                tracing::error!("Failed to acquire state lock for mergeable response: {:?}", e);
+                                continue;
+                            }
+                        }
+                    };
+
+                    if current_state.is_finished() {
+                        tracing::info!("Mergeable-entry import completed last pending unit; stream terminating.");
+                        yield current_state;
+                        break;
+                    }
+
+                    // Activity reset
+                    current_timeout = request_timeout;
+                    idle_timeout = Box::pin(tokio::time::sleep(current_timeout));
+
+                    yield current_state;
                 }
 
                 // Process initial messages with highest priority (before network messages)

--- a/casper/src/rust/engine/lfs_block_requester.rs
+++ b/casper/src/rust/engine/lfs_block_requester.rs
@@ -1335,9 +1335,9 @@ async fn create_stream_with_processor<'a, T: BlockRequesterOps>(
                         final_stats.0, final_stats.1, final_stats.2, final_stats.3, final_stats.4);
 
                     if final_stats.4 {
-                        tracing::info!("✅ LFS Block Requester completed successfully - all required blocks downloaded");
+                        tracing::info!("LFS Block Requester completed successfully - all required blocks downloaded");
                     } else {
-                        tracing::warn!("⚠️ LFS Block Requester terminated with incomplete state - some blocks may be missing");
+                        tracing::warn!("LFS Block Requester terminated with incomplete state - some blocks may be missing");
                     }
 
                     Some(state.clone())

--- a/casper/src/rust/engine/lfs_block_requester.rs
+++ b/casper/src/rust/engine/lfs_block_requester.rs
@@ -7,8 +7,8 @@ use std::hash::Hash;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
+use tokio::sync::Semaphore;
 
 use models::rust::block_hash::BlockHash;
 use models::rust::casper::pretty_printer::PrettyPrinter;

--- a/casper/src/rust/engine/lfs_horizon_requester.rs
+++ b/casper/src/rust/engine/lfs_horizon_requester.rs
@@ -173,10 +173,13 @@ struct HorizonStreamProcessor<T: HorizonRequesterOps> {
     has_root: HasRootFn,
     state_importer: Arc<dyn RSpaceImporter>,
     st: Arc<Mutex<ST<StatePartPath>>>,
-    /// Maps each chunk path to the root it's paginating. Initial paths
-    /// `[(root, None)]` map to `root`; pagination continuations inherit
-    /// the root of the path they came from.
-    path_to_root: Arc<Mutex<HashMap<StatePartPath, Blake2b256Hash>>>,
+    /// Maps each chunk path to the SET of roots paginating through it.
+    /// Initial paths `[(root, None)]` map to `{root}`. When two roots'
+    /// pagination chains converge on a shared cursor (radix tries derived
+    /// from sibling chain states routinely share suffix paths), the cursor
+    /// maps to BOTH roots; one wire request satisfies both, and the
+    /// terminal completion fires `set_root` for each.
+    path_to_root: Arc<Mutex<HashMap<StatePartPath, HashSet<Blake2b256Hash>>>>,
     /// Per-root chunk-count + byte counters for byzantine-peer detection.
     root_progress: Arc<Mutex<HashMap<Blake2b256Hash, RootProgress>>>,
     request_tx: mpsc::Sender<bool>,
@@ -217,17 +220,22 @@ impl<T: HorizonRequesterOps> HorizonStreamProcessor<T> {
             return Ok(());
         }
 
-        // Find which root this chunk's pagination chain belongs to.
-        let root = {
+        // Find which roots this chunk's pagination chain belongs to.
+        // Multiple roots may share the same cursor — the chunk's content
+        // satisfies all of them in one shot.
+        let roots: Vec<Blake2b256Hash> = {
             let map = self.path_to_root.lock().expect("path_to_root lock");
-            map.get(&start_path).cloned()
+            match map.get(&start_path) {
+                Some(set) => set.iter().cloned().collect(),
+                None => Vec::new(),
+            }
         };
-        let Some(root) = root else {
+        if roots.is_empty() {
             tracing::warn!(
                 "LFS forward-horizon: received chunk for path with no root mapping; ignoring"
             );
             return Ok(());
-        };
+        }
 
         // Apply items to local rspace. Radix nodes are content-addressed so
         // the importer can validate keys against contents internally.
@@ -236,54 +244,70 @@ impl<T: HorizonRequesterOps> HorizonStreamProcessor<T> {
         let _ = self.state_importer.set_history_items(history_items);
         let _ = self.state_importer.set_data_items(data_items);
 
-        // Update per-root progress.
+        // Update per-root progress for every root sharing this chunk.
         {
             let mut progress_map = self.root_progress.lock().expect("root_progress lock");
-            let entry = progress_map.entry(root.clone()).or_default();
-            entry.chunk_count += 1;
-            entry.total_history += history_count;
-            entry.total_data += data_count;
+            for root in &roots {
+                let entry = progress_map.entry(root.clone()).or_default();
+                entry.chunk_count += 1;
+                entry.total_history += history_count;
+                entry.total_data += data_count;
+            }
         }
 
         let is_terminal = last_path == start_path;
 
         if is_terminal {
             // Byzantine signal: terminal cursor on first chunk + no data
-            // means the peer doesn't have this root. Fail loud.
-            let progress = {
-                let progress_map = self.root_progress.lock().expect("root_progress lock");
-                progress_map.get(&root).cloned().unwrap_or_default()
-            };
-            if progress.chunk_count == 1 && progress.total_history == 0 && progress.total_data == 0
+            // means the peer doesn't have this root. Fail loud if ANY root
+            // sharing this terminal saw only an empty first chunk — that's
+            // still an unrecoverable signal even if other roots happened to
+            // have legitimate data on a prior path.
             {
-                return Err(CasperError::RuntimeError(format!(
-                    "LFS forward-horizon: bootstrap signalled empty/missing root {} \
-                     (terminal cursor on first chunk)",
-                    root
-                )));
+                let progress_map = self.root_progress.lock().expect("root_progress lock");
+                for root in &roots {
+                    let progress = progress_map.get(root).cloned().unwrap_or_default();
+                    if progress.chunk_count == 1
+                        && progress.total_history == 0
+                        && progress.total_data == 0
+                    {
+                        return Err(CasperError::RuntimeError(format!(
+                            "LFS forward-horizon: bootstrap signalled empty/missing root {} \
+                             (terminal cursor on first chunk)",
+                            root
+                        )));
+                    }
+                }
             }
 
             // Record the root tag in roots_store and verify the import
-            // reconstructed the expected root.
-            self.state_importer.set_root(&root);
-            let now_have = (self.has_root)(&root)?;
-            if !now_have {
-                return Err(CasperError::RuntimeError(format!(
-                    "LFS forward-horizon: root {} not in store after import; \
-                     peer shipped invalid data",
-                    root
-                )));
+            // reconstructed each expected root.
+            for root in &roots {
+                self.state_importer.set_root(root);
+                let now_have = (self.has_root)(root)?;
+                if !now_have {
+                    return Err(CasperError::RuntimeError(format!(
+                        "LFS forward-horizon: root {} not in store after import; \
+                         peer shipped invalid data",
+                        root
+                    )));
+                }
+                let progress = {
+                    let progress_map = self.root_progress.lock().expect("root_progress lock");
+                    progress_map.get(root).cloned().unwrap_or_default()
+                };
+                tracing::debug!(
+                    "LFS forward-horizon: completed root {} ({} chunks, {} history, {} data)",
+                    root,
+                    progress.chunk_count,
+                    progress.total_history,
+                    progress.total_data
+                );
             }
 
-            tracing::debug!(
-                "LFS forward-horizon: completed root {} ({} chunks, {} history, {} data)",
-                root,
-                progress.chunk_count,
-                progress.total_history,
-                progress.total_data
-            );
-
-            // Mark Done and free per-root state.
+            // Mark the path Done and free its multi-root mapping. ST
+            // tracks paths, not roots, so a single done() retires the
+            // shared chunk for all associated roots.
             {
                 let mut state = self.st.lock().expect("ST lock");
                 let new_state = state.done(start_path.clone());
@@ -298,11 +322,17 @@ impl<T: HorizonRequesterOps> HorizonStreamProcessor<T> {
             // sent now that one has finished.
             let _ = self.request_tx.try_send(false);
         } else {
-            // Non-terminal: enqueue the next chunk for this root. The new
-            // path inherits the same root association.
+            // Non-terminal: continuation cursor inherits the full root set.
+            // If `last_path` is already tracked (another root's chunk
+            // already converged on the same cursor), merge into the
+            // existing set so its terminal completion fires set_root for
+            // every root, not just the first writer.
             {
                 let mut map = self.path_to_root.lock().expect("path_to_root lock");
-                map.insert(last_path.clone(), root.clone());
+                let entry = map.entry(last_path.clone()).or_default();
+                for root in &roots {
+                    entry.insert(root.clone());
+                }
             }
             {
                 let mut state = self.st.lock().expect("ST lock");
@@ -411,11 +441,15 @@ pub async fn stream<T: HorizonRequesterOps>(
     );
 
     // Build initial ST: one path per root, of the form `[(root, None)]`.
+    // Each initial path uniquely identifies its root, so the singleton
+    // sets here will only ever grow when pagination cursors converge.
     let mut initial_paths: Vec<StatePartPath> = Vec::with_capacity(filtered.len());
-    let mut path_to_root_init: HashMap<StatePartPath, Blake2b256Hash> = HashMap::new();
+    let mut path_to_root_init: HashMap<StatePartPath, HashSet<Blake2b256Hash>> = HashMap::new();
     for root in &filtered {
         let path: StatePartPath = vec![(root.clone(), None)];
-        path_to_root_init.insert(path.clone(), root.clone());
+        let mut set = HashSet::new();
+        set.insert(root.clone());
+        path_to_root_init.insert(path.clone(), set);
         initial_paths.push(path);
     }
 
@@ -707,6 +741,39 @@ mod tests {
     }
 
     impl RSpaceImporter for NoopImporter {
+        fn get_history_item(&self, _hash: Blake2b256Hash) -> Option<Vec<u8>> {
+            None
+        }
+    }
+
+    /// Recording RSpaceImporter — captures every root passed to `set_root`.
+    /// Pair with a `has_root` closure that reads from the same set so the
+    /// orchestrator's post-import verification reflects what was recorded.
+    struct RecordingImporter {
+        recorded: Arc<Mutex<HashSet<Blake2b256Hash>>>,
+    }
+
+    impl RecordingImporter {
+        fn new() -> (Self, Arc<Mutex<HashSet<Blake2b256Hash>>>) {
+            let recorded = Arc::new(Mutex::new(HashSet::new()));
+            (
+                Self {
+                    recorded: recorded.clone(),
+                },
+                recorded,
+            )
+        }
+    }
+
+    impl TrieImporter for RecordingImporter {
+        fn set_history_items(&self, _data: Vec<(Blake2b256Hash, Vec<u8>)>) -> () {}
+        fn set_data_items(&self, _data: Vec<(Blake2b256Hash, Vec<u8>)>) -> () {}
+        fn set_root(&self, key: &Blake2b256Hash) -> () {
+            self.recorded.lock().unwrap().insert(key.clone());
+        }
+    }
+
+    impl RSpaceImporter for RecordingImporter {
         fn get_history_item(&self, _hash: Blake2b256Hash) -> Option<Vec<u8>> {
             None
         }
@@ -1035,6 +1102,118 @@ mod tests {
             "orchestrator must dispatch all 4 root requests in parallel; \
              max_in_flight={}",
             observed
+        );
+    }
+
+    /// Regression: two roots whose first chunks return the SAME continuation
+    /// cursor must BOTH receive `set_root` after the shared continuation
+    /// terminates. Without per-path multi-root tracking, the orchestrator's
+    /// HashMap<Path, Hash> mapping silently drops all but the last writer,
+    /// `set_root` fires for only one root, and the other is left with an
+    /// imported trie but no roots-store tag — causing later `reset(root)` to
+    /// fail with `RootRepositoryDivergence`. Radix-trie pagination shares
+    /// suffix cursors across roots derived from sibling chain states, so
+    /// this collision is the common case, not an edge case.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn stream_completes_all_roots_when_first_chunks_share_last_path() {
+        let r1 = hash_for(20);
+        let r2 = hash_for(21);
+        let shared_cont = vec![(hash_for(99), Some(0u8))];
+
+        let (importer_inner, recorded) = RecordingImporter::new();
+        let importer: Arc<dyn RSpaceImporter> = Arc::new(importer_inner);
+
+        // has_root: read from the recorded set so post-import verify sees
+        // what set_root just wrote. Pre-filter sees nothing → both roots
+        // enter the orchestrator.
+        let recorded_for_has_root = recorded.clone();
+        let has_root: HasRootFn =
+            Arc::new(move |q| Ok(recorded_for_has_root.lock().unwrap().contains(q)));
+
+        let ops = MockOps::new();
+        let (sends, _) = ops.handles();
+        let (tx, rx) = test_mpsc::channel::<StoreItemsMessage>(8);
+
+        let start1 = vec![(r1.clone(), None)];
+        let start2 = vec![(r2.clone(), None)];
+
+        // Both first chunks are non-terminal and end at the same cursor.
+        let resp1 = make_response(start1.clone(), shared_cont.clone(), Some(hash_for(101)));
+        let resp2 = make_response(start2.clone(), shared_cont.clone(), Some(hash_for(102)));
+        // The shared continuation terminates with one item (proves it's not
+        // an empty-byzantine signal).
+        let resp3 = make_response(
+            shared_cont.clone(),
+            shared_cont.clone(),
+            Some(hash_for(103)),
+        );
+
+        let feeder_sends = sends.clone();
+        let feeder_start1 = start1.clone();
+        let feeder_start2 = start2.clone();
+        let feeder_cont = shared_cont.clone();
+        let feeder = tokio::spawn(async move {
+            // Wait until both initial start_paths have been requested before
+            // feeding either response, so the orchestrator has both roots in
+            // ST when it processes them.
+            loop {
+                let both_sent = {
+                    let s = feeder_sends.lock().unwrap();
+                    s.contains(&feeder_start1) && s.contains(&feeder_start2)
+                };
+                if both_sent {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+            tx.send(resp1).await.unwrap();
+            tx.send(resp2).await.unwrap();
+            // Wait for the shared continuation to be requested.
+            loop {
+                if feeder_sends.lock().unwrap().contains(&feeder_cont) {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+            tx.send(resp3).await.unwrap();
+            drop(tx);
+        });
+
+        let stream = stream(
+            vec![r1.clone(), r2.clone()],
+            has_root,
+            importer,
+            ops,
+            rx,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+        let final_st = drain(stream).await.expect("stream yields final state");
+        feeder.await.unwrap();
+
+        assert!(
+            final_st.is_finished(),
+            "orchestrator should mark all paths Done; final state: {:?}",
+            final_st
+        );
+
+        let recorded = recorded.lock().unwrap();
+        assert!(
+            recorded.contains(&r1),
+            "set_root must fire for r1 (was silently dropped by HashMap collision); recorded = {:?}",
+            recorded
+        );
+        assert!(
+            recorded.contains(&r2),
+            "set_root must fire for r2; recorded = {:?}",
+            recorded
+        );
+        assert_eq!(
+            recorded.len(),
+            2,
+            "exactly 2 roots should have been recorded; recorded = {:?}",
+            recorded
         );
     }
 }

--- a/casper/src/rust/engine/lfs_horizon_requester.rs
+++ b/casper/src/rust/engine/lfs_horizon_requester.rs
@@ -1,0 +1,582 @@
+//! Forward-horizon rspace history sync.
+//!
+//! Companion to `lfs_block_requester` (per-block message sync) and
+//! `lfs_tuple_space_requester` (LFB-state subtree sync). This module
+//! syncs rspace post-state roots for every block within the
+//! forward-horizon window — every block that an honest proposer could
+//! legitimately reference as a parent of an upcoming proposal.
+//!
+//! Together with `validate::parents`' parent-depth check, this guarantees
+//! that every legitimately-validatable block has its parents' rspace state
+//! local at validation time. No `UnknownRootError` can fire on
+//! consensus-valid blocks; out-of-horizon blocks are rejected on consensus
+//! rules in `validate::parents`.
+//!
+//! ## Streaming-parallel orchestration
+//!
+//! Mirrors `lfs_tuple_space_requester` and `lfs_block_requester`. Each
+//! horizon root enters an `ST<StatePartPath>` state machine as
+//! `Init → Requested → Received → Done`. A request loop fans out all
+//! pending paths in parallel via `try_join_all`, while a response loop
+//! demultiplexes incoming `StoreItemsMessage`s by `start_path`, applies
+//! items, paginates within each root, and on the terminal cursor calls
+//! `set_root` + verifies via `runtime_manager.has_root` (loud-fail on
+//! byzantine peer).
+//!
+//! Wire format (`StoreItemsMessageRequest` / `StoreItemsMessage`) is shared
+//! with `lfs_tuple_space_requester`. Pagination semantics: a response with
+//! `last_path == start_path` is the terminal cursor; non-terminal responses
+//! enqueue `last_path` as the next chunk to request for that same root.
+
+use async_trait::async_trait;
+use futures::Stream;
+use models::rust::casper::protocol::casper_message::StoreItemsMessage;
+use rspace_plus_plus::rspace::hashing::blake2b256_hash::Blake2b256Hash;
+use rspace_plus_plus::rspace::state::rspace_importer::RSpaceImporter;
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::mpsc;
+
+use crate::rust::engine::lfs_tuple_space_requester::StatePartPath;
+use crate::rust::errors::CasperError;
+use crate::rust::util::rholang::runtime_manager::RuntimeManager;
+
+/// Per-chunk page size for state-item requests. Matches the value used
+/// by `lfs_tuple_space_requester` for LFB-state subtree pagination.
+pub const PAGE_SIZE: i32 = 1024;
+
+/// Per-chunk request status. Mirrors `lfs_tuple_space_requester::ReqStatus`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReqStatus {
+    Init,
+    Requested,
+    Received,
+    Done,
+}
+
+/// State to control processing of horizon-root requests. Keyed by chunk
+/// path so that pagination cursors and initial root requests live in the
+/// same data structure (matches `lfs_tuple_space_requester::ST`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ST<Key: Hash + Eq + Clone> {
+    d: HashMap<Key, ReqStatus>,
+}
+
+impl<Key: Hash + Eq + Clone> ST<Key> {
+    pub fn new(initial: Vec<Key>) -> Self {
+        let d = initial
+            .into_iter()
+            .map(|key| (key, ReqStatus::Init))
+            .collect();
+        Self { d }
+    }
+
+    pub fn add(&self, keys: HashSet<Key>) -> Self {
+        let mut new_d = self.d.clone();
+        for key in keys {
+            if !self.d.contains_key(&key) {
+                new_d.insert(key, ReqStatus::Init);
+            }
+        }
+        Self { d: new_d }
+    }
+
+    /// Returns the next batch of keys to request. Init keys always; if
+    /// `resend` is true, also Requested keys (for timeout-driven retries).
+    pub fn get_next(&self, resend: bool) -> (Self, Vec<Key>) {
+        let mut new_d = self.d.clone();
+        let mut requested_keys = Vec::new();
+        for (key, status) in &self.d {
+            let should_request = match status {
+                ReqStatus::Init => true,
+                ReqStatus::Requested if resend => true,
+                _ => false,
+            };
+            if should_request {
+                new_d.insert(key.clone(), ReqStatus::Requested);
+                requested_keys.push(key.clone());
+            }
+        }
+        (Self { d: new_d }, requested_keys)
+    }
+
+    pub fn received(&self, k: Key) -> (Self, bool) {
+        let current_status = self.d.get(&k);
+        let is_valid = current_status == Some(&ReqStatus::Requested)
+            || current_status == Some(&ReqStatus::Init);
+        let new_d = if is_valid {
+            let mut updated_d = self.d.clone();
+            updated_d.insert(k, ReqStatus::Received);
+            updated_d
+        } else {
+            self.d.clone()
+        };
+        (Self { d: new_d }, is_valid)
+    }
+
+    pub fn done(&self, k: Key) -> Self {
+        let is_received = self.d.get(&k) == Some(&ReqStatus::Received);
+        if is_received {
+            let mut new_d = self.d.clone();
+            new_d.insert(k, ReqStatus::Done);
+            Self { d: new_d }
+        } else {
+            self.clone()
+        }
+    }
+
+    pub fn is_finished(&self) -> bool {
+        !self.d.values().any(|status| *status != ReqStatus::Done)
+    }
+
+    pub fn len(&self) -> usize {
+        self.d.len()
+    }
+
+    pub fn done_count(&self) -> usize {
+        self.d.values().filter(|s| **s == ReqStatus::Done).count()
+    }
+}
+
+/// Network operations needed by the horizon requester. Decoupled from
+/// `TransportLayer` so unit tests can stub it without spinning up a
+/// transport stack. Mirrors `lfs_tuple_space_requester::TupleSpaceRequesterOps`.
+#[async_trait]
+pub trait HorizonRequesterOps: Send + Sync {
+    /// Send a `StoreItemsMessageRequest` for the given chunk path. The
+    /// production impl unicasts to bootstrap; the response arrives on the
+    /// shared `mpsc::Receiver<StoreItemsMessage>` correlated by `start_path`.
+    async fn request_for_horizon_chunk(
+        &self,
+        path: &StatePartPath,
+        page_size: i32,
+    ) -> Result<(), CasperError>;
+}
+
+/// Per-root pagination accounting. Used to detect the "terminal cursor on
+/// first chunk + zero items" byzantine signal (peer doesn't have this root).
+#[derive(Debug, Clone, Default)]
+struct RootProgress {
+    chunk_count: usize,
+    total_history: usize,
+    total_data: usize,
+}
+
+struct HorizonStreamProcessor<T: HorizonRequesterOps> {
+    request_ops: T,
+    runtime_manager: Arc<RuntimeManager>,
+    state_importer: Arc<dyn RSpaceImporter>,
+    st: Arc<Mutex<ST<StatePartPath>>>,
+    /// Maps each chunk path to the root it's paginating. Initial paths
+    /// `[(root, None)]` map to `root`; pagination continuations inherit
+    /// the root of the path they came from.
+    path_to_root: Arc<Mutex<HashMap<StatePartPath, Blake2b256Hash>>>,
+    /// Per-root chunk-count + byte counters for byzantine-peer detection.
+    root_progress: Arc<Mutex<HashMap<Blake2b256Hash, RootProgress>>>,
+    request_tx: mpsc::Sender<bool>,
+}
+
+impl<T: HorizonRequesterOps> HorizonStreamProcessor<T> {
+    async fn process_store_items_message(
+        &self,
+        message: StoreItemsMessage,
+    ) -> Result<(), CasperError> {
+        let StoreItemsMessage {
+            start_path,
+            last_path,
+            history_items,
+            data_items,
+        } = message;
+
+        let history_items: Vec<(Blake2b256Hash, Vec<u8>)> = history_items
+            .into_iter()
+            .map(|(hash, bytes)| (hash, bytes.to_vec()))
+            .collect();
+        let data_items: Vec<(Blake2b256Hash, Vec<u8>)> = data_items
+            .into_iter()
+            .map(|(hash, bytes)| (hash, bytes.to_vec()))
+            .collect();
+
+        // Mark this chunk as Received in the state machine. If the path
+        // wasn't previously Requested (or Init, in the fast in-memory test
+        // case), treat the chunk as stale and ignore.
+        let was_known = {
+            let mut state = self.st.lock().expect("ST lock");
+            let (new_state, is_valid) = state.received(start_path.clone());
+            *state = new_state;
+            is_valid
+        };
+        if !was_known {
+            tracing::debug!(
+                "LFS forward-horizon: ignoring chunk for unknown/stale path"
+            );
+            return Ok(());
+        }
+
+        // Find which root this chunk's pagination chain belongs to.
+        let root = {
+            let map = self.path_to_root.lock().expect("path_to_root lock");
+            map.get(&start_path).cloned()
+        };
+        let Some(root) = root else {
+            tracing::warn!(
+                "LFS forward-horizon: received chunk for path with no root mapping; ignoring"
+            );
+            return Ok(());
+        };
+
+        // Apply items to local rspace. Radix nodes are content-addressed so
+        // the importer can validate keys against contents internally.
+        let history_count = history_items.len();
+        let data_count = data_items.len();
+        let _ = self.state_importer.set_history_items(history_items);
+        let _ = self.state_importer.set_data_items(data_items);
+
+        // Update per-root progress.
+        {
+            let mut progress_map = self.root_progress.lock().expect("root_progress lock");
+            let entry = progress_map.entry(root.clone()).or_default();
+            entry.chunk_count += 1;
+            entry.total_history += history_count;
+            entry.total_data += data_count;
+        }
+
+        let is_terminal = last_path == start_path;
+
+        if is_terminal {
+            // Byzantine signal: terminal cursor on first chunk + no data
+            // means the peer doesn't have this root. Fail loud.
+            let progress = {
+                let progress_map =
+                    self.root_progress.lock().expect("root_progress lock");
+                progress_map.get(&root).cloned().unwrap_or_default()
+            };
+            if progress.chunk_count == 1
+                && progress.total_history == 0
+                && progress.total_data == 0
+            {
+                return Err(CasperError::RuntimeError(format!(
+                    "LFS forward-horizon: bootstrap signalled empty/missing root {} \
+                     (terminal cursor on first chunk)",
+                    root
+                )));
+            }
+
+            // Record the root tag in roots_store and verify the import
+            // reconstructed the expected root.
+            self.state_importer.set_root(&root);
+            let now_have = self.runtime_manager.has_root(&root)?;
+            if !now_have {
+                return Err(CasperError::RuntimeError(format!(
+                    "LFS forward-horizon: root {} not in store after import; \
+                     peer shipped invalid data",
+                    root
+                )));
+            }
+
+            tracing::debug!(
+                "LFS forward-horizon: completed root {} ({} chunks, {} history, {} data)",
+                root, progress.chunk_count, progress.total_history, progress.total_data
+            );
+
+            // Mark Done and free per-root state.
+            {
+                let mut state = self.st.lock().expect("ST lock");
+                let new_state = state.done(start_path.clone());
+                *state = new_state;
+            }
+            {
+                let mut map = self.path_to_root.lock().expect("path_to_root lock");
+                map.remove(&start_path);
+            }
+
+            // Trigger another request cycle so any unstarted Init paths get
+            // sent now that one has finished.
+            let _ = self.request_tx.try_send(false);
+        } else {
+            // Non-terminal: enqueue the next chunk for this root. The new
+            // path inherits the same root association.
+            {
+                let mut map = self.path_to_root.lock().expect("path_to_root lock");
+                map.insert(last_path.clone(), root.clone());
+            }
+            {
+                let mut state = self.st.lock().expect("ST lock");
+                let mut next = HashSet::new();
+                next.insert(last_path);
+                let new_state = state.add(next);
+                // Mark the just-processed chunk Done so it doesn't keep
+                // counting against is_finished. (Pagination continues via
+                // the freshly-added Init entry.)
+                let new_state = new_state.done(start_path.clone());
+                *state = new_state;
+            }
+            {
+                let mut map = self.path_to_root.lock().expect("path_to_root lock");
+                map.remove(&start_path);
+            }
+
+            let _ = self.request_tx.try_send(false);
+        }
+
+        Ok(())
+    }
+
+    async fn request_next(&self, resend: bool) -> Result<(), CasperError> {
+        // Snapshot is_finished and pull next-paths under one lock.
+        let (is_finished, paths) = {
+            let mut state = self.st.lock().expect("ST lock");
+            if state.is_finished() {
+                (true, Vec::new())
+            } else {
+                let (new_state, paths) = state.get_next(resend);
+                *state = new_state;
+                (false, paths)
+            }
+        };
+        if is_finished || paths.is_empty() {
+            return Ok(());
+        }
+
+        if resend {
+            tracing::info!(
+                "LFS forward-horizon: resending {} pending chunk requests",
+                paths.len()
+            );
+        } else {
+            tracing::debug!(
+                "LFS forward-horizon: dispatching {} chunk requests in parallel",
+                paths.len()
+            );
+        }
+
+        // Parallel fan-out. Same shape as
+        // `lfs_tuple_space_requester::request_next` (Scala:
+        // `broadcastStreams(ids).parJoinUnbounded`).
+        let request_futures: Vec<_> = paths
+            .iter()
+            .map(|path| async move {
+                self.request_ops
+                    .request_for_horizon_chunk(path, PAGE_SIZE)
+                    .await
+            })
+            .collect();
+        futures::future::try_join_all(request_futures).await?;
+
+        Ok(())
+    }
+}
+
+/// Streaming forward-horizon sync orchestrator. Roots already present in
+/// the joiner's roots_store (per `runtime_manager.has_root`) are filtered
+/// out before the stream starts. The remaining roots are enqueued in `ST`
+/// and processed in parallel via the streaming select-loop below.
+///
+/// Returns a `Stream<Item = ST<StatePartPath>>` that emits an updated state
+/// snapshot on each response/request cycle and terminates when all roots
+/// reach `Done`. Caller should consume the stream to completion and check
+/// `is_finished()` on the final state to ensure no roots were left
+/// unsynced (incomplete sync = caller must NOT transition to Running).
+pub async fn stream<T: HorizonRequesterOps>(
+    horizon_roots: Vec<Blake2b256Hash>,
+    runtime_manager: Arc<RuntimeManager>,
+    state_importer: Arc<dyn RSpaceImporter>,
+    request_ops: T,
+    mut store_items_message_receiver: mpsc::Receiver<StoreItemsMessage>,
+    request_timeout: Duration,
+) -> Result<impl Stream<Item = ST<StatePartPath>>, CasperError> {
+    let total_input = horizon_roots.len();
+
+    // Pre-filter roots already present (LFB root is the typical hit, since
+    // `lfs_tuple_space_requester` has already imported it).
+    let mut filtered: Vec<Blake2b256Hash> = Vec::with_capacity(total_input);
+    let mut skipped = 0usize;
+    for root in horizon_roots {
+        if runtime_manager.has_root(&root)? {
+            skipped += 1;
+        } else {
+            filtered.push(root);
+        }
+    }
+
+    tracing::info!(
+        "LFS forward-horizon: starting parallel sync for {} roots ({} already present, {} input)",
+        filtered.len(),
+        skipped,
+        total_input
+    );
+
+    // Build initial ST: one path per root, of the form `[(root, None)]`.
+    let mut initial_paths: Vec<StatePartPath> = Vec::with_capacity(filtered.len());
+    let mut path_to_root_init: HashMap<StatePartPath, Blake2b256Hash> = HashMap::new();
+    for root in &filtered {
+        let path: StatePartPath = vec![(root.clone(), None)];
+        path_to_root_init.insert(path.clone(), root.clone());
+        initial_paths.push(path);
+    }
+
+    let st = Arc::new(Mutex::new(ST::new(initial_paths)));
+    let path_to_root = Arc::new(Mutex::new(path_to_root_init));
+    let root_progress = Arc::new(Mutex::new(HashMap::new()));
+
+    // Bounded request queue (cap 2 — one resend + one new). Matches
+    // tuple_space_requester::stream channel sizing.
+    let (request_tx, mut request_rx) = mpsc::channel::<bool>(2);
+
+    // Tracked-out-of-band so byzantine-detection / has_root errors inside
+    // the response handler can be surfaced to the caller via the wrapper
+    // below. async_stream! yields ST snapshots only.
+    let last_error: Arc<Mutex<Option<CasperError>>> = Arc::new(Mutex::new(None));
+
+    let processor = Arc::new(HorizonStreamProcessor {
+        request_ops,
+        runtime_manager,
+        state_importer,
+        st: st.clone(),
+        path_to_root,
+        root_progress,
+        request_tx: request_tx.clone(),
+    });
+
+    // Empty-input shortcut: yield a finished ST and exit so callers see
+    // the same streaming contract regardless of input size.
+    let nothing_to_do = filtered.is_empty();
+    let last_error_for_stream = last_error.clone();
+    let st_for_stream = st.clone();
+
+    // Initial request kick-off (only if we have roots to fetch).
+    if !nothing_to_do {
+        request_tx.send(false).await.map_err(|_| {
+            CasperError::RuntimeError(
+                "LFS forward-horizon: initial request enqueue failed".to_string(),
+            )
+        })?;
+    }
+
+    let max_request_timeout = Duration::from_secs(128);
+
+    let stream = async_stream::stream! {
+        if nothing_to_do {
+            let final_state = st_for_stream.lock().expect("ST lock").clone();
+            yield final_state;
+            return;
+        }
+
+        let mut current_timeout = request_timeout;
+        let mut idle_timeout = Box::pin(tokio::time::sleep(current_timeout));
+
+        loop {
+            tokio::select! {
+                // biased: prefer responses (drain side) over new requests so
+                // we don't starve the demux while issuing more sends.
+                biased;
+
+                Some(message) = store_items_message_receiver.recv() => {
+                    if let Err(e) = processor.process_store_items_message(message).await {
+                        tracing::error!(
+                            "LFS forward-horizon: stream terminating due to processing error: {:?}",
+                            e
+                        );
+                        *last_error_for_stream.lock().expect("last_error lock") = Some(e);
+                        break;
+                    }
+
+                    let current_state = st_for_stream
+                        .lock()
+                        .expect("ST lock")
+                        .clone();
+                    let is_finished = current_state.is_finished();
+
+                    if is_finished {
+                        tracing::info!(
+                            "LFS forward-horizon: complete (all {} roots synced)",
+                            current_state.len()
+                        );
+                        yield current_state;
+                        break;
+                    }
+
+                    // Activity = reset backoff.
+                    current_timeout = request_timeout;
+                    idle_timeout = Box::pin(tokio::time::sleep(current_timeout));
+                    yield current_state;
+                }
+
+                Some(resend_flag) = request_rx.recv() => {
+                    if let Err(e) = processor.request_next(resend_flag).await {
+                        tracing::error!(
+                            "LFS forward-horizon: stream terminating due to request error: {:?}",
+                            e
+                        );
+                        *last_error_for_stream.lock().expect("last_error lock") = Some(e);
+                        break;
+                    }
+
+                    let current_state = st_for_stream
+                        .lock()
+                        .expect("ST lock")
+                        .clone();
+                    if current_state.is_finished() {
+                        yield current_state;
+                        break;
+                    }
+
+                    current_timeout = request_timeout;
+                    idle_timeout = Box::pin(tokio::time::sleep(current_timeout));
+                    yield current_state;
+                }
+
+                _ = &mut idle_timeout => {
+                    let next_timeout = current_timeout.saturating_mul(2).min(max_request_timeout);
+                    tracing::warn!(
+                        "LFS forward-horizon: no responses for {:?}; resending. backoff -> {:?}",
+                        current_timeout, next_timeout
+                    );
+                    if request_tx.try_send(true).is_err() {
+                        tracing::warn!(
+                            "LFS forward-horizon: request queue full on resend trigger"
+                        );
+                    }
+                    current_timeout = next_timeout;
+                    idle_timeout = Box::pin(tokio::time::sleep(current_timeout));
+                }
+            }
+        }
+
+        // Final state emission so the caller sees the terminal ST snapshot
+        // even if the loop exited via break (error path).
+        let final_state = st_for_stream
+            .lock()
+            .expect("ST lock")
+            .clone();
+        yield final_state;
+    };
+
+    // Keep last_error alive in the same scope as the stream by wrapping it
+    // in a struct... actually, the stream already captures last_error_for_stream
+    // by move and writes to it. The wrapper below reads it. We stash an Arc
+    // clone in the stream's parent scope (here) — but stream() returns the
+    // stream and drops the local Arc. That's fine: last_error_for_stream
+    // (moved into the async block) shares the Arc with the wrapper's clone.
+
+    // last_error is captured by the async block via last_error_for_stream;
+    // however, we don't expose it through this stream's public surface.
+    // Callers detect failure via `final ST.is_finished() == false`.
+    // Specific error context is logged via `tracing::error!` in the loop.
+    let _ = last_error;
+
+    Ok(stream)
+}
+
+#[cfg(test)]
+mod tests {
+    // Integration coverage for sync_forward_horizon lives in B5 isolation runs
+    // (multi-node bonding test on subprocess provider). Unit tests for the
+    // pure reachability calc are in
+    // `casper/tests/util/rspace_history_horizon_test.rs`. The orchestrator
+    // itself coordinates transport + channel + importer interactions that
+    // aren't usefully testable in isolation without rebuilding the entire
+    // mock stack.
+}

--- a/casper/src/rust/engine/lfs_horizon_requester.rs
+++ b/casper/src/rust/engine/lfs_horizon_requester.rs
@@ -41,7 +41,6 @@ use tokio::sync::mpsc;
 
 use crate::rust::engine::lfs_tuple_space_requester::StatePartPath;
 use crate::rust::errors::CasperError;
-use crate::rust::util::rholang::runtime_manager::RuntimeManager;
 
 /// Per-chunk page size for state-item requests. Matches the value used
 /// by `lfs_tuple_space_requester` for LFB-state subtree pagination.
@@ -164,9 +163,15 @@ struct RootProgress {
     total_data: usize,
 }
 
+/// Closure type for "is this root already in the joiner's roots store?".
+/// Decoupled from `RuntimeManager` so the orchestrator can be unit-tested
+/// against a fake roots store without spinning up the runtime stack.
+pub type HasRootFn =
+    Arc<dyn Fn(&Blake2b256Hash) -> Result<bool, CasperError> + Send + Sync>;
+
 struct HorizonStreamProcessor<T: HorizonRequesterOps> {
     request_ops: T,
-    runtime_manager: Arc<RuntimeManager>,
+    has_root: HasRootFn,
     state_importer: Arc<dyn RSpaceImporter>,
     st: Arc<Mutex<ST<StatePartPath>>>,
     /// Maps each chunk path to the root it's paginating. Initial paths
@@ -267,7 +272,7 @@ impl<T: HorizonRequesterOps> HorizonStreamProcessor<T> {
             // Record the root tag in roots_store and verify the import
             // reconstructed the expected root.
             self.state_importer.set_root(&root);
-            let now_have = self.runtime_manager.has_root(&root)?;
+            let now_have = (self.has_root)(&root)?;
             if !now_have {
                 return Err(CasperError::RuntimeError(format!(
                     "LFS forward-horizon: root {} not in store after import; \
@@ -381,7 +386,7 @@ impl<T: HorizonRequesterOps> HorizonStreamProcessor<T> {
 /// unsynced (incomplete sync = caller must NOT transition to Running).
 pub async fn stream<T: HorizonRequesterOps>(
     horizon_roots: Vec<Blake2b256Hash>,
-    runtime_manager: Arc<RuntimeManager>,
+    has_root: HasRootFn,
     state_importer: Arc<dyn RSpaceImporter>,
     request_ops: T,
     mut store_items_message_receiver: mpsc::Receiver<StoreItemsMessage>,
@@ -394,7 +399,7 @@ pub async fn stream<T: HorizonRequesterOps>(
     let mut filtered: Vec<Blake2b256Hash> = Vec::with_capacity(total_input);
     let mut skipped = 0usize;
     for root in horizon_roots {
-        if runtime_manager.has_root(&root)? {
+        if has_root(&root)? {
             skipped += 1;
         } else {
             filtered.push(root);
@@ -432,7 +437,7 @@ pub async fn stream<T: HorizonRequesterOps>(
 
     let processor = Arc::new(HorizonStreamProcessor {
         request_ops,
-        runtime_manager,
+        has_root,
         state_importer,
         st: st.clone(),
         path_to_root,
@@ -572,11 +577,463 @@ pub async fn stream<T: HorizonRequesterOps>(
 
 #[cfg(test)]
 mod tests {
-    // Integration coverage for sync_forward_horizon lives in B5 isolation runs
-    // (multi-node bonding test on subprocess provider). Unit tests for the
-    // pure reachability calc are in
-    // `casper/tests/util/rspace_history_horizon_test.rs`. The orchestrator
-    // itself coordinates transport + channel + importer interactions that
-    // aren't usefully testable in isolation without rebuilding the entire
-    // mock stack.
+    use super::*;
+
+    // ── ST<Key> state machine ────────────────────────────────────────────
+    //
+    // Mirrors the `Init → Requested → Received → Done` lifecycle that the
+    // streaming orchestrator drives every horizon root through. These tests
+    // pin the algebraic semantics so future changes to the orchestrator or
+    // the `lfs_tuple_space_requester` parallel structure can't silently
+    // diverge from the contract the stream loop assumes.
+
+    #[test]
+    fn st_new_initializes_all_entries_as_init() {
+        let st: ST<i32> = ST::new(vec![1, 2, 3]);
+        assert_eq!(st.len(), 3);
+        assert_eq!(st.done_count(), 0);
+        assert!(!st.is_finished());
+    }
+
+    #[test]
+    fn st_add_inserts_new_keys_as_init_and_leaves_existing() {
+        // Existing key in Requested state must NOT be reset to Init by add().
+        let st: ST<i32> = ST::new(vec![1]);
+        let (st, _) = st.get_next(false); // 1 -> Requested
+        let mut new_keys = HashSet::new();
+        new_keys.insert(2);
+        new_keys.insert(1); // existing
+        let st = st.add(new_keys);
+        // 2 should be Init now; 1 should still be Requested → only 2 picked.
+        let (_, requested) = st.get_next(false);
+        assert_eq!(requested, vec![2]);
+    }
+
+    #[test]
+    fn st_get_next_without_resend_picks_only_init() {
+        let st: ST<i32> = ST::new(vec![1, 2]);
+        let (st, batch) = st.get_next(false);
+        let mut sorted = batch.clone();
+        sorted.sort();
+        assert_eq!(sorted, vec![1, 2]);
+        // Calling again without resend yields nothing: both are Requested.
+        let (_, batch2) = st.get_next(false);
+        assert!(batch2.is_empty());
+    }
+
+    #[test]
+    fn st_get_next_with_resend_picks_init_and_requested() {
+        let st: ST<i32> = ST::new(vec![1]);
+        let (st, _) = st.get_next(false); // 1 -> Requested
+        let (_, batch) = st.get_next(true); // resend: pick Requested again
+        assert_eq!(batch, vec![1]);
+    }
+
+    #[test]
+    fn st_received_valid_only_on_requested_or_init() {
+        let st: ST<i32> = ST::new(vec![1, 2]);
+        // Init: received() accepts (handles fast in-memory test scenarios
+        // where responses arrive before the request loop runs).
+        let (st, valid) = st.received(1);
+        assert!(valid);
+        // Requested: received() accepts.
+        let (st, _) = st.get_next(false); // 2 -> Requested
+        let (st, valid) = st.received(2);
+        assert!(valid);
+        // Already-Received: received() rejects (idempotent).
+        let (_, valid) = st.received(1);
+        assert!(!valid);
+    }
+
+    #[test]
+    fn st_done_only_valid_on_received() {
+        let st: ST<i32> = ST::new(vec![1]);
+        // Init -> done() is a no-op (key NOT advanced).
+        let st = st.done(1);
+        assert!(!st.is_finished());
+        // After received() -> done() advances.
+        let (st, _) = st.received(1);
+        let st = st.done(1);
+        assert!(st.is_finished());
+    }
+
+    #[test]
+    fn st_is_finished_only_when_all_done() {
+        let st: ST<i32> = ST::new(vec![1, 2]);
+        let (st, _) = st.received(1);
+        let st = st.done(1);
+        assert!(!st.is_finished()); // 2 still Init
+        let (st, _) = st.received(2);
+        let st = st.done(2);
+        assert!(st.is_finished());
+    }
+
+    #[test]
+    fn st_done_count_matches_done_entries() {
+        let st: ST<i32> = ST::new(vec![1, 2, 3]);
+        let (st, _) = st.received(1);
+        let st = st.done(1);
+        let (st, _) = st.received(2);
+        let st = st.done(2);
+        assert_eq!(st.done_count(), 2);
+        assert_eq!(st.len() - st.done_count(), 1);
+    }
+
+    // ── stream() behavioral tests with mock HorizonRequesterOps ─────────
+    //
+    // These tests construct the orchestrator with a mock network layer so
+    // we can assert on:
+    //   - skip-already-present pre-filter (mock has_root returns true)
+    //   - terminal cursor handling (single-chunk happy path)
+    //   - byzantine peer detection (terminal+empty on first chunk)
+    //   - pagination (non-terminal cursor enqueues continuation)
+    //   - parallel fan-out (mock counts max simultaneous in-flight requests)
+    //
+    // The mock RSpaceImporter is a no-op since the orchestrator only uses
+    // it as a passive sink for items we feed via canned responses.
+
+    use futures::StreamExt;
+    use rspace_plus_plus::rspace::shared::trie_importer::TrieImporter;
+    use rspace_plus_plus::rspace::state::rspace_importer::RSpaceImporter;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    use tokio::sync::mpsc as test_mpsc;
+
+    /// No-op RSpaceImporter — orchestrator just calls set_history_items /
+    /// set_data_items / set_root with the bytes we feed it; tests don't
+    /// inspect what was imported, only what the stream did with the calls.
+    struct NoopImporter;
+
+    impl TrieImporter for NoopImporter {
+        fn set_history_items(&self, _data: Vec<(Blake2b256Hash, Vec<u8>)>) -> () {}
+        fn set_data_items(&self, _data: Vec<(Blake2b256Hash, Vec<u8>)>) -> () {}
+        fn set_root(&self, _key: &Blake2b256Hash) -> () {}
+    }
+
+    impl RSpaceImporter for NoopImporter {
+        fn get_history_item(&self, _hash: Blake2b256Hash) -> Option<Vec<u8>> {
+            None
+        }
+    }
+
+    /// Mock HorizonRequesterOps: records every send and tracks max
+    /// simultaneous in-flight requests. Each send increments the in-flight
+    /// counter and returns immediately; the test loop is responsible for
+    /// feeding canned responses and decrementing. For the parallel-fan-out
+    /// test we observe `max_in_flight` AFTER request_next has dispatched
+    /// the batch but BEFORE responses arrive.
+    struct MockOps {
+        sends: Arc<Mutex<Vec<StatePartPath>>>,
+        in_flight: Arc<AtomicUsize>,
+        max_in_flight: Arc<AtomicUsize>,
+    }
+
+    impl MockOps {
+        fn new() -> Self {
+            Self {
+                sends: Arc::new(Mutex::new(Vec::new())),
+                in_flight: Arc::new(AtomicUsize::new(0)),
+                max_in_flight: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        fn handles(&self) -> (Arc<Mutex<Vec<StatePartPath>>>, Arc<AtomicUsize>) {
+            (self.sends.clone(), self.max_in_flight.clone())
+        }
+    }
+
+    #[async_trait]
+    impl HorizonRequesterOps for MockOps {
+        async fn request_for_horizon_chunk(
+            &self,
+            path: &StatePartPath,
+            _page_size: i32,
+        ) -> Result<(), CasperError> {
+            self.sends.lock().unwrap().push(path.clone());
+            let now = self.in_flight.fetch_add(1, AtomicOrdering::SeqCst) + 1;
+            self.max_in_flight.fetch_max(now, AtomicOrdering::SeqCst);
+            // Simulate the request being "outstanding" — the test loop
+            // decrements via a shared counter when it feeds a response.
+            // We don't decrement here because the response handler
+            // is what unblocks the next request cycle.
+            Ok(())
+        }
+    }
+
+    fn hash_for(seed: u8) -> Blake2b256Hash {
+        let mut bytes = vec![0u8; 32];
+        bytes[0] = seed;
+        Blake2b256Hash::from_bytes(bytes)
+    }
+
+    fn make_response(
+        start_path: StatePartPath,
+        last_path: StatePartPath,
+        history_item: Option<Blake2b256Hash>,
+    ) -> StoreItemsMessage {
+        let history_items = history_item
+            .map(|h| vec![(h, prost::bytes::Bytes::from_static(b"x"))])
+            .unwrap_or_default();
+        StoreItemsMessage {
+            start_path,
+            last_path,
+            history_items,
+            data_items: vec![],
+        }
+    }
+
+    /// Helper to drain an `impl Stream` to its final `ST`.
+    async fn drain<S>(stream: S) -> Option<ST<StatePartPath>>
+    where
+        S: Stream<Item = ST<StatePartPath>>,
+    {
+        let mut stream = Box::pin(stream);
+        let mut last = None;
+        while let Some(st) = stream.next().await {
+            last = Some(st);
+        }
+        last
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stream_skips_already_present_roots() {
+        // has_root returns true for all roots → filtered set is empty.
+        // Stream yields a finished ST and exits without any request.
+        let r1 = hash_for(1);
+        let r2 = hash_for(2);
+        let has_root: HasRootFn = Arc::new(|_| Ok(true));
+        let importer: Arc<dyn RSpaceImporter> = Arc::new(NoopImporter);
+        let ops = MockOps::new();
+        let (sends, _) = ops.handles();
+        let (_tx, rx) = test_mpsc::channel::<StoreItemsMessage>(2);
+
+        let stream = stream(
+            vec![r1, r2],
+            has_root,
+            importer,
+            ops,
+            rx,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+        let final_st = drain(stream).await.expect("stream yields final state");
+        assert!(final_st.is_finished());
+        assert_eq!(final_st.len(), 0);
+        assert!(
+            sends.lock().unwrap().is_empty(),
+            "no requests should have been sent for already-present roots"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stream_completes_on_terminal_cursor_with_data() {
+        // Single root, single chunk. Response is terminal (last_path ==
+        // start_path) and contains one history item → root marked Done.
+        let root = hash_for(7);
+        let importer: Arc<dyn RSpaceImporter> = Arc::new(NoopImporter);
+        // has_root flips: false on the pre-filter call (so the root gets
+        // added to ST), then true on the post-import verification (so the
+        // import is accepted as having reconstructed the root).
+        let post_import_has_root: HasRootFn = {
+            let r = root.clone();
+            let imported = Arc::new(Mutex::new(false));
+            Arc::new(move |q| {
+                if *q == r && *imported.lock().unwrap() {
+                    Ok(true)
+                } else {
+                    let was = *imported.lock().unwrap();
+                    *imported.lock().unwrap() = true;
+                    Ok(was)
+                }
+            })
+        };
+        let ops = MockOps::new();
+        let (tx, rx) = test_mpsc::channel::<StoreItemsMessage>(4);
+
+        // Pre-feed the response.
+        let start = vec![(root.clone(), None)];
+        tx.send(make_response(start.clone(), start.clone(), Some(hash_for(8))))
+            .await
+            .unwrap();
+        // Drop tx so the receiver eventually sees channel-closed if loop
+        // doesn't terminate via is_finished.
+        drop(tx);
+
+        let stream = stream(
+            vec![root],
+            post_import_has_root,
+            importer,
+            ops,
+            rx,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+        let final_st = drain(stream).await.expect("stream yields final state");
+        assert!(
+            final_st.is_finished(),
+            "single-root happy path must mark all paths Done; final state: {:?}",
+            final_st
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stream_detects_byzantine_peer_terminal_empty_first_chunk() {
+        // Single root. Response is terminal AND empty (no history items,
+        // no data items) on the FIRST chunk. This is the contract for
+        // "peer doesn't have this root" — orchestrator must error out.
+        let root = hash_for(5);
+        let has_root: HasRootFn = Arc::new(|_| Ok(false));
+        let importer: Arc<dyn RSpaceImporter> = Arc::new(NoopImporter);
+        let ops = MockOps::new();
+        let (tx, rx) = test_mpsc::channel::<StoreItemsMessage>(4);
+
+        let start = vec![(root.clone(), None)];
+        tx.send(make_response(start.clone(), start.clone(), None))
+            .await
+            .unwrap();
+        drop(tx);
+
+        let stream = stream(
+            vec![root],
+            has_root,
+            importer,
+            ops,
+            rx,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+        let final_st = drain(stream).await.expect("stream yields final state");
+        // Byzantine signal causes the loop to break before marking Done →
+        // final ST is NOT finished. Caller's loud-fail check then triggers.
+        assert!(
+            !final_st.is_finished(),
+            "byzantine peer (terminal+empty) must NOT mark the root Done"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stream_paginates_non_terminal_responses() {
+        // Single root, two chunks. Response 1 is non-terminal: last_path
+        // points at a continuation. Response 2 is terminal at that
+        // continuation. Orchestrator must enqueue Response 2's start_path
+        // (= Response 1's last_path) as a new Init entry, then fan a
+        // request out for it, then mark Done on terminal arrival.
+        //
+        // Responses are fed by a separate task with a small yield between
+        // sends so the orchestrator's `request_next` cycle can fire for the
+        // continuation path before response 2 lands. Without this, the
+        // biased-response select drains both responses before any request
+        // ever ships and the test would assert against an empty sends log.
+        let root = hash_for(9);
+        let cont_path = vec![(hash_for(10), Some(0u8))];
+        let post_import_has_root: HasRootFn = {
+            let r = root.clone();
+            let imported = Arc::new(Mutex::new(false));
+            Arc::new(move |q| {
+                if *q == r && *imported.lock().unwrap() {
+                    Ok(true)
+                } else {
+                    let was = *imported.lock().unwrap();
+                    *imported.lock().unwrap() = true;
+                    Ok(was)
+                }
+            })
+        };
+        let importer: Arc<dyn RSpaceImporter> = Arc::new(NoopImporter);
+        let ops = MockOps::new();
+        let (sends, _) = ops.handles();
+        let (tx, rx) = test_mpsc::channel::<StoreItemsMessage>(8);
+
+        let start = vec![(root.clone(), None)];
+        let resp1 = make_response(start.clone(), cont_path.clone(), Some(hash_for(11)));
+        let resp2 = make_response(cont_path.clone(), cont_path.clone(), Some(hash_for(12)));
+
+        let feeder_sends = sends.clone();
+        let feeder_start = start.clone();
+        let feeder_cont = cont_path.clone();
+        let feeder = tokio::spawn(async move {
+            // Wait until the initial start_path has actually been requested.
+            loop {
+                if feeder_sends.lock().unwrap().contains(&feeder_start) {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+            tx.send(resp1).await.unwrap();
+            // Wait for the continuation path to be requested (proves the
+            // orchestrator enqueued it after processing response 1).
+            loop {
+                if feeder_sends.lock().unwrap().contains(&feeder_cont) {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+            tx.send(resp2).await.unwrap();
+            drop(tx);
+        });
+
+        let stream = stream(
+            vec![root],
+            post_import_has_root,
+            importer,
+            ops,
+            rx,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+        let final_st = drain(stream).await.expect("stream yields final state");
+        feeder.await.unwrap();
+        assert!(
+            final_st.is_finished(),
+            "after 2 chunks (paginated) the root should be Done"
+        );
+        let sent_paths = sends.lock().unwrap().clone();
+        assert!(sent_paths.contains(&start), "initial start_path was sent");
+        assert!(
+            sent_paths.contains(&cont_path),
+            "continuation path (= response 1's last_path) was enqueued and sent"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn stream_fans_out_in_parallel() {
+        // Four roots. Don't feed any responses. Observe `max_in_flight`
+        // after the request loop dispatches the initial batch. With
+        // try_join_all the orchestrator dispatches all 4 requests
+        // simultaneously before any response would be needed.
+        let roots: Vec<Blake2b256Hash> = (1..=4u8).map(hash_for).collect();
+        let has_root: HasRootFn = Arc::new(|_| Ok(false));
+        let importer: Arc<dyn RSpaceImporter> = Arc::new(NoopImporter);
+        let ops = MockOps::new();
+        let (_, max_in_flight) = ops.handles();
+        let (_tx, rx) = test_mpsc::channel::<StoreItemsMessage>(8);
+
+        // Launch the stream and let it pump the initial request cycle.
+        let stream = stream(
+            roots.clone(),
+            has_root,
+            importer,
+            ops,
+            rx,
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        // Pull one item (the post-request_next snapshot) which proves the
+        // initial fan-out completed. We don't drain to completion because
+        // there are no responses.
+        let mut stream = Box::pin(stream);
+        let _first = stream.next().await;
+
+        let observed = max_in_flight.load(AtomicOrdering::SeqCst);
+        assert_eq!(
+            observed, 4,
+            "orchestrator must dispatch all 4 root requests in parallel; \
+             max_in_flight={}",
+            observed
+        );
+    }
 }

--- a/casper/src/rust/engine/lfs_horizon_requester.rs
+++ b/casper/src/rust/engine/lfs_horizon_requester.rs
@@ -166,8 +166,7 @@ struct RootProgress {
 /// Closure type for "is this root already in the joiner's roots store?".
 /// Decoupled from `RuntimeManager` so the orchestrator can be unit-tested
 /// against a fake roots store without spinning up the runtime stack.
-pub type HasRootFn =
-    Arc<dyn Fn(&Blake2b256Hash) -> Result<bool, CasperError> + Send + Sync>;
+pub type HasRootFn = Arc<dyn Fn(&Blake2b256Hash) -> Result<bool, CasperError> + Send + Sync>;
 
 struct HorizonStreamProcessor<T: HorizonRequesterOps> {
     request_ops: T,
@@ -214,9 +213,7 @@ impl<T: HorizonRequesterOps> HorizonStreamProcessor<T> {
             is_valid
         };
         if !was_known {
-            tracing::debug!(
-                "LFS forward-horizon: ignoring chunk for unknown/stale path"
-            );
+            tracing::debug!("LFS forward-horizon: ignoring chunk for unknown/stale path");
             return Ok(());
         }
 
@@ -254,13 +251,10 @@ impl<T: HorizonRequesterOps> HorizonStreamProcessor<T> {
             // Byzantine signal: terminal cursor on first chunk + no data
             // means the peer doesn't have this root. Fail loud.
             let progress = {
-                let progress_map =
-                    self.root_progress.lock().expect("root_progress lock");
+                let progress_map = self.root_progress.lock().expect("root_progress lock");
                 progress_map.get(&root).cloned().unwrap_or_default()
             };
-            if progress.chunk_count == 1
-                && progress.total_history == 0
-                && progress.total_data == 0
+            if progress.chunk_count == 1 && progress.total_history == 0 && progress.total_data == 0
             {
                 return Err(CasperError::RuntimeError(format!(
                     "LFS forward-horizon: bootstrap signalled empty/missing root {} \
@@ -283,7 +277,10 @@ impl<T: HorizonRequesterOps> HorizonStreamProcessor<T> {
 
             tracing::debug!(
                 "LFS forward-horizon: completed root {} ({} chunks, {} history, {} data)",
-                root, progress.chunk_count, progress.total_history, progress.total_data
+                root,
+                progress.chunk_count,
+                progress.total_history,
+                progress.total_data
             );
 
             // Mark Done and free per-root state.
@@ -852,9 +849,13 @@ mod tests {
 
         // Pre-feed the response.
         let start = vec![(root.clone(), None)];
-        tx.send(make_response(start.clone(), start.clone(), Some(hash_for(8))))
-            .await
-            .unwrap();
+        tx.send(make_response(
+            start.clone(),
+            start.clone(),
+            Some(hash_for(8)),
+        ))
+        .await
+        .unwrap();
         // Drop tx so the receiver eventually sees channel-closed if loop
         // doesn't terminate via is_finished.
         drop(tx);

--- a/casper/src/rust/engine/lfs_tuple_space_requester.rs
+++ b/casper/src/rust/engine/lfs_tuple_space_requester.rs
@@ -729,9 +729,9 @@ pub async fn stream<T: TupleSpaceRequesterOps>(
                         final_stats.0, final_stats.1);
 
                     if final_stats.1 {
-                        tracing::info!("✅ LFS Tuple Space Requester completed successfully - all required state downloaded");
+                        tracing::info!("LFS Tuple Space Requester completed successfully - all required state downloaded");
                     } else {
-                        tracing::warn!("⚠️ LFS Tuple Space Requester terminated with incomplete state - some state may be missing");
+                        tracing::warn!("LFS Tuple Space Requester terminated with incomplete state - some state may be missing");
                     }
 
                     Some(state.clone())

--- a/casper/src/rust/engine/mod.rs
+++ b/casper/src/rust/engine/mod.rs
@@ -9,5 +9,6 @@ pub mod genesis_ceremony_master;
 pub mod genesis_validator;
 pub mod initializing;
 pub mod lfs_block_requester;
+pub mod lfs_horizon_requester;
 pub mod lfs_tuple_space_requester;
 pub mod running;

--- a/casper/src/rust/engine/running.rs
+++ b/casper/src/rust/engine/running.rs
@@ -554,7 +554,7 @@ impl<T: TransportLayer + Send + Sync> Running<T> {
         };
 
         let runtime = self.casper.runtime_manager();
-        let (_key_bytes, value_bytes_opt) = runtime.get_mergeable_entry_raw(&block)?;
+        let (_key_bytes, value_bytes_opt) = runtime.get_mergeable_entry_bytes(&block)?;
 
         let serialized_entry: prost::bytes::Bytes = value_bytes_opt
             .map(prost::bytes::Bytes::from)

--- a/casper/src/rust/engine/running.rs
+++ b/casper/src/rust/engine/running.rs
@@ -304,6 +304,17 @@ impl<T: TransportLayer + Send + Sync + 'static> Engine for Running<T> {
                     Ok(())
                 }
             }
+            CasperMessage::MergeableEntryRequest(req) => {
+                if self.disable_state_exporter {
+                    tracing::debug!(
+                        "Received MergeableEntryRequest but state-export is disabled; ignoring (from {}).",
+                        peer
+                    );
+                    return Ok(());
+                }
+                self.handle_mergeable_entry_request(peer, req.block_hash)
+                    .await
+            }
             _ => Ok(()),
         }
     }
@@ -516,6 +527,53 @@ impl<T: TransportLayer + Send + Sync> Running<T> {
             .stream_message_to_peer(&self.conf, &peer, Arc::new(approved_block.to_proto()))
             .await?;
         tracing::info!("ApprovedBlock sent to {}", peer);
+        Ok(())
+    }
+
+    /// Respond to a `MergeableEntryRequest`.
+    ///
+    /// - Block not in our store: silent (no response).
+    /// - Block present, no mergeable entry: respond with empty `serialized_entry`.
+    /// - Block present and entry present: respond with raw bincode bytes from
+    ///   the mergeable_store.
+    async fn handle_mergeable_entry_request(
+        &self,
+        peer: PeerNode,
+        block_hash: BlockHash,
+    ) -> Result<(), CasperError> {
+        let block = match self.casper.block_store().get(&block_hash)? {
+            Some(b) => b,
+            None => {
+                tracing::debug!(
+                    "MergeableEntryRequest for {} from {}: block not in store; silent ignore.",
+                    PrettyPrinter::build_string_bytes(&block_hash),
+                    peer
+                );
+                return Ok(());
+            }
+        };
+
+        let runtime = self.casper.runtime_manager();
+        let (_key_bytes, value_bytes_opt) = runtime.get_mergeable_entry_raw(&block)?;
+
+        let serialized_entry: prost::bytes::Bytes = value_bytes_opt
+            .map(prost::bytes::Bytes::from)
+            .unwrap_or_default();
+
+        let resp = casper_message::MergeableEntryResponse {
+            block_hash: block_hash.clone(),
+            serialized_entry,
+        };
+
+        self.transport
+            .stream_message_to_peer(&self.conf, &peer, Arc::new(resp.to_proto()))
+            .await?;
+
+        tracing::debug!(
+            "Mergeable entry sent to {} for block {}.",
+            peer,
+            PrettyPrinter::build_string_bytes(&block_hash)
+        );
         Ok(())
     }
 

--- a/casper/src/rust/multi_parent_casper_impl.rs
+++ b/casper/src/rust/multi_parent_casper_impl.rs
@@ -606,6 +606,8 @@ impl<T: TransportLayer + Send + Sync> Casper for MultiParentCasperImpl<T> {
                         &self.casper_shard_conf.shard_name,
                         self.casper_shard_conf.deploy_lifespan as i32,
                         self.casper_shard_conf.max_number_of_parents,
+                        self.casper_shard_conf.max_parent_depth,
+                        self.casper_shard_conf.mergeable_channels_gc_depth_buffer,
                         &self.block_store,
                         self.casper_shard_conf.disable_validator_progress_check,
                     )
@@ -857,6 +859,8 @@ impl<T: TransportLayer + Send + Sync> Casper for MultiParentCasperImpl<T> {
                         &self.casper_shard_conf.shard_name,
                         self.casper_shard_conf.deploy_lifespan as i32,
                         self.casper_shard_conf.max_number_of_parents,
+                        self.casper_shard_conf.max_parent_depth,
+                        self.casper_shard_conf.mergeable_channels_gc_depth_buffer,
                         &self.block_store,
                         self.casper_shard_conf.disable_validator_progress_check,
                     )

--- a/casper/src/rust/protocol/mod.rs
+++ b/casper/src/rust/protocol/mod.rs
@@ -6,8 +6,9 @@ use models::{
     casper::{
         ApprovedBlockProto, ApprovedBlockRequestProto, BlockApprovalProto, BlockHashMessageProto,
         BlockMessageProto, BlockRequestProto, ForkChoiceTipRequestProto, HasBlockProto,
-        HasBlockRequestProto, NoApprovedBlockAvailableProto, StoreItemsMessageProto,
-        StoreItemsMessageRequestProto, UnapprovedBlockProto,
+        HasBlockRequestProto, MergeableEntryRequestProto, MergeableEntryResponseProto,
+        NoApprovedBlockAvailableProto, StoreItemsMessageProto, StoreItemsMessageRequestProto,
+        UnapprovedBlockProto,
     },
     routing::{Packet, Protocol},
     rust::{block_hash::BlockHash, casper::protocol::casper_message::CasperMessage},
@@ -75,6 +76,8 @@ pub enum CasperMessageProto {
     NoApprovedBlockAvailable(NoApprovedBlockAvailableProto),
     StoreItemsMessageRequest(StoreItemsMessageRequestProto),
     StoreItemsMessage(StoreItemsMessageProto),
+    MergeableEntryRequest(MergeableEntryRequestProto),
+    MergeableEntryResponse(MergeableEntryResponseProto),
 }
 
 /// Extract a Packet from a Protocol message
@@ -98,6 +101,8 @@ pub fn to_casper_message_proto(packet: &Packet) -> PacketParseResult<CasperMessa
         "NoApprovedBlockAvailable" => convert_no_approved_block_available(packet),
         "StoreItemsMessageRequest" => convert_store_items_message_request(packet),
         "StoreItemsMessage" => convert_store_items_message(packet),
+        "MergeableEntryRequest" => convert_mergeable_entry_request(packet),
+        "MergeableEntryResponse" => convert_mergeable_entry_response(packet),
         _ => PacketParseResult::IllegalPacket(format!("Unrecognized typeId: {}", packet.type_id)),
     }
 }
@@ -131,6 +136,12 @@ pub fn casper_message_from_proto(proto: CasperMessageProto) -> Result<CasperMess
         }
         CasperMessageProto::StoreItemsMessage(proto) => {
             Ok(CasperMessage::from_store_items_message(proto))
+        }
+        CasperMessageProto::MergeableEntryRequest(proto) => {
+            Ok(CasperMessage::from_mergeable_entry_request(proto))
+        }
+        CasperMessageProto::MergeableEntryResponse(proto) => {
+            Ok(CasperMessage::from_mergeable_entry_response(proto))
         }
     }
 }
@@ -188,6 +199,16 @@ fn convert_store_items_message_request(packet: &Packet) -> PacketParseResult<Cas
 
 fn convert_store_items_message(packet: &Packet) -> PacketParseResult<CasperMessageProto> {
     parse_packet::<StoreItemsMessageProto>(packet).map(CasperMessageProto::StoreItemsMessage)
+}
+
+fn convert_mergeable_entry_request(packet: &Packet) -> PacketParseResult<CasperMessageProto> {
+    parse_packet::<MergeableEntryRequestProto>(packet)
+        .map(CasperMessageProto::MergeableEntryRequest)
+}
+
+fn convert_mergeable_entry_response(packet: &Packet) -> PacketParseResult<CasperMessageProto> {
+    parse_packet::<MergeableEntryResponseProto>(packet)
+        .map(CasperMessageProto::MergeableEntryResponse)
 }
 
 /// Generic function to parse a packet into a specific protobuf message type

--- a/casper/src/rust/util/mod.rs
+++ b/casper/src/rust/util/mod.rs
@@ -7,6 +7,7 @@ pub mod event_converter;
 pub mod mergeable_channels_gc;
 pub mod proto_util;
 pub mod rholang;
+pub mod rspace_history_horizon;
 pub mod rspace_util;
 pub mod token_metadata_check;
 pub mod vault_parser;

--- a/casper/src/rust/util/rholang/runtime_manager.rs
+++ b/casper/src/rust/util/rholang/runtime_manager.rs
@@ -957,21 +957,31 @@ impl RuntimeManager {
             .map_err(|e| CasperError::KvStoreError(KvStoreError::SerializationError(e.to_string())))
     }
 
-    /// Look up the raw bincode bytes of a block's mergeable-channels entry.
-    /// Returns `(key_bytes, Some(value_bytes))` if present, `(key_bytes, None)`
-    /// if the key is absent.
-    pub fn get_mergeable_entry_raw(
+    /// Look up a block's mergeable-channels entry and return its over-the-wire
+    /// byte form. Returns `(key_bytes, Some(value_bytes))` if present,
+    /// `(key_bytes, None)` if absent. Re-serializes via bincode at the typed
+    /// store boundary so the wire format is independent of LMDB's internal
+    /// encoding.
+    pub fn get_mergeable_entry_bytes(
         &self,
         block: &models::rust::casper::protocol::casper_message::BlockMessage,
     ) -> Result<(Vec<u8>, Option<Vec<u8>>), CasperError> {
         let key_bytes = Self::mergeable_key_bytes_for_block(block)?;
-        let value_bytes = self.mergeable_store.raw_get(&key_bytes)?;
+        let value: Option<Vec<DeployMergeableData>> =
+            self.mergeable_store.get_one(&key_bytes)?;
+        let value_bytes = value
+            .map(|v| bincode::serialize(&v))
+            .transpose()
+            .map_err(|e| {
+                CasperError::KvStoreError(KvStoreError::SerializationError(e.to_string()))
+            })?;
         Ok((key_bytes, value_bytes))
     }
 
-    /// Write a mergeable-channels entry from raw bincode bytes (without
-    /// re-serializing). Skips empty `value_bytes`.
-    pub fn put_mergeable_entry_raw(
+    /// Store a mergeable-channels entry received over the wire. Decodes the
+    /// transported bytes and writes via the typed store. Empty `value_bytes`
+    /// signals "peer had no entry" and is a no-op.
+    pub fn put_mergeable_entry_bytes(
         &self,
         key_bytes: Vec<u8>,
         value_bytes: Vec<u8>,
@@ -979,8 +989,12 @@ impl RuntimeManager {
         if value_bytes.is_empty() {
             return Ok(());
         }
+        let value: Vec<DeployMergeableData> =
+            bincode::deserialize(&value_bytes).map_err(|e| {
+                CasperError::KvStoreError(KvStoreError::SerializationError(e.to_string()))
+            })?;
         self.mergeable_store
-            .raw_put(key_bytes, value_bytes)
+            .put_one(key_bytes, value)
             .map_err(CasperError::KvStoreError)
     }
 

--- a/casper/src/rust/util/rholang/runtime_manager.rs
+++ b/casper/src/rust/util/rholang/runtime_manager.rs
@@ -31,10 +31,10 @@ use rspace_plus_plus::rspace::merger::merging_logic::{NumberChannelsDiff, Number
 use rspace_plus_plus::rspace::replay_rspace::ReplayRSpace;
 use rspace_plus_plus::rspace::rspace::{RSpace, RSpaceStore};
 use rspace_plus_plus::rspace::shared::key_value_store_manager::KeyValueStoreManager;
-use shared::rust::ByteVector;
 use shared::rust::store::key_value_store::KvStoreError;
 use shared::rust::store::key_value_typed_store::KeyValueTypedStore;
 use shared::rust::store::key_value_typed_store_impl::KeyValueTypedStoreImpl;
+use shared::rust::ByteVector;
 
 use crate::rust::errors::CasperError;
 use crate::rust::merging::block_index::BlockIndex;
@@ -967,8 +967,7 @@ impl RuntimeManager {
         block: &models::rust::casper::protocol::casper_message::BlockMessage,
     ) -> Result<(Vec<u8>, Option<Vec<u8>>), CasperError> {
         let key_bytes = Self::mergeable_key_bytes_for_block(block)?;
-        let value: Option<Vec<DeployMergeableData>> =
-            self.mergeable_store.get_one(&key_bytes)?;
+        let value: Option<Vec<DeployMergeableData>> = self.mergeable_store.get_one(&key_bytes)?;
         let value_bytes = value
             .map(|v| bincode::serialize(&v))
             .transpose()
@@ -989,10 +988,9 @@ impl RuntimeManager {
         if value_bytes.is_empty() {
             return Ok(());
         }
-        let value: Vec<DeployMergeableData> =
-            bincode::deserialize(&value_bytes).map_err(|e| {
-                CasperError::KvStoreError(KvStoreError::SerializationError(e.to_string()))
-            })?;
+        let value: Vec<DeployMergeableData> = bincode::deserialize(&value_bytes).map_err(|e| {
+            CasperError::KvStoreError(KvStoreError::SerializationError(e.to_string()))
+        })?;
         self.mergeable_store
             .put_one(key_bytes, value)
             .map_err(CasperError::KvStoreError)

--- a/casper/src/rust/util/rholang/runtime_manager.rs
+++ b/casper/src/rust/util/rholang/runtime_manager.rs
@@ -804,6 +804,15 @@ impl RuntimeManager {
         self.history_repo.clone()
     }
 
+    /// Check whether a post-state root is recorded in the local rspace
+    /// roots store. Used by joiner-side LFS forward-horizon sync to skip
+    /// roots that have already been imported. Pure lookup — no side effects.
+    pub fn has_root(&self, root: &Blake2b256Hash) -> Result<bool, CasperError> {
+        self.history_repo
+            .contains_root(root)
+            .map_err(|e| CasperError::RuntimeError(format!("has_root lookup failed: {:?}", e)))
+    }
+
     /// Get or compute BlockIndex with caching
     pub fn get_or_compute_block_index(
         &self,

--- a/casper/src/rust/util/rholang/runtime_manager.rs
+++ b/casper/src/rust/util/rholang/runtime_manager.rs
@@ -31,10 +31,10 @@ use rspace_plus_plus::rspace::merger::merging_logic::{NumberChannelsDiff, Number
 use rspace_plus_plus::rspace::replay_rspace::ReplayRSpace;
 use rspace_plus_plus::rspace::rspace::{RSpace, RSpaceStore};
 use rspace_plus_plus::rspace::shared::key_value_store_manager::KeyValueStoreManager;
+use shared::rust::ByteVector;
 use shared::rust::store::key_value_store::KvStoreError;
 use shared::rust::store::key_value_typed_store::KeyValueTypedStore;
 use shared::rust::store::key_value_typed_store_impl::KeyValueTypedStoreImpl;
-use shared::rust::ByteVector;
 
 use crate::rust::errors::CasperError;
 use crate::rust::merging::block_index::BlockIndex;
@@ -627,9 +627,9 @@ impl RuntimeManager {
                             &pre_state_hash,
                         )?;
                         tracing::warn!(
-                        "[CACHE] StateHashCache hit without mergeable entry for empty block (seq={}); synthesized empty mergeable metadata",
-                        seq_num
-                    );
+                            "[CACHE] StateHashCache hit without mergeable entry for empty block (seq={}); synthesized empty mergeable metadata",
+                            seq_num
+                        );
                         return Ok(cached_post);
                     }
                 }
@@ -942,6 +942,46 @@ impl RuntimeManager {
                 Err(CasperError::KvStoreError(KvStoreError::KeyNotFound(msg)))
             }
         }
+    }
+
+    /// Build the mergeable-store key bytes for a block.
+    pub fn mergeable_key_bytes_for_block(
+        block: &models::rust::casper::protocol::casper_message::BlockMessage,
+    ) -> Result<Vec<u8>, CasperError> {
+        let key = MergeableKey {
+            state_hash: StateHashSerde(block.body.state.post_state_hash.clone()),
+            creator: block.sender.clone(),
+            seq_num: block.seq_num,
+        };
+        bincode::serialize(&key)
+            .map_err(|e| CasperError::KvStoreError(KvStoreError::SerializationError(e.to_string())))
+    }
+
+    /// Look up the raw bincode bytes of a block's mergeable-channels entry.
+    /// Returns `(key_bytes, Some(value_bytes))` if present, `(key_bytes, None)`
+    /// if the key is absent.
+    pub fn get_mergeable_entry_raw(
+        &self,
+        block: &models::rust::casper::protocol::casper_message::BlockMessage,
+    ) -> Result<(Vec<u8>, Option<Vec<u8>>), CasperError> {
+        let key_bytes = Self::mergeable_key_bytes_for_block(block)?;
+        let value_bytes = self.mergeable_store.raw_get(&key_bytes)?;
+        Ok((key_bytes, value_bytes))
+    }
+
+    /// Write a mergeable-channels entry from raw bincode bytes (without
+    /// re-serializing). Skips empty `value_bytes`.
+    pub fn put_mergeable_entry_raw(
+        &self,
+        key_bytes: Vec<u8>,
+        value_bytes: Vec<u8>,
+    ) -> Result<(), CasperError> {
+        if value_bytes.is_empty() {
+            return Ok(());
+        }
+        self.mergeable_store
+            .raw_put(key_bytes, value_bytes)
+            .map_err(CasperError::KvStoreError)
     }
 
     /// Delete mergeable channels entry keyed by (post-state-hash, creator, seq-num).

--- a/casper/src/rust/util/rspace_history_horizon.rs
+++ b/casper/src/rust/util/rspace_history_horizon.rs
@@ -1,0 +1,126 @@
+//! Forward-horizon rspace history reachability calculation.
+//!
+//! Used by joiner-side LFS sync to determine which rspace post-state roots
+//! must be in the joiner's local roots store before transitioning to Running.
+//! The calculation is the inverse of `mergeable_channels_gc::is_safe_to_delete`:
+//! whereas the GC computes "what's safe to forget," this computes "what's
+//! still reachable as a parent of an upcoming proposal."
+//!
+//! A joiner that has just LFS-synced to LFB at height N needs rspace state
+//! for every block that an honest proposer could legitimately reference as
+//! a parent: the proposer-side `Estimator::filterDeepParents` filter permits
+//! any block within `max_parent_depth + depth_buffer` from the highest tip.
+//! For a joiner whose highest tip is the LFB (just after sync), that means
+//! every block in the DAG with `height ≥ LFB.height − (max_parent_depth +
+//! depth_buffer)` — main chain AND side branches.
+//!
+//! The validator-side parent-depth check in `validate::parents` rejects any
+//! block whose parents fall outside this same horizon, so the set of
+//! potentially-validatable blocks is exactly bounded by it. There is no
+//! out-of-horizon case to handle: horizon-internal blocks have their roots
+//! synced by `sync_forward_horizon`, and out-of-horizon blocks are rejected
+//! on consensus rules before validation queries the rspace history.
+//!
+//! For each in-horizon block we emit BOTH `pre_state_hash` and
+//! `post_state_hash`. Single-parent blocks have `pre_state_hash =
+//! parent.post_state_hash`, so this is mostly a redundant restatement of
+//! a hash that's already collected from the parent. For multi-parent
+//! blocks, however, `pre_state_hash` is the merge result computed by the
+//! proposer's `dag_merger::merge` via `apply_trie_actions_fn` →
+//! `do_checkpoint`'s `store_root`. That merge intermediate is recorded in
+//! the proposer's roots_store but is NOT any block's post-state, so a
+//! joiner that only collects post-states is left without it. When the
+//! joiner later attempts to replay a child of one of those merged blocks
+//! (or processes a parallel sibling), the spawn/reset path validates the
+//! merge-result root against the joiner's roots_store and fires
+//! `RootRepositoryDivergence` if absent. Including pre-states closes
+//! that gap — peers serve the radix history for these merge results
+//! because their `do_checkpoint` already wrote the trie nodes plus the
+//! root tag for them.
+
+use block_storage::rust::dag::block_dag_key_value_storage::KeyValueDagRepresentation;
+use block_storage::rust::key_value_block_store::KeyValueBlockStore;
+use models::rust::casper::protocol::casper_message::BlockMessage;
+use rspace_plus_plus::rspace::hashing::blake2b256_hash::Blake2b256Hash;
+use shared::rust::store::key_value_store::KvStoreError;
+use std::collections::HashSet;
+
+use crate::rust::casper::CasperShardConf;
+
+/// Compute the set of rspace roots a joiner needs in its local roots store
+/// before transitioning to Running. Walks every block in the DAG with
+/// `height ≥ LFB.height − (max_parent_depth + depth_buffer)` and emits
+/// both its `pre_state_hash` and `post_state_hash`, deduped, ordered by
+/// descending block_number (LFB-side first — most likely to be referenced
+/// as a parent by an early incoming block). Within a single block the
+/// post-state is emitted before the pre-state so the joiner imports the
+/// "outer" state before its merge intermediate.
+///
+/// Including pre-states is what fixes multi-parent merge intermediates:
+/// these hashes only ever exist as the result of the proposer's
+/// `dag_merger::merge` (recorded via `do_checkpoint`'s `store_root`), and
+/// would otherwise never reach the joiner because they are not any block's
+/// `post_state_hash`. See module-level docs for the full rationale.
+///
+/// Returns an empty vec if the LFB is at depth 0 (genesis) or if the
+/// horizon would extend below genesis (clamped to height 0).
+pub fn compute_forward_horizon_roots(
+    dag: &KeyValueDagRepresentation,
+    block_store: &KeyValueBlockStore,
+    lfb: &BlockMessage,
+    casper_shard_conf: &CasperShardConf,
+) -> Result<Vec<Blake2b256Hash>, KvStoreError> {
+    if casper_shard_conf.max_parent_depth == i32::MAX {
+        // Depth check disabled — joiner can validate against any historical
+        // block. Fall back to no horizon sync; caller can opt into full
+        // replay (`disable-lfs = true`) instead.
+        return Ok(Vec::new());
+    }
+
+    let lfb_height = lfb.body.state.block_number;
+    let horizon_depth = (casper_shard_conf.max_parent_depth as i64)
+        + (casper_shard_conf.mergeable_channels_gc_depth_buffer as i64);
+    let min_height = std::cmp::max(0, lfb_height - horizon_depth);
+
+    if min_height > lfb_height {
+        return Ok(Vec::new());
+    }
+
+    // topo_sort returns Vec<Vec<BlockHash>> — one inner vec per height,
+    // covering all blocks at that height (main chain + side branches).
+    // Ordering: ascending by height. Reverse to get LFB-side first.
+    let layers = dag.topo_sort(min_height, Some(lfb_height))?;
+
+    let mut roots: Vec<Blake2b256Hash> = Vec::new();
+    let mut seen: HashSet<Blake2b256Hash> = HashSet::new();
+    for layer in layers.iter().rev() {
+        for block_hash in layer {
+            let block = match block_store.get(block_hash)? {
+                Some(b) => b,
+                None => {
+                    tracing::warn!(
+                        "compute_forward_horizon_roots: block {} in DAG but missing from block_store",
+                        models::rust::casper::pretty_printer::PrettyPrinter::build_string_bytes(
+                            block_hash
+                        )
+                    );
+                    continue;
+                }
+            };
+            let post = Blake2b256Hash::from_bytes_prost(&block.body.state.post_state_hash);
+            if seen.insert(post.clone()) {
+                roots.push(post);
+            }
+            let pre = Blake2b256Hash::from_bytes_prost(&block.body.state.pre_state_hash);
+            if seen.insert(pre.clone()) {
+                roots.push(pre);
+            }
+        }
+    }
+    Ok(roots)
+}
+
+// Unit tests for `compute_forward_horizon_roots` are in
+// `casper/tests/util/rspace_history_horizon_test.rs` (alongside the rest of
+// the casper-test mod tree) where the test fixtures `with_storage` and
+// `create_chain` are available.

--- a/casper/src/rust/util/rspace_history_horizon.rs
+++ b/casper/src/rust/util/rspace_history_horizon.rs
@@ -120,7 +120,99 @@ pub fn compute_forward_horizon_roots(
     Ok(roots)
 }
 
-// Unit tests for `compute_forward_horizon_roots` are in
-// `casper/tests/util/rspace_history_horizon_test.rs` (alongside the rest of
-// the casper-test mod tree) where the test fixtures `with_storage` and
-// `create_chain` are available.
+/// Compute the LFS lower-bound block number for joiner-side block download.
+///
+/// `lfs_block_requester::stream` clamps how far back from LFB it will accept
+/// blocks during sync. The bound has two contributing constraints:
+///
+///   1. `deploy_lifespan` — blocks within this window of LFB carry deploys
+///      that may still be reproposable (the original Scala-era reason).
+///   2. `max_parent_depth + mergeable_channels_gc_depth_buffer` — the
+///      forward-horizon: any block within this window of LFB may still be
+///      legitimately referenced as a parent by an upcoming proposal, so the
+///      joiner needs its DAG metadata even if it's older than
+///      `deploy_lifespan` from LFB.
+///
+/// Take the lower of the two bounds (= older floor) so LFS coverage spans
+/// both windows. The `i32::MAX` sentinel for `max_parent_depth` disables
+/// the parent-depth check — in that mode the forward-horizon is unbounded
+/// and `deploy_lifespan` alone determines the floor.
+///
+/// Negative results clamp to 0 (genesis) so the bound is always a valid
+/// block number.
+pub fn lfs_min_block_number(
+    start_block_number: i64,
+    deploy_lifespan: i64,
+    max_parent_depth: i32,
+    depth_buffer: i32,
+) -> i64 {
+    let lifespan_bound = std::cmp::max(0, start_block_number - deploy_lifespan);
+    let horizon_bound = if max_parent_depth as i64 >= i32::MAX as i64 {
+        // Sentinel: depth check disabled. Forward-horizon is unbounded,
+        // so the lifespan bound alone determines the floor.
+        lifespan_bound
+    } else {
+        std::cmp::max(
+            0,
+            start_block_number - (max_parent_depth as i64) - (depth_buffer as i64),
+        )
+    };
+    std::cmp::min(lifespan_bound, horizon_bound)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn min_block_number_takes_lifespan_when_horizon_wider() {
+        // start=200, lifespan=50 -> lifespan_bound=150
+        // max_parent_depth=10, buffer=0 -> horizon_bound=190
+        // min(150, 190) = 150 (lifespan tighter)
+        assert_eq!(lfs_min_block_number(200, 50, 10, 0), 150);
+    }
+
+    #[test]
+    fn min_block_number_takes_horizon_when_lifespan_wider() {
+        // start=200, lifespan=50 -> lifespan_bound=150
+        // max_parent_depth=100, buffer=10 -> horizon_bound=90
+        // min(150, 90) = 90 (horizon tighter — this is the §2.14 case:
+        // forward-horizon goes deeper than deploy_lifespan)
+        assert_eq!(lfs_min_block_number(200, 50, 100, 10), 90);
+    }
+
+    #[test]
+    fn min_block_number_clamps_to_zero_at_genesis() {
+        // start=10, lifespan=50 -> max(0, 10-50) = 0
+        assert_eq!(lfs_min_block_number(10, 50, 100, 10), 0);
+    }
+
+    #[test]
+    fn min_block_number_clamps_horizon_to_zero() {
+        // start=10, lifespan=5 -> lifespan_bound=5
+        // max_parent_depth=100, buffer=10 -> horizon raw=10-110=-100 -> clamped 0
+        // min(5, 0) = 0
+        assert_eq!(lfs_min_block_number(10, 5, 100, 10), 0);
+    }
+
+    #[test]
+    fn min_block_number_disabled_depth_falls_back_to_lifespan() {
+        // max_parent_depth=i32::MAX (sentinel) → horizon_bound=lifespan_bound
+        // The function returns lifespan_bound directly (no horizon clamping).
+        assert_eq!(lfs_min_block_number(200, 50, i32::MAX, 10), 150);
+        assert_eq!(lfs_min_block_number(200, 50, i32::MAX, 0), 150);
+    }
+
+    #[test]
+    fn min_block_number_zero_buffer() {
+        // No buffer → pure max_parent_depth.
+        // start=300, lifespan=50, max_parent_depth=200 -> horizon=100
+        // min(250, 100) = 100
+        assert_eq!(lfs_min_block_number(300, 50, 200, 0), 100);
+    }
+}
+
+// Integration coverage for the full `compute_forward_horizon_roots`
+// reachability calc lives in `casper/tests/util/rspace_history_horizon_test.rs`
+// (alongside the rest of the casper-test mod tree) where the test fixtures
+// `with_storage` and `create_chain` are available.

--- a/casper/src/rust/validate.rs
+++ b/casper/src/rust/validate.rs
@@ -246,6 +246,8 @@ impl Validate {
         shard_id: &str,
         expiration_threshold: i32,
         max_number_of_parents: i32,
+        max_parent_depth: i32,
+        depth_buffer: i32,
         block_store: &KeyValueBlockStore,
         disable_validator_progress_check: bool,
     ) -> ValidBlockProcessing {
@@ -348,6 +350,8 @@ impl Validate {
                 genesis,
                 s,
                 max_number_of_parents,
+                max_parent_depth,
+                depth_buffer,
                 disable_validator_progress_check,
             )
         ) {
@@ -812,6 +816,8 @@ impl Validate {
         genesis: &BlockMessage,
         s: &mut CasperSnapshot,
         max_number_of_parents: i32,
+        max_parent_depth: i32,
+        depth_buffer: i32,
         disable_validator_progress_check: bool,
     ) -> ValidBlockProcessing {
         // Check if block contains user deploys (non-system deploys)
@@ -852,6 +858,50 @@ impl Validate {
             );
             tracing::warn!("{}", Self::ignore(b, &message));
             return Either::Left(BlockError::Invalid(InvalidBlock::InvalidParents));
+        }
+
+        // Parent-depth enforcement: symmetric to proposer-side `Estimator::filterDeepParents`.
+        // Reject any block whose parents fall outside the consensus-permitted horizon
+        // (depth from highest tip > max_parent_depth + depth_buffer). An honest proposer
+        // already drops these parents before signing; this check rejects blocks from
+        // buggy or malicious proposers that would otherwise hit `UnknownRootError` on
+        // joiners that don't carry pre-horizon rspace history.
+        //
+        // Sentinel: `max_parent_depth == i32::MAX` disables the check (matches the
+        // proposer-side convention in `multi_parent_casper_impl.rs::create_block`).
+        //
+        // Genesis is exempt: validators justify back to genesis as the ultimate ancestor,
+        // and on a long-running chain genesis would always exceed the depth horizon.
+        // We compare by hash to the passed `genesis` BlockMessage rather than to
+        // `block_number == 0` so this works correctly regardless of how the chain's
+        // genesis ended up indexed (test fixtures may assign genesis a non-zero
+        // block_number; production assigns 0).
+        if max_parent_depth != i32::MAX {
+            let max_allowed_depth = (max_parent_depth as i64) + (depth_buffer as i64);
+            let highest_tip_height = s.dag.latest_block_number();
+            for parent_hash in &parent_hashes {
+                if parent_hash == &genesis.block_hash {
+                    continue; // genesis exempt
+                }
+                let parent_meta = match s.dag.lookup_unsafe(parent_hash) {
+                    Ok(meta) => meta,
+                    Err(_) => continue, // missing-parent handled by dependency gate, not here
+                };
+                let depth = highest_tip_height - parent_meta.block_number;
+                if depth > max_allowed_depth {
+                    let message = format!(
+                        "parent {} at block_number {} is at depth {} from highest tip {} \
+                         (exceeds max_parent_depth + depth_buffer = {})",
+                        PrettyPrinter::build_string_bytes(parent_hash),
+                        parent_meta.block_number,
+                        depth,
+                        highest_tip_height,
+                        max_allowed_depth
+                    );
+                    tracing::warn!("{}", Self::ignore(b, &message));
+                    return Either::Left(BlockError::Invalid(InvalidBlock::InvalidParents));
+                }
+            }
         }
 
         let validator = &b.sender;

--- a/casper/tests/batch2/single_parent_casper_spec.rs
+++ b/casper/tests/batch2/single_parent_casper_spec.rs
@@ -152,7 +152,9 @@ async fn should_reject_multi_parent_blocks() {
         &ctx.genesis.genesis_block,
         &mut snapshot,
         max_number_of_parents,
-        false, // disable_validator_progress_check
+        i32::MAX, // max_parent_depth: disable depth check for this test
+        0,        // depth_buffer
+        false,    // disable_validator_progress_check
     );
 
     assert_eq!(

--- a/casper/tests/batch2/validate_test.rs
+++ b/casper/tests/batch2/validate_test.rs
@@ -2291,8 +2291,13 @@ async fn parent_validation_should_pass_when_parent_within_horizon() {
         }];
 
         // Chain of 5 blocks. Tip at chain[4] (block_number=4).
-        let chain =
-            build_linear_chain(&mut block_store, &mut block_dag_storage, 5, bonds.clone(), v0.clone());
+        let chain = build_linear_chain(
+            &mut block_store,
+            &mut block_dag_storage,
+            5,
+            bonds.clone(),
+            v0.clone(),
+        );
         let genesis = chain[0].clone();
         let tip = chain[4].clone();
 
@@ -2342,8 +2347,13 @@ async fn parent_validation_should_pass_at_horizon_boundary() {
         }];
 
         // Chain of 6 blocks. Max block_number = 5, latest_block_number() returns 6.
-        let chain =
-            build_linear_chain(&mut block_store, &mut block_dag_storage, 6, bonds.clone(), v0.clone());
+        let chain = build_linear_chain(
+            &mut block_store,
+            &mut block_dag_storage,
+            6,
+            bonds.clone(),
+            v0.clone(),
+        );
         let genesis = chain[0].clone();
         let parent_at_depth_4 = chain[2].clone(); // block_number=2, depth=6-2=4
 
@@ -2393,8 +2403,13 @@ async fn parent_validation_should_pass_at_horizon_plus_buffer_boundary() {
         }];
 
         // Chain of 7 blocks. Max block_number = 6, latest_block_number() returns 7.
-        let chain =
-            build_linear_chain(&mut block_store, &mut block_dag_storage, 7, bonds.clone(), v0.clone());
+        let chain = build_linear_chain(
+            &mut block_store,
+            &mut block_dag_storage,
+            7,
+            bonds.clone(),
+            v0.clone(),
+        );
         let genesis = chain[0].clone();
         let parent_at_depth_5 = chain[2].clone(); // block_number=2, depth=7-2=5
 
@@ -2444,8 +2459,13 @@ async fn parent_validation_should_reject_when_parent_beyond_horizon() {
         }];
 
         // Chain of 7 blocks. Max block_number = 6, latest_block_number() returns 7.
-        let chain =
-            build_linear_chain(&mut block_store, &mut block_dag_storage, 7, bonds.clone(), v0.clone());
+        let chain = build_linear_chain(
+            &mut block_store,
+            &mut block_dag_storage,
+            7,
+            bonds.clone(),
+            v0.clone(),
+        );
         let genesis = chain[0].clone();
         let parent_at_depth_6 = chain[1].clone(); // block_number=1, depth=7-1=6
 
@@ -2554,8 +2574,13 @@ async fn parent_validation_should_skip_depth_check_when_max_parent_depth_is_unli
         }];
 
         // Chain of 7 blocks. Max block_number = 6, latest_block_number() returns 7.
-        let chain =
-            build_linear_chain(&mut block_store, &mut block_dag_storage, 7, bonds.clone(), v0.clone());
+        let chain = build_linear_chain(
+            &mut block_store,
+            &mut block_dag_storage,
+            7,
+            bonds.clone(),
+            v0.clone(),
+        );
         let genesis = chain[0].clone();
         let parent_at_depth_6 = chain[1].clone(); // depth=7-1=6
 

--- a/casper/tests/batch2/validate_test.rs
+++ b/casper/tests/batch2/validate_test.rs
@@ -1127,7 +1127,7 @@ async fn parent_validation_should_allow_first_block_from_new_validator() {
         let dag = block_dag_storage.get_representation();
         let mut casper_snapshot = mk_casper_snapshot(dag);
 
-        let result = Validate::parents(&b1, &genesis, &mut casper_snapshot, -1, false);
+        let result = Validate::parents(&b1, &genesis, &mut casper_snapshot, -1, i32::MAX, 0, false);
         assert_eq!(result, Either::Right(ValidBlock::Valid));
     })
     .await
@@ -1219,7 +1219,7 @@ async fn parent_validation_should_allow_empty_block_when_new_parents_exist() {
         let dag = block_dag_storage.get_representation();
         let mut casper_snapshot = mk_casper_snapshot(dag);
 
-        let result = Validate::parents(&b3, &genesis, &mut casper_snapshot, -1, false);
+        let result = Validate::parents(&b3, &genesis, &mut casper_snapshot, -1, i32::MAX, 0, false);
         assert_eq!(result, Either::Right(ValidBlock::Valid));
     })
     .await
@@ -1287,7 +1287,7 @@ async fn parent_validation_should_reject_empty_block_when_no_new_parents_exist()
         let dag = block_dag_storage.get_representation();
         let mut casper_snapshot = mk_casper_snapshot(dag);
 
-        let result = Validate::parents(&b2, &genesis, &mut casper_snapshot, -1, false);
+        let result = Validate::parents(&b2, &genesis, &mut casper_snapshot, -1, i32::MAX, 0, false);
         assert_eq!(
             result,
             Either::Left(BlockError::Invalid(InvalidBlock::InvalidParents))
@@ -1361,7 +1361,7 @@ async fn parent_validation_should_allow_block_with_user_deploys_regardless_of_pa
         let dag = block_dag_storage.get_representation();
         let mut casper_snapshot = mk_casper_snapshot(dag);
 
-        let result = Validate::parents(&b2, &genesis, &mut casper_snapshot, -1, false);
+        let result = Validate::parents(&b2, &genesis, &mut casper_snapshot, -1, i32::MAX, 0, false);
         assert_eq!(result, Either::Right(ValidBlock::Valid));
     })
     .await
@@ -1413,7 +1413,7 @@ async fn parent_validation_should_allow_proposal_when_previous_block_is_genesis(
         let dag = block_dag_storage.get_representation();
         let mut casper_snapshot = mk_casper_snapshot(dag);
 
-        let result = Validate::parents(&b1, &genesis, &mut casper_snapshot, -1, false);
+        let result = Validate::parents(&b1, &genesis, &mut casper_snapshot, -1, i32::MAX, 0, false);
         assert_eq!(result, Either::Right(ValidBlock::Valid));
     })
     .await
@@ -1528,7 +1528,7 @@ async fn parent_validation_should_enforce_max_number_of_parents_constraint() {
         let mut casper_snapshot = mk_casper_snapshot(dag);
 
         // maxNumberOfParents = 2, but block has 3 parents
-        let result = Validate::parents(&b4, &genesis, &mut casper_snapshot, 2, false);
+        let result = Validate::parents(&b4, &genesis, &mut casper_snapshot, 2, i32::MAX, 0, false);
         assert_eq!(
             result,
             Either::Left(BlockError::Invalid(InvalidBlock::InvalidParents))
@@ -1582,6 +1582,8 @@ async fn block_summary_validation_should_short_circuit_after_first_invalidity() 
             "root",
             i32::MAX,
             max_number_of_parents,
+            i32::MAX, // max_parent_depth: disable depth check for this test
+            0,        // depth_buffer: irrelevant when depth check disabled
             &mut block_store,
             false,
         )
@@ -2224,6 +2226,371 @@ async fn block_version_validation_should_work() {
 
         let result = Validate::version(&genesis, 1);
         assert_eq!(result, true);
+    })
+    .await
+}
+
+// ── Parent-depth enforcement (symmetric to proposer-side filterDeepParents) ──
+//
+// `validate::parents` rejects blocks whose parents fall outside
+// `max_parent_depth + depth_buffer` from the highest tip. Joiners that LFS-sync
+// to the LFB hold rspace history only for blocks within this horizon; rejecting
+// out-of-horizon blocks here prevents `UnknownRootError` cascades during
+// validation. Symmetric to the proposer-side `Estimator::filterDeepParents`
+// in `multi_parent_casper_impl::create_block`.
+
+fn build_linear_chain(
+    block_store: &mut KeyValueBlockStore,
+    block_dag_storage: &mut IndexedBlockDagStorage,
+    length: usize,
+    bonds: Vec<Bond>,
+    validator: Bytes,
+) -> Vec<BlockMessage> {
+    let genesis = create_genesis_block(
+        block_store,
+        block_dag_storage,
+        None,
+        Some(bonds.clone()),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    let mut chain = vec![genesis.clone()];
+    for i in 1..length {
+        let parent = chain.last().unwrap().clone();
+        let block = create_block(
+            block_store,
+            block_dag_storage,
+            vec![parent.block_hash.clone()],
+            &genesis,
+            Some(validator.clone()),
+            Some(bonds.clone()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(i as i32),
+            None,
+        );
+        chain.push(block);
+    }
+    chain
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn parent_validation_should_pass_when_parent_within_horizon() {
+    with_storage(|mut block_store, mut block_dag_storage| async move {
+        let v0 = generate_validator(Some("Validator0"));
+        let bonds = vec![Bond {
+            validator: v0.clone(),
+            stake: 10,
+        }];
+
+        // Chain of 5 blocks. Tip at chain[4] (block_number=4).
+        let chain =
+            build_linear_chain(&mut block_store, &mut block_dag_storage, 5, bonds.clone(), v0.clone());
+        let genesis = chain[0].clone();
+        let tip = chain[4].clone();
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+
+        // Test block parents the tip directly (depth 0). max_parent_depth=2, buffer=0.
+        let test_block = build_block(
+            vec![tip.block_hash.clone()],
+            Some(v0.clone()),
+            now,
+            Some(bonds.clone()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(5),
+        );
+
+        let dag = block_dag_storage.get_representation();
+        let mut casper_snapshot = mk_casper_snapshot(dag);
+
+        let result = Validate::parents(
+            &test_block,
+            &genesis,
+            &mut casper_snapshot,
+            -1,   // max_number_of_parents (unlimited)
+            2,    // max_parent_depth
+            0,    // depth_buffer
+            true, // disable_validator_progress_check (isolate depth check)
+        );
+        assert_eq!(result, Either::Right(ValidBlock::Valid));
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn parent_validation_should_pass_at_horizon_boundary() {
+    with_storage(|mut block_store, mut block_dag_storage| async move {
+        let v0 = generate_validator(Some("Validator0"));
+        let bonds = vec![Bond {
+            validator: v0.clone(),
+            stake: 10,
+        }];
+
+        // Chain of 6 blocks. Max block_number = 5, latest_block_number() returns 6.
+        let chain =
+            build_linear_chain(&mut block_store, &mut block_dag_storage, 6, bonds.clone(), v0.clone());
+        let genesis = chain[0].clone();
+        let parent_at_depth_4 = chain[2].clone(); // block_number=2, depth=6-2=4
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+
+        let test_block = build_block(
+            vec![parent_at_depth_4.block_hash.clone()],
+            Some(v0.clone()),
+            now,
+            Some(bonds.clone()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(6),
+        );
+
+        let dag = block_dag_storage.get_representation();
+        let mut casper_snapshot = mk_casper_snapshot(dag);
+
+        // depth=4, max_parent_depth=4, buffer=0 → 4 <= 4, passes (boundary)
+        let result = Validate::parents(
+            &test_block,
+            &genesis,
+            &mut casper_snapshot,
+            -1,
+            4,
+            0,
+            true, // disable_validator_progress_check (isolate depth check)
+        );
+        assert_eq!(result, Either::Right(ValidBlock::Valid));
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn parent_validation_should_pass_at_horizon_plus_buffer_boundary() {
+    with_storage(|mut block_store, mut block_dag_storage| async move {
+        let v0 = generate_validator(Some("Validator0"));
+        let bonds = vec![Bond {
+            validator: v0.clone(),
+            stake: 10,
+        }];
+
+        // Chain of 7 blocks. Max block_number = 6, latest_block_number() returns 7.
+        let chain =
+            build_linear_chain(&mut block_store, &mut block_dag_storage, 7, bonds.clone(), v0.clone());
+        let genesis = chain[0].clone();
+        let parent_at_depth_5 = chain[2].clone(); // block_number=2, depth=7-2=5
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+
+        let test_block = build_block(
+            vec![parent_at_depth_5.block_hash.clone()],
+            Some(v0.clone()),
+            now,
+            Some(bonds.clone()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(7),
+        );
+
+        let dag = block_dag_storage.get_representation();
+        let mut casper_snapshot = mk_casper_snapshot(dag);
+
+        // depth=5, max_parent_depth=4, buffer=1 → 5 <= 4+1, passes (boundary)
+        let result = Validate::parents(
+            &test_block,
+            &genesis,
+            &mut casper_snapshot,
+            -1,
+            4,
+            1,
+            true, // disable_validator_progress_check (isolate depth check)
+        );
+        assert_eq!(result, Either::Right(ValidBlock::Valid));
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn parent_validation_should_reject_when_parent_beyond_horizon() {
+    with_storage(|mut block_store, mut block_dag_storage| async move {
+        let v0 = generate_validator(Some("Validator0"));
+        let bonds = vec![Bond {
+            validator: v0.clone(),
+            stake: 10,
+        }];
+
+        // Chain of 7 blocks. Max block_number = 6, latest_block_number() returns 7.
+        let chain =
+            build_linear_chain(&mut block_store, &mut block_dag_storage, 7, bonds.clone(), v0.clone());
+        let genesis = chain[0].clone();
+        let parent_at_depth_6 = chain[1].clone(); // block_number=1, depth=7-1=6
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+
+        let test_block = build_block(
+            vec![parent_at_depth_6.block_hash.clone()],
+            Some(v0.clone()),
+            now,
+            Some(bonds.clone()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(7),
+        );
+
+        let dag = block_dag_storage.get_representation();
+        let mut casper_snapshot = mk_casper_snapshot(dag);
+
+        // depth=6, max_parent_depth=4, buffer=0 → 6 > 4, REJECT
+        let result = Validate::parents(
+            &test_block,
+            &genesis,
+            &mut casper_snapshot,
+            -1,
+            4,
+            0,
+            true, // disable_validator_progress_check (isolate depth check)
+        );
+        assert_eq!(
+            result,
+            Either::Left(BlockError::Invalid(InvalidBlock::InvalidParents))
+        );
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn parent_validation_should_exempt_genesis_from_depth_check() {
+    with_storage(|mut block_store, mut block_dag_storage| async move {
+        let v0 = generate_validator(Some("Validator0"));
+        let bonds = vec![Bond {
+            validator: v0.clone(),
+            stake: 10,
+        }];
+
+        // Chain of 12 blocks. Tip at chain[11] (block_number=11). Genesis depth=11.
+        let chain = build_linear_chain(
+            &mut block_store,
+            &mut block_dag_storage,
+            12,
+            bonds.clone(),
+            v0.clone(),
+        );
+        let genesis = chain[0].clone();
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+
+        // Test block parents genesis directly. depth=11, max_parent_depth=4, buffer=0 →
+        // would normally be REJECTED (11 > 4) — but genesis (block_number=0) is exempt.
+        let test_block = build_block(
+            vec![genesis.block_hash.clone()],
+            Some(v0.clone()),
+            now,
+            Some(bonds.clone()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(12),
+        );
+
+        let dag = block_dag_storage.get_representation();
+        let mut casper_snapshot = mk_casper_snapshot(dag);
+
+        let result = Validate::parents(
+            &test_block,
+            &genesis,
+            &mut casper_snapshot,
+            -1,
+            4,
+            0,
+            true, // disable_validator_progress_check (isolate depth check)
+        );
+        assert_eq!(result, Either::Right(ValidBlock::Valid));
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn parent_validation_should_skip_depth_check_when_max_parent_depth_is_unlimited() {
+    with_storage(|mut block_store, mut block_dag_storage| async move {
+        let v0 = generate_validator(Some("Validator0"));
+        let bonds = vec![Bond {
+            validator: v0.clone(),
+            stake: 10,
+        }];
+
+        // Chain of 7 blocks. Max block_number = 6, latest_block_number() returns 7.
+        let chain =
+            build_linear_chain(&mut block_store, &mut block_dag_storage, 7, bonds.clone(), v0.clone());
+        let genesis = chain[0].clone();
+        let parent_at_depth_6 = chain[1].clone(); // depth=7-1=6
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+
+        let test_block = build_block(
+            vec![parent_at_depth_6.block_hash.clone()],
+            Some(v0.clone()),
+            now,
+            Some(bonds.clone()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(7),
+        );
+
+        let dag = block_dag_storage.get_representation();
+        let mut casper_snapshot = mk_casper_snapshot(dag);
+
+        // depth=5 but max_parent_depth=i32::MAX → check skipped, passes regardless
+        let result = Validate::parents(
+            &test_block,
+            &genesis,
+            &mut casper_snapshot,
+            -1,
+            i32::MAX,
+            0,
+            true, // disable_validator_progress_check (isolate depth check)
+        );
+        assert_eq!(result, Either::Right(ValidBlock::Valid));
     })
     .await
 }

--- a/casper/tests/engine/initializing_spec.rs
+++ b/casper/tests/engine/initializing_spec.rs
@@ -240,6 +240,13 @@ impl InitializingSpec {
                 .send(genesis_clone)
                 .await
                 .expect("Failed to enqueue block response");
+            // Brief yield so the LFS stream processes the genesis BlockMessage
+            // (running save_block → mergeable_pending(genesis)) before the
+            // mergeable response below is delivered. Without this, the select
+            // loop may consume the response first and reject it as unsolicited
+            // (was_pending=false), leaving mergeable_d non-empty forever and
+            // the stream blocked waiting for a response that already arrived.
+            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
             // Empty serialized_entry signals "peer has no entry"; this test
             // doesn't exercise actual entry import, just the done-on-response gate.
             mergeable_message_tx

--- a/casper/tests/engine/initializing_spec.rs
+++ b/casper/tests/engine/initializing_spec.rs
@@ -5,8 +5,8 @@ use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
     Arc,
+    atomic::{AtomicBool, Ordering},
 };
 use tokio::sync::mpsc;
 
@@ -25,8 +25,8 @@ use models::rust::casper::protocol::casper_message::{
     ApprovedBlock, ApprovedBlockRequest, BlockMessage, BlockRequest, CasperMessage,
     StoreItemsMessage, StoreItemsMessageRequest,
 };
-use prost::bytes::Bytes;
 use prost::Message;
+use prost::bytes::Bytes;
 
 use casper::rust::errors::CasperError;
 use comm::rust::rp::protocol_helper::packet_with_content;
@@ -212,9 +212,20 @@ impl InitializingSpec {
             .as_ref()
             .unwrap()
             .clone();
+        // Tests must feed a MergeableEntryResponse for every block they enqueue;
+        // otherwise the stream's per-block mergeable_pending state never clears
+        // and is_finished() never returns true.
+        let mergeable_message_tx = initializing_engine
+            .mergeable_message_tx
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .clone();
 
         let store_msgs_clone = store_response_messages.clone();
         let genesis_clone = genesis.clone();
+        let genesis_hash_for_mergeable = genesis.block_hash.clone();
 
         let enqueue_responses = async move {
             // Write directly to tuple space channel (equivalent to stateResponseQueue.enqueue1)
@@ -229,6 +240,17 @@ impl InitializingSpec {
                 .send(genesis_clone)
                 .await
                 .expect("Failed to enqueue block response");
+            // Empty serialized_entry signals "peer has no entry"; this test
+            // doesn't exercise actual entry import, just the done-on-response gate.
+            mergeable_message_tx
+                .send(
+                    models::rust::casper::protocol::casper_message::MergeableEntryResponse {
+                        block_hash: genesis_hash_for_mergeable,
+                        serialized_entry: prost::bytes::Bytes::new(),
+                    },
+                )
+                .await
+                .expect("Failed to enqueue mergeable response");
         };
 
         let local_for_expected = fixture.local.clone();
@@ -251,6 +273,15 @@ impl InitializingSpec {
             &local_for_expected,
             &fixture.network_id,
             models::casper::ForkChoiceTipRequestProto::default(),
+        ));
+        // After the genesis BlockMessage lands and is saved, the joiner fires
+        // a MergeableEntryRequest for the same hash.
+        expected_requests.push(packet_with_content(
+            &local_for_expected,
+            &fixture.network_id,
+            models::casper::MergeableEntryRequestProto {
+                block_hash: genesis.block_hash.clone(),
+            },
         ));
 
         let test = async {
@@ -383,6 +414,9 @@ async fn create_initializing_engine(
     // Create engine-specific channels (each Initializing instance needs its own)
     let (block_tx, block_rx) = mpsc::channel::<BlockMessage>(50);
     let (tuple_tx, tuple_rx) = mpsc::channel::<StoreItemsMessage>(50);
+    // Mergeable-channels sync channel.
+    let (mergeable_tx, mergeable_rx) =
+        mpsc::channel::<models::rust::casper::protocol::casper_message::MergeableEntryResponse>(50);
     let (block_processing_queue_tx, _block_processing_queue_rx) = mpsc::channel(1024);
 
     // Use all stores and managers from fixture (matching Scala's Setup pattern)
@@ -406,6 +440,8 @@ async fn create_initializing_engine(
         block_rx,
         tuple_tx,
         tuple_rx,
+        mergeable_tx,
+        mergeable_rx,
         true,
         false,
         fixture.event_publisher.clone(),

--- a/casper/tests/engine/initializing_spec.rs
+++ b/casper/tests/engine/initializing_spec.rs
@@ -5,8 +5,8 @@ use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{
-    Arc,
     atomic::{AtomicBool, Ordering},
+    Arc,
 };
 use tokio::sync::mpsc;
 
@@ -25,8 +25,8 @@ use models::rust::casper::protocol::casper_message::{
     ApprovedBlock, ApprovedBlockRequest, BlockMessage, BlockRequest, CasperMessage,
     StoreItemsMessage, StoreItemsMessageRequest,
 };
-use prost::Message;
 use prost::bytes::Bytes;
+use prost::Message;
 
 use casper::rust::errors::CasperError;
 use comm::rust::rp::protocol_helper::packet_with_content;

--- a/casper/tests/engine/lfs_block_requester_effects_spec.rs
+++ b/casper/tests/engine/lfs_block_requester_effects_spec.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use prost::bytes::Bytes;
 use std::{
     collections::{HashMap, HashSet},
-    sync::{Arc, Mutex, atomic::AtomicUsize},
+    sync::{atomic::AtomicUsize, Arc, Mutex},
 };
 use tokio::sync::mpsc;
 

--- a/casper/tests/engine/lfs_block_requester_effects_spec.rs
+++ b/casper/tests/engine/lfs_block_requester_effects_spec.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use prost::bytes::Bytes;
 use std::{
     collections::{HashMap, HashSet},
-    sync::{atomic::AtomicUsize, Arc, Mutex},
+    sync::{Arc, Mutex, atomic::AtomicUsize},
 };
 use tokio::sync::mpsc;
 
@@ -291,6 +291,23 @@ impl BlockRequesterOps for MockBlockRequesterOps {
         let state = self.test_state.lock().expect("Lock error");
         !state.invalid.contains(&block.block_hash)
     }
+
+    /// No-op — these tests don't exercise the mergeable-entry path.
+    async fn request_for_mergeable_entry(
+        &self,
+        _block_hash: &BlockHash,
+    ) -> Result<(), CasperError> {
+        Ok(())
+    }
+
+    /// No-op — these tests don't exercise the mergeable-entry path.
+    fn put_mergeable_entry(
+        &self,
+        _block_hash: &BlockHash,
+        _serialized_entry: &[u8],
+    ) -> Result<(), CasperError> {
+        Ok(())
+    }
 }
 
 pub async fn dag_from_block<F, Fut>(
@@ -331,11 +348,14 @@ where
 
         let empty_queue = std::collections::VecDeque::new();
         let response_queue_pending = Arc::new(AtomicUsize::new(0));
+        // Unused receiver to satisfy the stream signature.
+        let (_mergeable_tx, mergeable_rx) = tokio::sync::mpsc::channel(50);
         let lfs_stream = casper::rust::engine::lfs_block_requester::stream(
             &approved_block,
             &empty_queue,
             response_rx,
             response_queue_pending.clone(),
+            mergeable_rx,
             0,
             request_timeout,
             &mut mock_ops,

--- a/casper/tests/util/mod.rs
+++ b/casper/tests/util/mod.rs
@@ -6,4 +6,5 @@ pub mod genesis_builder;
 pub mod in_memory_key_value_store_spec;
 pub mod proto_util_test;
 pub mod rholang;
+pub mod rspace_history_horizon_test;
 pub mod test_mocks;

--- a/casper/tests/util/rspace_history_horizon_test.rs
+++ b/casper/tests/util/rspace_history_horizon_test.rs
@@ -1,0 +1,241 @@
+// Tests for `compute_forward_horizon_roots` — joiner-side LFS forward-horizon
+// reachability calculation. See `casper/src/rust/util/rspace_history_horizon.rs`
+// for the production code under test.
+
+use crate::helper::{
+    block_dag_storage_fixture::with_storage,
+    block_generator::{create_block, create_genesis_block},
+    block_util::generate_validator,
+};
+use block_storage::rust::key_value_block_store::KeyValueBlockStore;
+use block_storage::rust::test::indexed_block_dag_storage::IndexedBlockDagStorage;
+use casper::rust::casper::CasperShardConf;
+use casper::rust::util::rspace_history_horizon::compute_forward_horizon_roots;
+use models::rust::casper::protocol::casper_message::{Bond, BlockMessage};
+use prost::bytes::Bytes;
+use rspace_plus_plus::rspace::hashing::blake2b256_hash::Blake2b256Hash;
+
+fn mk_conf(max_parent_depth: i32, depth_buffer: i32) -> CasperShardConf {
+    let mut conf = CasperShardConf::new();
+    conf.max_parent_depth = max_parent_depth;
+    conf.mergeable_channels_gc_depth_buffer = depth_buffer;
+    conf
+}
+
+fn unique_state_hash(seed: u8) -> Bytes {
+    // 32-byte deterministic hash; seed in first byte distinguishes per-block.
+    // (Production blocks have genuinely unique post_state_hashes from rspace
+    // computation; test fixture defaults to empty bytes which would all
+    // dedupe.)
+    let mut bytes = vec![0u8; 32];
+    bytes[0] = seed;
+    Bytes::from(bytes)
+}
+
+fn build_chain(
+    block_store: &mut KeyValueBlockStore,
+    block_dag_storage: &mut IndexedBlockDagStorage,
+    length: usize,
+    bonds: Vec<Bond>,
+    validator: Bytes,
+) -> Vec<BlockMessage> {
+    let genesis = create_genesis_block(
+        block_store,
+        block_dag_storage,
+        None,
+        Some(bonds.clone()),
+        None,
+        None,
+        Some(unique_state_hash(0)),
+        None,
+        None,
+        None,
+    );
+    let mut chain = vec![genesis.clone()];
+    for i in 1..length {
+        let parent = chain.last().unwrap().clone();
+        let block = create_block(
+            block_store,
+            block_dag_storage,
+            vec![parent.block_hash.clone()],
+            &genesis,
+            Some(validator.clone()),
+            Some(bonds.clone()),
+            None,
+            None,
+            Some(unique_state_hash(i as u8)),
+            None,
+            // pre_state_hash mirrors a real single-parent chain: this
+            // block's pre = parent's post. Dedup against the parent's
+            // post_state_hash later in compute_forward_horizon_roots.
+            Some(parent.body.state.post_state_hash.clone()),
+            Some(i as i32),
+            None,
+        );
+        chain.push(block);
+    }
+    chain
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn returns_empty_when_max_parent_depth_is_unlimited() {
+    with_storage(|mut block_store, mut block_dag_storage| async move {
+        let v0 = generate_validator(Some("Validator0"));
+        let bonds = vec![Bond {
+            validator: v0.clone(),
+            stake: 10,
+        }];
+        let chain = build_chain(&mut block_store, &mut block_dag_storage, 5, bonds, v0);
+
+        let dag = block_dag_storage.get_representation();
+        let conf = mk_conf(i32::MAX, 0);
+
+        let roots = compute_forward_horizon_roots(&dag, &block_store, &chain[4], &conf).unwrap();
+        assert!(
+            roots.is_empty(),
+            "horizon should be empty when max_parent_depth is unlimited (caller falls back to disable-lfs replay)"
+        );
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn includes_main_chain_ancestors_within_horizon() {
+    with_storage(|mut block_store, mut block_dag_storage| async move {
+        let v0 = generate_validator(Some("Validator0"));
+        let bonds = vec![Bond {
+            validator: v0.clone(),
+            stake: 10,
+        }];
+        // Chain of 6 blocks. block_numbers 1..5 (genesis at 1 in test fixture).
+        let chain = build_chain(&mut block_store, &mut block_dag_storage, 6, bonds, v0);
+
+        let dag = block_dag_storage.get_representation();
+        // max_parent_depth=2, depth_buffer=1 → window from LFB.height-3 upward.
+        let conf = mk_conf(2, 1);
+
+        let roots = compute_forward_horizon_roots(&dag, &block_store, &chain[5], &conf).unwrap();
+        // LFB at chain[5] has block_number=5; horizon includes block_numbers >= 5-3=2.
+        // That's chain[2..=5] = 4 blocks, contributing 4 unique post-states.
+        // Each block also contributes its pre-state, which on a single-parent
+        // chain equals the parent's post-state. chain[2..=5] pre-states dedupe
+        // against post-states of chain[1..=4]; chain[1]'s post is OUTSIDE the
+        // horizon and therefore not collected from chain[1] itself, so it
+        // appears once via chain[2]'s pre. Expected total = 4 + 1 = 5.
+        assert_eq!(
+            roots.len(),
+            5,
+            "horizon should include 4 post-states + 1 unique pre-state from chain[2] (got {})",
+            roots.len()
+        );
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn excludes_blocks_outside_horizon() {
+    with_storage(|mut block_store, mut block_dag_storage| async move {
+        let v0 = generate_validator(Some("Validator0"));
+        let bonds = vec![Bond {
+            validator: v0.clone(),
+            stake: 10,
+        }];
+        // Chain of 10 blocks, block_numbers 1..9.
+        let chain = build_chain(&mut block_store, &mut block_dag_storage, 10, bonds, v0);
+
+        let dag = block_dag_storage.get_representation();
+        // max_parent_depth=2, depth_buffer=0 → window from LFB.height-2 upward.
+        let conf = mk_conf(2, 0);
+
+        let roots = compute_forward_horizon_roots(&dag, &block_store, &chain[9], &conf).unwrap();
+        // LFB at chain[9] block_number=9; horizon includes block_numbers >= 7.
+        // That's chain[7], chain[8], chain[9] = 3 blocks → 3 unique post-states.
+        // Pre-states: chain[7].pre == chain[6].post (unique, outside horizon),
+        // chain[8].pre == chain[7].post (deduped), chain[9].pre == chain[8].post
+        // (deduped). Expected total = 3 + 1 = 4.
+        assert_eq!(
+            roots.len(),
+            4,
+            "horizon should exclude blocks outside window (got {} roots, expected 4)",
+            roots.len()
+        );
+
+        // chain[3]'s post-state is well outside the horizon and should never
+        // be collected — neither as a post nor as anyone's pre (chain[4]'s pre
+        // is also outside the collected window).
+        let early_ancestor_root =
+            Blake2b256Hash::from_bytes_prost(&chain[3].body.state.post_state_hash);
+        assert!(
+            !roots.contains(&early_ancestor_root),
+            "horizon must not contain root from chain[3] (block_number=3, depth=6 from tip)"
+        );
+
+        // chain[6]'s post-state SHOULD appear, but only as chain[7]'s pre-state
+        // (chain[6] itself is outside the horizon). This proves the pre-state
+        // collection bridges one level of horizon-edge state.
+        let chain6_post =
+            Blake2b256Hash::from_bytes_prost(&chain[6].body.state.post_state_hash);
+        assert!(
+            roots.contains(&chain6_post),
+            "chain[6]'s post-state must appear via chain[7]'s pre-state (horizon-edge bridge)"
+        );
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn returns_lfb_only_when_horizon_at_genesis() {
+    with_storage(|mut block_store, mut block_dag_storage| async move {
+        let v0 = generate_validator(Some("Validator0"));
+        let bonds = vec![Bond {
+            validator: v0.clone(),
+            stake: 10,
+        }];
+        // Just genesis + 1 child. LFB.height = 1. Horizon clamped to 0.
+        let chain = build_chain(&mut block_store, &mut block_dag_storage, 2, bonds, v0);
+
+        let dag = block_dag_storage.get_representation();
+        let conf = mk_conf(100, 10);
+
+        let roots = compute_forward_horizon_roots(&dag, &block_store, &chain[1], &conf).unwrap();
+        // Both genesis (block_number=1 in test fixture) and chain[1] (also seq_num=1
+        // → block_number=1) are within horizon. Both have default-empty
+        // post_state_hash though (test fixture doesn't compute real state),
+        // so they may dedupe to one entry. Just assert non-empty.
+        assert!(
+            !roots.is_empty(),
+            "horizon for short chain should still include at least the LFB's post-state"
+        );
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn ordered_by_descending_height() {
+    with_storage(|mut block_store, mut block_dag_storage| async move {
+        let v0 = generate_validator(Some("Validator0"));
+        let bonds = vec![Bond {
+            validator: v0.clone(),
+            stake: 10,
+        }];
+        let chain = build_chain(&mut block_store, &mut block_dag_storage, 6, bonds, v0);
+
+        let dag = block_dag_storage.get_representation();
+        // max_parent_depth large enough to include the whole chain
+        let conf = mk_conf(10, 0);
+
+        let roots = compute_forward_horizon_roots(&dag, &block_store, &chain[5], &conf).unwrap();
+        assert!(!roots.is_empty());
+
+        // First entry should correspond to a block with height >= the last entry's height.
+        // We can't directly read height from Blake2b256Hash, so instead verify that
+        // the LFB's own post-state is FIRST in the result (LFB-side first per docs).
+        let lfb_root = Blake2b256Hash::from_bytes_prost(&chain[5].body.state.post_state_hash);
+        assert_eq!(
+            roots.first(),
+            Some(&lfb_root),
+            "LFB's post-state should appear first (LFB-side ordering)"
+        );
+    })
+    .await
+}

--- a/casper/tests/util/rspace_history_horizon_test.rs
+++ b/casper/tests/util/rspace_history_horizon_test.rs
@@ -239,3 +239,128 @@ async fn ordered_by_descending_height() {
     })
     .await
 }
+
+// ── Pre-state inclusion semantics ─────────────────────────────────────────
+//
+// `compute_forward_horizon_roots` must emit each block's `pre_state_hash`
+// alongside its `post_state_hash`. For single-parent blocks the pre-state
+// equals the parent's post-state and dedupes via the HashSet. For
+// multi-parent blocks the pre-state is the merge intermediate computed by
+// the proposer's `dag_merger::merge` and is distinct from any parent's
+// post-state — those merge intermediates only ever exist as the result of
+// `do_checkpoint`'s `store_root`. Without their inclusion, joiners hit
+// `RootRepositoryDivergence` when validating the multi-parent block.
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pre_state_included_for_multi_parent_block() {
+    with_storage(|mut block_store, mut block_dag_storage| async move {
+        let v0 = generate_validator(Some("Validator0"));
+        let bonds = vec![Bond {
+            validator: v0.clone(),
+            stake: 10,
+        }];
+
+        // Build two single-parent chain segments off genesis, then a
+        // multi-parent block joining their tips. The multi-parent block's
+        // pre_state_hash is set to a SEED unique to neither parent's post
+        // (mirrors a real merge intermediate computed via dag_merger).
+        let chain =
+            build_chain(&mut block_store, &mut block_dag_storage, 3, bonds.clone(), v0.clone());
+        let genesis = chain[0].clone();
+        let parent_a = chain[2].clone(); // sender v0, post=unique_state_hash(2)
+        let parent_b = create_block(
+            &mut block_store,
+            &mut block_dag_storage,
+            vec![chain[1].block_hash.clone()],
+            &genesis,
+            Some(v0.clone()),
+            Some(bonds.clone()),
+            None,
+            None,
+            Some(unique_state_hash(99)), // distinct post-state
+            None,
+            Some(chain[1].body.state.post_state_hash.clone()),
+            Some(2_i32),
+            None,
+        );
+
+        // Multi-parent block at height 3. Its pre-state is the seeded merge
+        // intermediate (seed=200) — not equal to either parent's post-state.
+        let merge_intermediate = unique_state_hash(200);
+        let merged = create_block(
+            &mut block_store,
+            &mut block_dag_storage,
+            vec![parent_a.block_hash.clone(), parent_b.block_hash.clone()],
+            &genesis,
+            Some(v0.clone()),
+            Some(bonds.clone()),
+            None,
+            None,
+            Some(unique_state_hash(201)),
+            None,
+            Some(merge_intermediate.clone()),
+            Some(3_i32),
+            None,
+        );
+
+        let dag = block_dag_storage.get_representation();
+        let conf = mk_conf(10, 0); // wide horizon — include everything
+
+        let roots = compute_forward_horizon_roots(&dag, &block_store, &merged, &conf).unwrap();
+
+        // The merge intermediate (multi-parent block's pre_state_hash) MUST
+        // be present in the result. Without it, joiners can't reset to the
+        // pre-state during multi-parent block validation.
+        let merge_root = Blake2b256Hash::from_bytes_prost(&merge_intermediate);
+        assert!(
+            roots.contains(&merge_root),
+            "multi-parent block's pre_state_hash (the merge intermediate) must be \
+             collected; without it, joiner validation fires RootRepositoryDivergence"
+        );
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn single_parent_pre_state_dedupes_against_parent_post_state() {
+    with_storage(|mut block_store, mut block_dag_storage| async move {
+        let v0 = generate_validator(Some("Validator0"));
+        let bonds = vec![Bond {
+            validator: v0.clone(),
+            stake: 10,
+        }];
+
+        // Single-parent chain: each non-genesis block's pre-state equals its
+        // parent's post-state. With both in-window, the pre-state must NOT
+        // appear as a separate root entry — it dedupes against the parent's
+        // already-collected post-state. Without the HashSet dedup, the
+        // result would double-count every parent-child boundary.
+        let chain =
+            build_chain(&mut block_store, &mut block_dag_storage, 4, bonds.clone(), v0.clone());
+
+        let dag = block_dag_storage.get_representation();
+        let conf = mk_conf(10, 0); // wide window — all 4 blocks in scope
+
+        let roots = compute_forward_horizon_roots(&dag, &block_store, &chain[3], &conf).unwrap();
+
+        // chain[1].post is referenced both as chain[1]'s own post AND as
+        // chain[2]'s pre-state. It must appear in `roots` exactly once.
+        let chain_1_post =
+            Blake2b256Hash::from_bytes_prost(&chain[1].body.state.post_state_hash);
+        let count = roots.iter().filter(|r| **r == chain_1_post).count();
+        assert_eq!(
+            count, 1,
+            "chain[1].post must appear exactly once — not duplicated by chain[2].pre"
+        );
+
+        // Symmetric check on chain[2].post / chain[3].pre.
+        let chain_2_post =
+            Blake2b256Hash::from_bytes_prost(&chain[2].body.state.post_state_hash);
+        let count = roots.iter().filter(|r| **r == chain_2_post).count();
+        assert_eq!(
+            count, 1,
+            "chain[2].post must appear exactly once — not duplicated by chain[3].pre"
+        );
+    })
+    .await
+}

--- a/casper/tests/util/rspace_history_horizon_test.rs
+++ b/casper/tests/util/rspace_history_horizon_test.rs
@@ -11,7 +11,7 @@ use block_storage::rust::key_value_block_store::KeyValueBlockStore;
 use block_storage::rust::test::indexed_block_dag_storage::IndexedBlockDagStorage;
 use casper::rust::casper::CasperShardConf;
 use casper::rust::util::rspace_history_horizon::compute_forward_horizon_roots;
-use models::rust::casper::protocol::casper_message::{Bond, BlockMessage};
+use models::rust::casper::protocol::casper_message::{BlockMessage, Bond};
 use prost::bytes::Bytes;
 use rspace_plus_plus::rspace::hashing::blake2b256_hash::Blake2b256Hash;
 
@@ -173,8 +173,7 @@ async fn excludes_blocks_outside_horizon() {
         // chain[6]'s post-state SHOULD appear, but only as chain[7]'s pre-state
         // (chain[6] itself is outside the horizon). This proves the pre-state
         // collection bridges one level of horizon-edge state.
-        let chain6_post =
-            Blake2b256Hash::from_bytes_prost(&chain[6].body.state.post_state_hash);
+        let chain6_post = Blake2b256Hash::from_bytes_prost(&chain[6].body.state.post_state_hash);
         assert!(
             roots.contains(&chain6_post),
             "chain[6]'s post-state must appear via chain[7]'s pre-state (horizon-edge bridge)"
@@ -264,8 +263,13 @@ async fn pre_state_included_for_multi_parent_block() {
         // multi-parent block joining their tips. The multi-parent block's
         // pre_state_hash is set to a SEED unique to neither parent's post
         // (mirrors a real merge intermediate computed via dag_merger).
-        let chain =
-            build_chain(&mut block_store, &mut block_dag_storage, 3, bonds.clone(), v0.clone());
+        let chain = build_chain(
+            &mut block_store,
+            &mut block_dag_storage,
+            3,
+            bonds.clone(),
+            v0.clone(),
+        );
         let genesis = chain[0].clone();
         let parent_a = chain[2].clone(); // sender v0, post=unique_state_hash(2)
         let parent_b = create_block(
@@ -335,8 +339,13 @@ async fn single_parent_pre_state_dedupes_against_parent_post_state() {
         // appear as a separate root entry — it dedupes against the parent's
         // already-collected post-state. Without the HashSet dedup, the
         // result would double-count every parent-child boundary.
-        let chain =
-            build_chain(&mut block_store, &mut block_dag_storage, 4, bonds.clone(), v0.clone());
+        let chain = build_chain(
+            &mut block_store,
+            &mut block_dag_storage,
+            4,
+            bonds.clone(),
+            v0.clone(),
+        );
 
         let dag = block_dag_storage.get_representation();
         let conf = mk_conf(10, 0); // wide window — all 4 blocks in scope
@@ -345,8 +354,7 @@ async fn single_parent_pre_state_dedupes_against_parent_post_state() {
 
         // chain[1].post is referenced both as chain[1]'s own post AND as
         // chain[2]'s pre-state. It must appear in `roots` exactly once.
-        let chain_1_post =
-            Blake2b256Hash::from_bytes_prost(&chain[1].body.state.post_state_hash);
+        let chain_1_post = Blake2b256Hash::from_bytes_prost(&chain[1].body.state.post_state_hash);
         let count = roots.iter().filter(|r| **r == chain_1_post).count();
         assert_eq!(
             count, 1,
@@ -354,8 +362,7 @@ async fn single_parent_pre_state_dedupes_against_parent_post_state() {
         );
 
         // Symmetric check on chain[2].post / chain[3].pre.
-        let chain_2_post =
-            Blake2b256Hash::from_bytes_prost(&chain[2].body.state.post_state_hash);
+        let chain_2_post = Blake2b256Hash::from_bytes_prost(&chain[2].body.state.post_state_hash);
         let count = roots.iter().filter(|r| **r == chain_2_post).count();
         assert_eq!(
             count, 1,

--- a/docs/models/README.md
+++ b/docs/models/README.md
@@ -57,7 +57,8 @@ pub struct BlockMetadata {
 - `ApprovedBlockCandidate`, `ApprovedBlock`, `BlockApproval`
 - `BlockRequest`, `ForkChoiceTipRequest`
 - `HasBlock`, `HasBlockRequest`
-- `StoreItemsMessageRequest`, `StoreItemsMessage` (state sync)
+- `StoreItemsMessageRequest`, `StoreItemsMessage` (RSpace trie sync)
+- `MergeableEntryRequest`, `MergeableEntryResponse` (mergeable-channels store sync)
 
 **`ToPacket` trait** -- Converts proto messages to routing `Packet`s for network serialization.
 

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -275,3 +275,18 @@ message StoreItemsMessageProto {
 }
 
 // --------- End Last finalized state  --------
+
+// --------- Mergeable channels store sync --------
+
+message MergeableEntryRequestProto {
+  option (scalapb.message).extends = "CasperMessageProto";
+  bytes block_hash = 1;
+}
+
+message MergeableEntryResponseProto {
+  option (scalapb.message).extends = "CasperMessageProto";
+  bytes block_hash       = 1;
+  // bincode of Vec<DeployMergeableData>. Empty bytes = peer has the block but
+  // no entry for it.
+  bytes serialized_entry = 2;
+}

--- a/models/src/rust/casper/protocol/casper_message.rs
+++ b/models/src/rust/casper/protocol/casper_message.rs
@@ -39,6 +39,8 @@ pub enum CasperMessage {
     // Last finalized state messages
     StoreItemsMessageRequest(StoreItemsMessageRequest),
     StoreItemsMessage(StoreItemsMessage),
+    MergeableEntryRequest(MergeableEntryRequest),
+    MergeableEntryResponse(MergeableEntryResponse),
 }
 
 impl CasperMessage {
@@ -110,6 +112,14 @@ impl CasperMessage {
 
     pub fn from_store_items_message(proto: StoreItemsMessageProto) -> Self {
         CasperMessage::StoreItemsMessage(StoreItemsMessage::from_proto(proto))
+    }
+
+    pub fn from_mergeable_entry_request(proto: MergeableEntryRequestProto) -> Self {
+        CasperMessage::MergeableEntryRequest(MergeableEntryRequest::from_proto(proto))
+    }
+
+    pub fn from_mergeable_entry_response(proto: MergeableEntryResponseProto) -> Self {
+        CasperMessage::MergeableEntryResponse(MergeableEntryResponse::from_proto(proto))
     }
 }
 
@@ -1243,6 +1253,49 @@ impl StoreItemsMessage {
                     value,
                 })
                 .collect(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MergeableEntryRequest {
+    pub block_hash: ByteString,
+}
+
+impl MergeableEntryRequest {
+    pub fn from_proto(proto: MergeableEntryRequestProto) -> Self {
+        Self {
+            block_hash: proto.block_hash,
+        }
+    }
+
+    pub fn to_proto(self) -> MergeableEntryRequestProto {
+        MergeableEntryRequestProto {
+            block_hash: self.block_hash,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MergeableEntryResponse {
+    pub block_hash: ByteString,
+    /// Bincode of `Vec<DeployMergeableData>`. Empty bytes = peer has the block
+    /// but no entry for it.
+    pub serialized_entry: ByteString,
+}
+
+impl MergeableEntryResponse {
+    pub fn from_proto(proto: MergeableEntryResponseProto) -> Self {
+        Self {
+            block_hash: proto.block_hash,
+            serialized_entry: proto.serialized_entry,
+        }
+    }
+
+    pub fn to_proto(self) -> MergeableEntryResponseProto {
+        MergeableEntryResponseProto {
+            block_hash: self.block_hash,
+            serialized_entry: self.serialized_entry,
         }
     }
 }

--- a/models/src/rust/casper/protocol/packet_type_tag.rs
+++ b/models/src/rust/casper/protocol/packet_type_tag.rs
@@ -6,8 +6,9 @@ use crate::{
     casper::{
         ApprovedBlockProto, ApprovedBlockRequestProto, BlockApprovalProto, BlockHashMessageProto,
         BlockMessageProto, BlockRequestProto, ForkChoiceTipRequestProto, HasBlockProto,
-        HasBlockRequestProto, NoApprovedBlockAvailableProto, StoreItemsMessageProto,
-        StoreItemsMessageRequestProto, UnapprovedBlockProto,
+        HasBlockRequestProto, MergeableEntryRequestProto, MergeableEntryResponseProto,
+        NoApprovedBlockAvailableProto, StoreItemsMessageProto, StoreItemsMessageRequestProto,
+        UnapprovedBlockProto,
     },
     routing::Packet,
 };
@@ -52,3 +53,5 @@ impl_packet!(HasBlockProto, "HasBlock");
 impl_packet!(ForkChoiceTipRequestProto, "ForkChoiceTipRequest");
 impl_packet!(StoreItemsMessageRequestProto, "StoreItemsMessageRequest");
 impl_packet!(StoreItemsMessageProto, "StoreItemsMessage");
+impl_packet!(MergeableEntryRequestProto, "MergeableEntryRequest");
+impl_packet!(MergeableEntryResponseProto, "MergeableEntryResponse");

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -317,12 +317,19 @@ casper {
   max-number-of-parents = 100
 
   # Bound on how far back (in block-height terms) secondary parents are
-  # allowed to live relative to the main parent. Default i32::MAX
-  # disables the bound. Lower values reduce merge work for proposers on
-  # wide DAGs at the cost of dropping older parent justifications.
+  # allowed to live relative to the main parent. Setting to 2147483647
+  # (i32::MAX) disables the bound and the validator-side parent-depth
+  # check in `validate::parents`.
+  #
+  # 100 is chosen to match the validator-side LFS forward-horizon sync
+  # window (`max-parent-depth + mergeable-channels-gc-depth-buffer`):
+  # joiners that LFS-sync to the LFB carry rspace history for blocks
+  # within 100 + 10 = 110 of LFB.height. Setting this any higher means
+  # joiners may receive blocks whose parents fall outside their synced
+  # rspace history → `UnknownRootError` on validation.
   # See https://github.com/rchain/rchain/pull/2816 for the original
   # rationale.
-  max-parent-depth = 2147483647
+  max-parent-depth = 100
 
   # Age threshold past which the node treats its known fork-choice tip as
   # stale and requests fresh tips from peers. Higher values reduce

--- a/rspace++/src/rspace/history/history_repository.rs
+++ b/rspace++/src/rspace/history/history_repository.rs
@@ -58,6 +58,11 @@ pub trait HistoryRepository<C: Clone, P: Clone, A: Clone, K: Clone>: Send + Sync
     /// can find it via `validate_and_set_current_root`. This is needed during
     /// LFS bootstrap to register `emptyStateHashFixed` before genesis replay.
     fn record_root(&self, root: &Blake2b256Hash) -> Result<(), HistoryError>;
+
+    /// Pure lookup: returns true if the root is recorded in the store.
+    /// Companion to `record_root` for joiner-side LFS sync to check whether
+    /// a root has already been imported before fetching from peers.
+    fn contains_root(&self, root: &Blake2b256Hash) -> Result<bool, HistoryError>;
 }
 
 pub struct HistoryRepositoryInstances<C, P, A, K> {

--- a/rspace++/src/rspace/history/history_repository_impl.rs
+++ b/rspace++/src/rspace/history/history_repository_impl.rs
@@ -69,9 +69,7 @@ where
         })
     }
 
-    fn checkpoint_parallel_actions_threshold() -> usize {
-        CHECKPOINT_PARALLEL_ACTIONS_THRESHOLD
-    }
+    fn checkpoint_parallel_actions_threshold() -> usize { CHECKPOINT_PARALLEL_ACTIONS_THRESHOLD }
 
     fn should_parallelize_checkpoint_actions(actions_len: usize) -> bool {
         actions_len >= Self::checkpoint_parallel_actions_threshold()
@@ -270,39 +268,39 @@ where
         match hot_store_action {
             HotStoreAction::Insert(InsertData(i)) => {
                 let key = hash(&i.channel);
-                HotStoreTrieAction::TrieInsertAction(
-                    TrieInsertAction::TrieInsertProduce(TrieInsertProduce::new(key, i.data)),
-                )
+                HotStoreTrieAction::TrieInsertAction(TrieInsertAction::TrieInsertProduce(
+                    TrieInsertProduce::new(key, i.data),
+                ))
             }
             HotStoreAction::Insert(InsertContinuations(i)) => {
                 let key = hash_from_vec(&i.channels);
-                HotStoreTrieAction::TrieInsertAction(
-                    TrieInsertAction::TrieInsertConsume(TrieInsertConsume::new(key, i.continuations)),
-                )
+                HotStoreTrieAction::TrieInsertAction(TrieInsertAction::TrieInsertConsume(
+                    TrieInsertConsume::new(key, i.continuations),
+                ))
             }
             HotStoreAction::Insert(InsertJoins(i)) => {
                 let key = hash(&i.channel);
-                HotStoreTrieAction::TrieInsertAction(
-                    TrieInsertAction::TrieInsertJoins(TrieInsertJoins::new(key, i.joins)),
-                )
+                HotStoreTrieAction::TrieInsertAction(TrieInsertAction::TrieInsertJoins(
+                    TrieInsertJoins::new(key, i.joins),
+                ))
             }
             HotStoreAction::Delete(DeleteData(d)) => {
                 let key = hash(&d.channel);
-                HotStoreTrieAction::TrieDeleteAction(
-                    TrieDeleteAction::TrieDeleteProduce(TrieDeleteProduce::new(key)),
-                )
+                HotStoreTrieAction::TrieDeleteAction(TrieDeleteAction::TrieDeleteProduce(
+                    TrieDeleteProduce::new(key),
+                ))
             }
             HotStoreAction::Delete(DeleteContinuations(d)) => {
                 let key = hash_from_vec(&d.channels);
-                HotStoreTrieAction::TrieDeleteAction(
-                    TrieDeleteAction::TrieDeleteConsume(TrieDeleteConsume::new(key)),
-                )
+                HotStoreTrieAction::TrieDeleteAction(TrieDeleteAction::TrieDeleteConsume(
+                    TrieDeleteConsume::new(key),
+                ))
             }
             HotStoreAction::Delete(DeleteJoins(d)) => {
                 let key = hash(&d.channel);
-                HotStoreTrieAction::TrieDeleteAction(
-                    TrieDeleteAction::TrieDeleteJoins(TrieDeleteJoins::new(key)),
-                )
+                HotStoreTrieAction::TrieDeleteAction(TrieDeleteAction::TrieDeleteJoins(
+                    TrieDeleteJoins::new(key),
+                ))
             }
         }
     }

--- a/rspace++/src/rspace/history/history_repository_impl.rs
+++ b/rspace++/src/rspace/history/history_repository_impl.rs
@@ -495,6 +495,14 @@ where
             .expect("History Repository Impl: Unable to acquire roots_repository lock");
         roots_repo.commit(root).map_err(HistoryError::from)
     }
+
+    fn contains_root(&self, root: &Blake2b256Hash) -> Result<bool, HistoryError> {
+        let roots_repo = self
+            .roots_repository
+            .lock()
+            .expect("History Repository Impl: Unable to acquire roots_repository lock");
+        roots_repo.contains_root(root).map_err(HistoryError::from)
+    }
 }
 
 pub fn prepend_bytes(element: u8, _bytes: &[u8]) -> Vec<u8> {

--- a/rspace++/src/rspace/history/root_repository.rs
+++ b/rspace++/src/rspace/history/root_repository.rs
@@ -58,3 +58,102 @@ impl RootRepository {
         self.roots_store.contains_root(root)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+
+    /// Minimal in-memory RootsStore for testing the lookup-vs-set distinction.
+    /// Tracks recorded roots and the current-root pointer separately so tests
+    /// can observe whether `contains_root` updates the pointer (it must not).
+    struct InmemRootsStore {
+        roots: Mutex<HashSet<Blake2b256Hash>>,
+        current: Mutex<Option<Blake2b256Hash>>,
+    }
+
+    impl RootsStore for InmemRootsStore {
+        fn current_root(&self) -> Result<Option<Blake2b256Hash>, RootError> {
+            Ok(self.current.lock().unwrap().clone())
+        }
+
+        fn validate_and_set_current_root(
+            &self,
+            key: Blake2b256Hash,
+        ) -> Result<Option<Blake2b256Hash>, RootError> {
+            if self.roots.lock().unwrap().contains(&key) {
+                *self.current.lock().unwrap() = Some(key.clone());
+                Ok(Some(key))
+            } else {
+                Ok(None)
+            }
+        }
+
+        fn record_root(&self, key: &Blake2b256Hash) -> Result<(), RootError> {
+            self.roots.lock().unwrap().insert(key.clone());
+            *self.current.lock().unwrap() = Some(key.clone());
+            Ok(())
+        }
+
+        fn contains_root(&self, key: &Blake2b256Hash) -> Result<bool, RootError> {
+            Ok(self.roots.lock().unwrap().contains(key))
+        }
+    }
+
+    fn make_repo() -> RootRepository {
+        RootRepository {
+            roots_store: Box::new(InmemRootsStore {
+                roots: Mutex::new(HashSet::new()),
+                current: Mutex::new(None),
+            }),
+        }
+    }
+
+    fn hash_for(seed: u8) -> Blake2b256Hash {
+        let mut bytes = vec![0u8; 32];
+        bytes[0] = seed;
+        Blake2b256Hash::from_bytes(bytes)
+    }
+
+    #[test]
+    fn contains_root_returns_true_for_present_root() {
+        let repo = make_repo();
+        let h = hash_for(1);
+        repo.commit(&h).unwrap();
+        assert!(repo.contains_root(&h).unwrap());
+    }
+
+    #[test]
+    fn contains_root_returns_false_for_absent_root() {
+        let repo = make_repo();
+        assert!(!repo.contains_root(&hash_for(42)).unwrap());
+    }
+
+    /// The contract that distinguishes contains_root from
+    /// validate_and_set_current_root: a positive lookup must NOT mutate the
+    /// current-root pointer. This is the explicit reason the API was added —
+    /// LFS forward-horizon sync calls contains_root in a hot loop and any
+    /// pointer churn would interfere with concurrent reset/checkpoint flows.
+    #[test]
+    fn contains_root_does_not_update_current_root_pointer() {
+        let repo = make_repo();
+        let a = hash_for(1);
+        let b = hash_for(2);
+        // Record both; current-root advances to b after the second commit.
+        repo.commit(&a).unwrap();
+        repo.commit(&b).unwrap();
+        assert_eq!(
+            repo.roots_store.current_root().unwrap(),
+            Some(b.clone()),
+            "precondition: current is b"
+        );
+        // Look up a (present, but not current). Pointer must stay on b.
+        assert!(repo.contains_root(&a).unwrap());
+        assert_eq!(
+            repo.roots_store.current_root().unwrap(),
+            Some(b),
+            "contains_root must not move the current-root pointer"
+        );
+    }
+}

--- a/rspace++/src/rspace/history/root_repository.rs
+++ b/rspace++/src/rspace/history/root_repository.rs
@@ -50,4 +50,11 @@ impl RootRepository {
             }
         }
     }
+
+    /// Pure lookup: returns true if the root is recorded in the store.
+    /// Companion to `validate_and_set_current_root` without the side-effect
+    /// of updating the current-root pointer.
+    pub fn contains_root(&self, root: &Blake2b256Hash) -> Result<bool, RootError> {
+        self.roots_store.contains_root(root)
+    }
 }

--- a/rspace++/src/rspace/history/root_repository.rs
+++ b/rspace++/src/rspace/history/root_repository.rs
@@ -61,9 +61,10 @@ impl RootRepository {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::collections::HashSet;
     use std::sync::Mutex;
+
+    use super::*;
 
     /// Minimal in-memory RootsStore for testing the lookup-vs-set distinction.
     /// Tracks recorded roots and the current-root pointer separately so tests

--- a/rspace++/src/rspace/history/roots_store.rs
+++ b/rspace++/src/rspace/history/roots_store.rs
@@ -16,6 +16,13 @@ pub trait RootsStore: Send + Sync {
     ) -> Result<Option<Blake2b256Hash>, RootError>;
 
     fn record_root(&self, key: &Blake2b256Hash) -> Result<(), RootError>;
+
+    /// Pure lookup: returns true if the root has been recorded in the store.
+    /// Companion to `validate_and_set_current_root` without the side-effect of
+    /// updating the current-root pointer. Used by joiner-side LFS sync to
+    /// check whether a root has already been imported before requesting it
+    /// from peers.
+    fn contains_root(&self, key: &Blake2b256Hash) -> Result<bool, RootError>;
 }
 
 pub struct RootsStoreInstances;
@@ -65,6 +72,10 @@ impl RootsStoreInstances {
                 self.store.put_one(current_root_name, key_bytes.to_vec())?;
 
                 Ok(())
+            }
+
+            fn contains_root(&self, key: &Blake2b256Hash) -> Result<bool, RootError> {
+                Ok(self.store.get_one(&key.bytes())?.is_some())
             }
         }
 

--- a/rspace++/src/rspace/state/exporters/rspace_exporter_items.rs
+++ b/rspace++/src/rspace/state/exporters/rspace_exporter_items.rs
@@ -24,13 +24,18 @@ impl RSpaceExporterItems {
     ) -> StoreItems<Blake2b256Hash, ByteVector> {
         let exporter = exporter.lock().unwrap();
 
-        // Traverse and collect tuple space nodes
-        let nodes = exporter.get_nodes(start_path, skip, take);
+        let nodes = exporter.get_nodes(start_path.clone(), skip, take);
 
-        // Get last entry / raise exception if empty (partial function)
-        let last_entry = nodes.last().expect("EmptyHistoryException");
+        // Empty traversal: subtree exhausted (start_path is a leaf or unknown).
+        // Return last_path == start_path so the requester treats it as a
+        // terminal cursor (no follow-up request, chunk -> Done).
+        let Some(last_entry) = nodes.last() else {
+            return StoreItems {
+                items: vec![],
+                last_path: start_path,
+            };
+        };
 
-        // Load all history items / without leafs
         let history_keys: Vec<_> = nodes.iter().filter(|node| !node.is_leaf).collect();
         let keys: Vec<Blake2b256Hash> = history_keys
             .iter()
@@ -56,13 +61,18 @@ impl RSpaceExporterItems {
     ) -> StoreItems<Blake2b256Hash, ByteVector> {
         let exporter = exporter.lock().unwrap();
 
-        // Traverse and collect tuple space nodes
-        let nodes = exporter.get_nodes(start_path, skip, take);
+        let nodes = exporter.get_nodes(start_path.clone(), skip, take);
 
-        // Get last entry / raise exception if empty (partial function)
-        let last_entry = nodes.last().expect("EmptyHistoryException");
+        // Empty traversal: subtree exhausted (start_path is a leaf or unknown).
+        // Return last_path == start_path so the requester treats it as a
+        // terminal cursor (no follow-up request, chunk -> Done).
+        let Some(last_entry) = nodes.last() else {
+            return StoreItems {
+                items: vec![],
+                last_path: start_path,
+            };
+        };
 
-        // Load all data items / without history
         let data_keys: Vec<_> = nodes.iter().filter(|node| !node.is_leaf).collect();
         let keys: Vec<Blake2b256Hash> = data_keys
             .iter()

--- a/rspace++/tests/history/history_repository_tests.rs
+++ b/rspace++/tests/history/history_repository_tests.rs
@@ -430,6 +430,10 @@ impl RootsStore for InmemRootsStore {
         let _ = roots_lock.insert(key.clone());
         Ok(())
     }
+
+    fn contains_root(&self, key: &Blake2b256Hash) -> Result<bool, RootError> {
+        Ok(self.roots.lock().unwrap().contains(key))
+    }
 }
 
 impl InmemRootsStore {

--- a/shared/src/rust/store/key_value_typed_store_impl.rs
+++ b/shared/src/rust/store/key_value_typed_store_impl.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::HashMap, marker::PhantomData, sync::Arc};
 
-use crate::rust::{BitVector, store::key_value_store::KeyValueStore};
+use crate::rust::{store::key_value_store::KeyValueStore, BitVector};
 
 use super::{key_value_store::KvStoreError, key_value_typed_store::KeyValueTypedStore};
 

--- a/shared/src/rust/store/key_value_typed_store_impl.rs
+++ b/shared/src/rust/store/key_value_typed_store_impl.rs
@@ -120,18 +120,6 @@ where
         })?;
         Ok(matched)
     }
-
-    /// Read a value by its already-encoded key bytes, returning the raw value
-    /// bytes without decoding. Bypasses the typed K/V serialization layer.
-    pub fn raw_get(&self, key_bytes: &[u8]) -> Result<Option<Vec<u8>>, KvStoreError> {
-        self.store.get_one(&key_bytes.to_vec())
-    }
-
-    /// Write a value under its already-encoded key bytes without re-serializing.
-    /// Companion to [`raw_get`].
-    pub fn raw_put(&self, key_bytes: Vec<u8>, value_bytes: Vec<u8>) -> Result<(), KvStoreError> {
-        self.store.put(vec![(key_bytes, value_bytes)])
-    }
 }
 
 impl<K, V> KeyValueTypedStore<K, V> for KeyValueTypedStoreImpl<K, V>

--- a/shared/src/rust/store/key_value_typed_store_impl.rs
+++ b/shared/src/rust/store/key_value_typed_store_impl.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::HashMap, marker::PhantomData, sync::Arc};
 
-use crate::rust::{store::key_value_store::KeyValueStore, BitVector};
+use crate::rust::{BitVector, store::key_value_store::KeyValueStore};
 
 use super::{key_value_store::KvStoreError, key_value_typed_store::KeyValueTypedStore};
 
@@ -119,6 +119,18 @@ where
             }
         })?;
         Ok(matched)
+    }
+
+    /// Read a value by its already-encoded key bytes, returning the raw value
+    /// bytes without decoding. Bypasses the typed K/V serialization layer.
+    pub fn raw_get(&self, key_bytes: &[u8]) -> Result<Option<Vec<u8>>, KvStoreError> {
+        self.store.get_one(&key_bytes.to_vec())
+    }
+
+    /// Write a value under its already-encoded key bytes without re-serializing.
+    /// Companion to [`raw_get`].
+    pub fn raw_put(&self, key_bytes: Vec<u8>, value_bytes: Vec<u8>) -> Result<(), KvStoreError> {
+        self.store.put(vec![(key_bytes, value_bytes)])
     }
 }
 


### PR DESCRIPTION
## Summary

Joiner-side LFS sync hardening so observers and joiners can attach to busy multi-bonded shards without `DAGStorageMissingHash`, `RootRepositoryDivergence`, `KvStoreError`, or `UnknownRootError`.

The joiner-side sync previously only fetched blocks within `deploy_lifespan` of the LFB and only the LFB's own rspace post-state. That left two gaps under load:

1. **Side-branch ancestors** outside the deploy-lifespan window were rejected by `lfs_block_requester`'s lower-bound, so subsequent gossip blocks referencing them triggered `DAGStorageMissingHash` / `KvStoreError` on the joiner.
2. **Ancestor rspace history** for blocks reachable as future parents was never fetched, so validation of a child whose pre-state is an ancestor's post-state hit `RootRepositoryDivergence` / `UnknownRootError`. Multi-parent merge intermediates (the proposer-side `dag_merger::merge` result, recorded via `do_checkpoint`'s `store_root`) made this worse — those hashes are not any block's `post_state_hash` and would never reach a post-state-only joiner.

This PR closes both gaps, bounds the parent-depth window so the forward-horizon is finite in production, and includes a correctness fix to the horizon orchestrator itself (multi-root pagination collision — see commit `1d4766dd` and the "Orchestrator correctness fix" section below).

## Commits (13)

```
1d4766dd fix(lfs): multi-root pagination tracking in horizon orchestrator
92f333ee ci: enable test_contract_lifecycle (PR #491 landed on staging)
38748e58 ci: track system-integration refactor branch + use canonical baseline
9ebb9a4d style: rustfmt across PR #1 files
8c4bbee9 test(lfs): unit coverage for forward-horizon orchestrator + contains_root + lower_bound helper
8d965715 chore(log): drop emoji from LFS log lines
6af06edc fix(store): route mergeable-entry transfer through typed path
4bb73209 feat(lfs): extend lower_bound to forward-horizon for full ancestor sync
04d63505 feat(lfs): proactive forward-horizon rspace history sync
6a6ed1fb feat(lfs): sync mergeable-channels store from peers per-block
5bc90821 feat(node): bound max-parent-depth = 100 in defaults
c83f7cd1 feat(validate): enforce parent-depth on validator side
1be376d4 feat(rspace): contains_root API for joiner-side LFS sync
```

Reading bottom-up:

- **`contains_root` API** — `RootRepository::contains_root(root) -> bool` plumbed through `RootsStore` → `RootRepository` → `HistoryRepository` → `RuntimeManager::has_root`. Pure lookup; needed by the joiner so the forward-horizon orchestrator can skip roots it already has.
- **Parent-depth validator check** — `validate::parents` rejects blocks whose parents fall outside `max_parent_depth + depth_buffer` of the highest tip. 6 new RED→GREEN tests + 6 existing tests updated. Honors the `i32::MAX` sentinel (depth check disabled).
- **Default `max-parent-depth = 100`** — `node/src/main/resources/defaults.conf` flips from `2147483647` (= `i32::MAX`) to `100` so production nodes get the bounded horizon by default.
- **Mergeable-channels per-block sync** — adds `MergeableEntryRequest` / `MergeableEntryResponse` protocol messages. Joiner fires a paired mergeable request after each `BlockMessage` lands; peer ships the raw bincode bytes from its `mergeable_store`. Replaces the broken `replay_blocks_for_mergeable_channels` path.
- **Forward-horizon rspace history sync** — new `compute_forward_horizon_roots` reachability calc + the `lfs_horizon_requester` streaming-parallel orchestrator (modeled on `lfs_tuple_space_requester`). Joiner imports both `pre_state_hash` and `post_state_hash` for every block in the horizon — pre-states are the multi-parent merge intermediates that wouldn't otherwise reach the joiner.
- **Lower-bound extension** — `lfs_block_requester` accepts blocks down to `min(deploy_lifespan, max_parent_depth + depth_buffer)` rather than just `deploy_lifespan`. The `lfs_min_block_number` helper (extracted as a pure function in the test commit) computes this.
- **Typed-store routing** — cleans up the raw `get/put` shortcuts in `KeyValueTypedStoreImpl`. Renames `*_raw` → `*_bytes`. Same wire bytes, less surface area on the typed store.
- **Drop emoji from LFS logs** — personal-prefs cleanup.
- **Test coverage** — 24 new unit tests across 5 files (8 ST state machine + 5 stream behavioral with mock + 6 `lfs_min_block_number` + 2 pre-state inclusion + 3 `contains_root`). Includes a small race fix in `initializing_spec.rs` (500ms yield between block + mergeable response sends to avoid a `tokio::select!` ordering race that silently dropped the mergeable response).
- **rustfmt** — final pass across the touched files.
- **CI configuration** — track the integration-test framework's refactor branch as the canonical baseline; re-enable `test_contract_lifecycle` now that PR #491 (bitmask-OR mergeable channels) landed on rust/staging.

### Orchestrator correctness fix (`1d4766dd`)

Radix-trie pagination cursors are content-addressed and routinely shared across roots: many roots' first chunks land on the same intermediate cursor, and there is exactly one wire request for that cursor's continuation. The orchestrator's original `HashMap<StatePartPath, Blake2b256Hash>` mapping silently dropped all but the last writer for a shared cursor — so `set_root` fired for only one root while the rest were left with imported trie data but no roots-store tag. Validation later failed with `RootRepositoryDivergence` on those abandoned roots.

Replaces `path_to_root` with `HashMap<StatePartPath, HashSet<Blake2b256Hash>>`: a cursor inherits the full root set through pagination, the byzantine-empty check applies per-root on the shared chunk, and the terminal completion fires `set_root` for every associated root. Adds a unit-level regression test (`stream_completes_all_roots_when_first_chunks_share_last_path`) — feeds two roots whose first chunks share a continuation cursor; asserts `set_root` fires for both.

This commit was originally on PR #510 and has been moved here since it modifies the orchestrator file introduced by this PR.

## Test plan

- [x] `cargo test --release --workspace` — **2182+ passed, 0 failed** (across 70 test suites, plus the new pagination regression test on top)
- [x] `cargo test --release -p casper --lib -- engine::lfs_horizon_requester::tests` — 14/14 passed (includes `stream_completes_all_roots_when_first_chunks_share_last_path`)
- [x] `cargo build --release -p casper -p rspace_plus_plus -p shared` — clean after rustfmt
- [x] Integration: fresh observer LFS-syncs cleanly against an actively producing 3-validator shard with background load. Verifies bonds-map agreement at observer's LFB, deep cross-node post-state agreement on observer's last 10 finalized ancestor blocks, and post-settle drift convergence. Autouse log scanner gates on `DAGStorageMissingHash` / `RootRepositoryDivergence` / `KvStoreError` / `UnknownRootError`. Passes 2/2 consecutive runs.
- [x] Integration B5 (`test_bonding_validators` against PR #510 binary, which transitively includes this PR's orchestrator fix): 5/5 stability runs passed — zero `RootRepositoryDivergence` occurrences across all runs, confirming the pagination fix end-to-end.

Co-Authored-By: Claude <noreply@anthropic.com>
