### PR TITLE
fix(validation): cascade-invalidate + ReplayCache mergeable-entry safety

### DIFF
--- a/casper/src/rust/block_status.rs
+++ b/casper/src/rust/block_status.rs
@@ -58,6 +58,11 @@ pub enum InvalidBlock {
     InvalidBondsCache,
     InvalidBlockHash,
     InvalidRejectedDeploy,
+    // Cascading invalidation: this block's parent_hash_list contains one or
+    // more blocks already recorded as invalid. The chain through them is
+    // unviable, so this block is also invalid. NOT slashable — the creator
+    // may not have known the parent was invalid in their view.
+    InvalidParent,
     ContainsExpiredDeploy,
     ContainsTimeExpiredDeploy,
     ContainsFutureDeploy,

--- a/casper/src/rust/blocks/block_processor.rs
+++ b/casper/src/rust/blocks/block_processor.rs
@@ -56,6 +56,30 @@ pub struct BlockProcessor<T: TransportLayer + Send + Sync> {
     dependencies: BlockProcessorDependencies<T>,
 }
 
+/// Outcome of the parent-dependency gate. Determines whether a block can be
+/// validated now, must wait, or has already been disqualified by an invalid
+/// ancestor.
+#[derive(Debug, Clone)]
+pub enum Readiness {
+    /// All parents are present in the DAG and recorded valid. Block may be
+    /// validated immediately.
+    Ready,
+    /// One or more parents are missing locally (need fetch) or in flight (in
+    /// the casper buffer). The block must wait — commit to buffer with the
+    /// dependency set, request missing.
+    Waiting {
+        deps_to_fetch: HashSet<BlockHash>,
+        deps_in_buffer: HashSet<BlockHash>,
+    },
+    /// One or more parents are recorded invalid (in `invalid_blocks_set` or
+    /// the equivocation tracker). The chain through them is unviable, so
+    /// this block is also invalid via cascading invalidation. The block
+    /// MUST NOT enter validation — its parents have no mergeable-channels
+    /// entries written, which is exactly the race that produced the original
+    /// `Missing mergeable entry` cascade. See `check_dependencies_with_effects`.
+    InvalidParents(HashSet<BlockHash>),
+}
+
 const CASPER_BUFFER_PRUNE_INTERVAL_MS: u64 = 5_000;
 const CASPER_BUFFER_STALE_TTL_MS: u64 = 180_000;
 const CASPER_BUFFER_MAX_APPROX_NODES: usize = 16_384;
@@ -64,6 +88,7 @@ const CASPER_BUFFER_STALE_PRUNED_METRIC: &str = "casper.buffer.stale-pruned";
 const CASPER_BUFFER_OVERFLOW_PRUNED_METRIC: &str = "casper.buffer.overflow-pruned";
 const CASPER_BUFFER_APPROX_NODES_METRIC: &str = "casper.buffer.approx-nodes";
 const CASPER_BUFFER_DEPENDENCY_LOOP_PRUNED_METRIC: &str = "casper.buffer.dependency-loop-pruned";
+const BLOCK_CASCADE_INVALIDATED_METRIC: &str = "casper.block-processor.cascade-invalidated";
 const MISSING_DEPENDENCY_ATTEMPTS_MAX: u32 = 32;
 const MISSING_DEPENDENCY_QUARANTINE_MS: u64 = 10_000;
 const MALLOC_TRIM_INTERVAL_BLOCKS: u64 = 8;
@@ -178,54 +203,79 @@ impl<T: TransportLayer + Send + Sync> BlockProcessor<T> {
             return Ok(false);
         }
 
-        let (is_ready, deps_to_fetch, deps_in_buffer) = self
+        let readiness = self
             .dependencies
-            .get_non_validated_dependencies(casper, block)
+            .get_non_validated_dependencies(casper.clone(), block)
             .await?;
 
-        if is_ready {
-            self.dependencies
-                .clear_missing_dependency_attempts(&block.block_hash)?;
-            // store pendant block in buffer, it will be removed once block is validated and added to DAG
-            self.dependencies.commit_to_buffer(block, None).await?;
-        } else {
-            if self
-                .dependencies
-                .register_missing_dependency_attempt(&block.block_hash)?
-            {
-                tracing::warn!(
-                    "Throttling block {} after {} missing-dependency checks (keeping in buffer).",
-                    PrettyPrinter::build_string(CasperMessage::BlockMessage(block.clone()), true),
-                    MISSING_DEPENDENCY_ATTEMPTS_MAX
-                );
-                metrics::counter!(CASPER_BUFFER_DEPENDENCY_LOOP_PRUNED_METRIC, "source" => BLOCK_PROCESSOR_METRICS_SOURCE, "reason" => "attempts")
-                    .increment(1);
+        match readiness {
+            Readiness::Ready => {
                 self.dependencies
                     .clear_missing_dependency_attempts(&block.block_hash)?;
-                self.dependencies
-                    .mark_missing_dependency_quarantine(&block.block_hash)?;
+                // store pendant block in buffer, it will be removed once block is validated and added to DAG
+                self.dependencies.commit_to_buffer(block, None).await?;
+                Ok(true)
             }
+            Readiness::Waiting {
+                deps_to_fetch,
+                deps_in_buffer,
+            } => {
+                if self
+                    .dependencies
+                    .register_missing_dependency_attempt(&block.block_hash)?
+                {
+                    tracing::warn!(
+                        "Throttling block {} after {} missing-dependency checks (keeping in buffer).",
+                        PrettyPrinter::build_string(CasperMessage::BlockMessage(block.clone()), true),
+                        MISSING_DEPENDENCY_ATTEMPTS_MAX
+                    );
+                    metrics::counter!(CASPER_BUFFER_DEPENDENCY_LOOP_PRUNED_METRIC, "source" => BLOCK_PROCESSOR_METRICS_SOURCE, "reason" => "attempts")
+                        .increment(1);
+                    self.dependencies
+                        .clear_missing_dependency_attempts(&block.block_hash)?;
+                    self.dependencies
+                        .mark_missing_dependency_quarantine(&block.block_hash)?;
+                }
 
-            // associate parents with new block in casper buffer
-            let mut all_deps = deps_to_fetch.clone();
-            all_deps.extend(deps_in_buffer.clone());
-            self.dependencies
-                .commit_to_buffer(block, Some(all_deps))
-                .await?;
-            self.dependencies
-                .request_missing_dependencies(&deps_to_fetch)
-                .await?;
-            // Recovery path: if dependency graph is stuck in buffer (no fresh deps to fetch),
-            // force a network re-request for buffered dependencies.
-            if deps_to_fetch.is_empty() && !deps_in_buffer.is_empty() {
+                let mut all_deps = deps_to_fetch.clone();
+                all_deps.extend(deps_in_buffer.clone());
                 self.dependencies
-                    .recover_stale_buffer_dependencies(&deps_in_buffer)
+                    .commit_to_buffer(block, Some(all_deps))
                     .await?;
+                self.dependencies
+                    .request_missing_dependencies(&deps_to_fetch)
+                    .await?;
+                // Recovery path: if dependency graph is stuck in buffer (no fresh deps to fetch),
+                // force a network re-request for buffered dependencies.
+                if deps_to_fetch.is_empty() && !deps_in_buffer.is_empty() {
+                    self.dependencies
+                        .recover_stale_buffer_dependencies(&deps_in_buffer)
+                        .await?;
+                }
+                self.dependencies.ack_processed(block).await?;
+                Ok(false)
             }
-            self.dependencies.ack_processed(block).await?;
+            Readiness::InvalidParents(invalid_parents) => {
+                tracing::warn!(
+                    "Block {} cascading-invalidated: parent(s) {} recorded invalid.",
+                    PrettyPrinter::build_string_bytes(&block.block_hash),
+                    PrettyPrinter::build_string_hashes(
+                        &invalid_parents
+                            .iter()
+                            .map(|h| h.as_ref().to_vec())
+                            .collect::<Vec<_>>()
+                    )
+                );
+                metrics::counter!(BLOCK_CASCADE_INVALIDATED_METRIC, "source" => BLOCK_PROCESSOR_METRICS_SOURCE)
+                    .increment(1);
+                let dag = self.dependencies.block_dag_storage.get_representation();
+                self.dependencies
+                    .effects_for_invalid_block(casper, block, &InvalidBlock::InvalidParent, &dag)
+                    .await?;
+                self.dependencies.ack_processed(block).await?;
+                Ok(false)
+            }
         }
-
-        Ok(is_ready)
     }
 
     /// validate block and invoke all effects required
@@ -281,12 +331,18 @@ impl<T: TransportLayer + Send + Sync> BlockProcessor<T> {
                 match invalid_block {
                     BlockError::Invalid(i) => {
                         self.dependencies
-                            .effects_for_invalid_block(casper, block, i, &snapshot)
+                            .effects_for_invalid_block(casper, block, i, &snapshot.dag)
                             .await
                     }
                     BlockError::BlockException(ref err) => {
-                        tracing::warn!(
-                            "Block {} raised BlockException ({}); recording as InvalidTransaction to prevent dependent-block stall.",
+                        // Post gating-fix this should be unreachable: the dependency
+                        // gate in `check_dependencies_with_effects` rejects children
+                        // of invalid parents before validation runs, so the only
+                        // remaining mergeable-entry write race is structurally
+                        // impossible. Surface loudly if this ever fires — it points
+                        // at a regression in the gate or a new exception path.
+                        tracing::error!(
+                            "UNEXPECTED: Block {} raised BlockException post-gate-fix ({}); falling back to InvalidTransaction recording. Investigate as a regression.",
                             PrettyPrinter::build_string_bytes(&block.block_hash),
                             err
                         );
@@ -295,7 +351,7 @@ impl<T: TransportLayer + Send + Sync> BlockProcessor<T> {
                                 casper,
                                 block,
                                 &InvalidBlock::InvalidTransaction,
-                                &snapshot,
+                                &snapshot.dag,
                             )
                             .await
                     }
@@ -441,19 +497,36 @@ impl<T: TransportLayer + Send + Sync> BlockProcessorDependencies<T> {
     }
 
     /// Equivalent to Scala's: getNonValidatedDependencies = (c: Casper[F], b: BlockMessage) => { ... }
+    /// Classify a block's dependencies into one of three buckets: `Ready`
+    /// (all parents valid-in-DAG, all referenced hashes locally known),
+    /// `Waiting` (some referenced hashes missing or in flight), or
+    /// `InvalidParents` (one or more *parent* hashes recorded invalid).
+    ///
+    /// The InvalidParents bucket is what prevents the parent-child
+    /// mergeable-entry race: an invalid parent has no mergeable-channels
+    /// entry, so the child must not enter validation against it; the caller
+    /// cascade-invalidates instead.
+    ///
+    /// Justifications are *not* state dependencies — they only need to be
+    /// locally known (DAG, eq tracker, or invalid set is fine). So an
+    /// invalid justification does NOT trigger cascade; only invalid parents
+    /// do.
     pub async fn get_non_validated_dependencies(
         &self,
         casper: Arc<dyn Casper + Send + Sync + 'static>,
         block: &BlockMessage,
-    ) -> Result<(bool, HashSet<BlockHash>, HashSet<BlockHash>), CasperError> {
+    ) -> Result<Readiness, CasperError> {
         let all_deps = proto_util::dependencies_hashes_of(block);
+        let parent_hashes: HashSet<BlockHash> =
+            proto_util::parent_hashes(block).into_iter().collect();
 
-        // in addition, equivocation tracker has to be checked, as admissible equivocations are not stored in DAG
+        // Equivocation-tracked hashes (admissible equivocations live here even
+        // when also recorded in invalid_blocks_set; ignorable ones may not be
+        // in the local DAG at all).
         let equivocation_hashes: HashSet<BlockHash> = {
             self.block_dag_storage
                 .access_equivocations_tracker(|tracker| {
                     let equivocation_records = tracker.data()?;
-                    // Use HashSet to ensure uniqueness and O(1) lookup, just like Scala's Set
                     let hashes: HashSet<BlockHash> = equivocation_records
                         .iter()
                         .flat_map(|record| record.equivocation_detected_block_hashes.iter())
@@ -463,8 +536,6 @@ impl<T: TransportLayer + Send + Sync> BlockProcessorDependencies<T> {
                 })
                 .map_err(|e| CasperError::RuntimeError(e.to_string()))?
         };
-        // Invalid blocks are already known/built into Casper state and should not be re-fetched
-        // as unresolved dependencies.
         let invalid_block_hashes: HashSet<BlockHash> = {
             self.block_dag_storage
                 .get_representation()
@@ -474,95 +545,95 @@ impl<T: TransportLayer + Send + Sync> BlockProcessorDependencies<T> {
                 .collect()
         };
 
-        let deps_in_buffer_all: Vec<BlockHash> = {
-            all_deps
-                .iter()
-                .filter_map(|dep| {
-                    let block_hash_serde = BlockHashSerde(dep.clone());
-                    if self.casper_buffer.contains(&block_hash_serde)
-                        || self.casper_buffer.is_pendant(&block_hash_serde)
-                    {
-                        Some(dep.clone())
-                    } else {
-                        None
-                    }
-                })
-                .collect()
-        };
-
-        let deps_in_dag: Vec<BlockHash> = all_deps
+        // Cascade only on invalid PARENTS — not justifications. A parent
+        // contributes its post-state to the merge, so an invalid parent
+        // (no mergeable-channels entry written) makes the child unviable.
+        // A justification just acknowledges a validator's latest message;
+        // an invalid justification is fine and does not need a mergeable entry.
+        let invalid_parents: HashSet<BlockHash> = parent_hashes
             .iter()
-            .filter_map(|dep| {
-                if casper.dag_contains(dep) {
-                    Some(dep.clone())
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        let deps_in_eq_tracker: Vec<BlockHash> = all_deps
-            .iter()
-            .filter(|&dep| equivocation_hashes.contains(dep))
-            .cloned()
-            .collect();
-        let deps_in_invalid_set: Vec<BlockHash> = all_deps
-            .iter()
-            .filter(|&dep| invalid_block_hashes.contains(dep))
+            .filter(|&p| invalid_block_hashes.contains(p) || equivocation_hashes.contains(p))
             .cloned()
             .collect();
 
-        let mut deps_validated: Vec<BlockHash> = deps_in_dag.clone();
-        deps_validated.extend(deps_in_eq_tracker.iter().cloned());
-        deps_validated.extend(deps_in_invalid_set.iter().cloned());
-
-        // If a dependency is already validated, it should not be treated as a blocking
-        // buffer dependency even if stale buffer relations still exist for that hash.
-        let deps_in_buffer: Vec<BlockHash> = deps_in_buffer_all
-            .iter()
-            .filter(|dep| !deps_validated.contains(dep))
-            .cloned()
-            .collect();
-
-        let deps_to_fetch: Vec<BlockHash> = all_deps
-            .iter()
-            .filter(|&dep| !deps_in_buffer.contains(dep))
-            .filter(|&dep| !deps_validated.contains(dep))
-            .cloned()
-            .collect();
-
-        let ready = deps_to_fetch.is_empty() && deps_in_buffer.is_empty();
-
-        if !ready {
+        if !invalid_parents.is_empty() {
             tracing::debug!(
-                "Block {} waiting on missing dependencies. To fetch: {}. In buffer: {}. Validated: {}.",
+                "Block {} has invalid parent(s): {}",
                 PrettyPrinter::build_string(CasperMessage::BlockMessage(block.clone()), true),
                 PrettyPrinter::build_string_hashes(
-                    &deps_to_fetch
-                        .iter()
-                        .map(|h| h.as_ref().to_vec())
-                        .collect::<Vec<_>>()
-                ),
-                PrettyPrinter::build_string_hashes(
-                    &deps_in_buffer
-                        .iter()
-                        .map(|h| h.as_ref().to_vec())
-                        .collect::<Vec<_>>()
-                ),
-                PrettyPrinter::build_string_hashes(
-                    &deps_validated
+                    &invalid_parents
                         .iter()
                         .map(|h| h.as_ref().to_vec())
                         .collect::<Vec<_>>()
                 )
             );
+            return Ok(Readiness::InvalidParents(invalid_parents));
         }
 
-        Ok((
-            ready,
-            deps_to_fetch.into_iter().collect::<HashSet<BlockHash>>(),
-            deps_in_buffer.into_iter().collect::<HashSet<BlockHash>>(),
-        ))
+        // For Ready/Waiting partitioning, "satisfied" means the dep is
+        // locally known: in DAG (valid or invalid), in the eq tracker, or
+        // in invalid_blocks_set. Justifications can be any of these.
+        // Parents at this point are guaranteed valid (cascade returned above
+        // for invalid ones), so an in-DAG parent has its mergeable entry —
+        // closing the parent-child race.
+        let deps_validated: HashSet<BlockHash> = all_deps
+            .iter()
+            .filter(|&dep| {
+                casper.dag_contains(dep)
+                    || invalid_block_hashes.contains(dep)
+                    || equivocation_hashes.contains(dep)
+            })
+            .cloned()
+            .collect();
+
+        let deps_in_buffer: HashSet<BlockHash> = all_deps
+            .iter()
+            .filter(|&dep| !deps_validated.contains(dep))
+            .filter(|dep| {
+                let block_hash_serde = BlockHashSerde((*dep).clone());
+                self.casper_buffer.contains(&block_hash_serde)
+                    || self.casper_buffer.is_pendant(&block_hash_serde)
+            })
+            .cloned()
+            .collect();
+
+        let deps_to_fetch: HashSet<BlockHash> = all_deps
+            .iter()
+            .filter(|dep| !deps_validated.contains(*dep) && !deps_in_buffer.contains(*dep))
+            .cloned()
+            .collect();
+
+        if deps_to_fetch.is_empty() && deps_in_buffer.is_empty() {
+            return Ok(Readiness::Ready);
+        }
+
+        tracing::debug!(
+            "Block {} waiting on missing dependencies. To fetch: {}. In buffer: {}. Validated: {}.",
+            PrettyPrinter::build_string(CasperMessage::BlockMessage(block.clone()), true),
+            PrettyPrinter::build_string_hashes(
+                &deps_to_fetch
+                    .iter()
+                    .map(|h| h.as_ref().to_vec())
+                    .collect::<Vec<_>>()
+            ),
+            PrettyPrinter::build_string_hashes(
+                &deps_in_buffer
+                    .iter()
+                    .map(|h| h.as_ref().to_vec())
+                    .collect::<Vec<_>>()
+            ),
+            PrettyPrinter::build_string_hashes(
+                &deps_validated
+                    .iter()
+                    .map(|h| h.as_ref().to_vec())
+                    .collect::<Vec<_>>()
+            )
+        );
+
+        Ok(Readiness::Waiting {
+            deps_to_fetch,
+            deps_in_buffer,
+        })
     }
 
     /// Equivalent to Scala's: commitToBuffer = (b: BlockMessage, deps: Option[Set[BlockHash]]) => { ... }
@@ -856,9 +927,9 @@ impl<T: TransportLayer + Send + Sync> BlockProcessorDependencies<T> {
         casper: Arc<dyn Casper + Send + Sync + 'static>,
         block: &BlockMessage,
         invalid_block: &InvalidBlock,
-        snapshot: &CasperSnapshot,
+        dag: &KeyValueDagRepresentation,
     ) -> Result<KeyValueDagRepresentation, CasperError> {
-        let dag = casper.handle_invalid_block(block, invalid_block, &snapshot.dag)?;
+        let dag = casper.handle_invalid_block(block, invalid_block, dag)?;
 
         // Equivalent to Scala's: CommUtil[F].sendBlockHash(b.blockHash, b.sender)
         if let Err(err) = self

--- a/casper/src/rust/multi_parent_casper_impl.rs
+++ b/casper/src/rust/multi_parent_casper_impl.rs
@@ -1157,6 +1157,18 @@ impl<T: TransportLayer + Send + Sync> Casper for MultiParentCasperImpl<T> {
                 )
             }
 
+            // Cascading invalidation. Not slashable (the creator may not have
+            // known the parent was invalid in their view), but MUST be inserted
+            // into the DAG with invalid=true so further descendants also
+            // cascade — otherwise the chain can re-enter validation and hit
+            // the original parent-child mergeable-entry race.
+            InvalidBlock::InvalidParent => handle_invalid_block_effect(
+                &self.block_dag_storage,
+                &self.casper_buffer_storage,
+                status,
+                block,
+            ),
+
             _ => {
                 let block_hash_serde = BlockHashSerde(block.block_hash.clone());
                 self.casper_buffer_storage.remove(block_hash_serde)?;

--- a/casper/src/rust/util/rholang/runtime_manager.rs
+++ b/casper/src/rust/util/rholang/runtime_manager.rs
@@ -642,6 +642,16 @@ impl RuntimeManager {
         }
 
         // Step 2: Check replay cache (deterministic replay delta)
+        //
+        // Same safety constraint as StateHashCache (Step 1): a fast-return
+        // here would skip `save_mergeable_channels`, leaving a block in the
+        // DAG with no mergeable entry. Subsequent children whose validation
+        // reads this block's mergeable entry would fail with
+        // "Missing mergeable entry ..." — the exact failure mode the cache
+        // was designed not to introduce. Mirror the StateHashCache check:
+        // only fast-return if the mergeable entry already exists for this
+        // block key; otherwise fall through to full replay so the entry
+        // gets written.
         let replay_cache_key = ReplayCacheKey::new(
             start_hash.clone(),
             sender.bytes.to_vec(),
@@ -650,18 +660,37 @@ impl RuntimeManager {
         );
         if let Some(ref cache) = self.replay_cache {
             if let Some(entry) = cache.get(&replay_cache_key) {
-                tracing::info!("[CACHE] ReplayCache hit for sender seq={}", seq_num);
+                let mergeable_key = MergeableKey {
+                    state_hash: StateHashSerde(entry.post_state.clone()),
+                    creator: sender.bytes.clone(),
+                    seq_num,
+                };
+                let mergeable_key_encoded = bincode::serialize(&mergeable_key).map_err(|e| {
+                    CasperError::KvStoreError(KvStoreError::SerializationError(e.to_string()))
+                })?;
 
-                // Rig the replay runtime with cached event log
-                let replay_runtime = self.spawn_replay_runtime().await;
-                let rspace_events: Vec<_> = entry
-                    .event_log
-                    .iter()
-                    .map(crate::rust::util::event_converter::to_rspace_event)
-                    .collect();
-                replay_runtime.rig(rspace_events).await?;
+                if self
+                    .mergeable_store
+                    .contains_key(mergeable_key_encoded.clone())?
+                {
+                    tracing::info!("[CACHE] ReplayCache hit for sender seq={}", seq_num);
 
-                return Ok(entry.post_state);
+                    // Rig the replay runtime with cached event log
+                    let replay_runtime = self.spawn_replay_runtime().await;
+                    let rspace_events: Vec<_> = entry
+                        .event_log
+                        .iter()
+                        .map(crate::rust::util::event_converter::to_rspace_event)
+                        .collect();
+                    replay_runtime.rig(rspace_events).await?;
+
+                    return Ok(entry.post_state);
+                }
+
+                tracing::warn!(
+                    "[CACHE] ReplayCache hit without mergeable entry for seq={}; falling back to full replay",
+                    seq_num
+                );
             }
         }
 

--- a/casper/tests/blocks/block_processor_test.rs
+++ b/casper/tests/blocks/block_processor_test.rs
@@ -3,23 +3,35 @@ use crate::helper::{
     block_dag_storage_fixture::with_storage, block_generator::create_genesis_block,
     block_util::generate_validator,
 };
+use async_trait::async_trait;
 use block_storage::rust::{
     casperbuffer::casper_buffer_key_value_storage::CasperBufferKeyValueStorage,
-    dag::block_dag_key_value_storage::BlockDagKeyValueStorage,
+    dag::block_dag_key_value_storage::{
+        BlockDagKeyValueStorage, DeployId, KeyValueDagRepresentation,
+    },
 };
 use casper::rust::{
-    blocks::block_processor::BlockProcessorDependencies, engine::block_retriever::BlockRetriever,
+    block_status::{BlockError, InvalidBlock, ValidBlock},
+    blocks::block_processor::{BlockProcessor, BlockProcessorDependencies},
+    casper::{test_helpers::TestCasperWithSnapshot, Casper, CasperSnapshot, DeployError},
+    engine::block_retriever::BlockRetriever,
+    errors::CasperError,
 };
 use comm::rust::{
     rp::connect::{Connections, ConnectionsCell},
     test_instances::{create_rp_conf_ask, TransportLayerStub},
 };
+use crypto::rust::signatures::signed::Signed;
 use models::rust::{
     block_hash::BlockHash,
-    casper::protocol::casper_message::{BlockMessage, Bond, Header},
+    casper::protocol::casper_message::{BlockMessage, Bond, DeployData, Header},
 };
-use rspace_plus_plus::rspace::shared::{
-    in_mem_store_manager::InMemoryStoreManager, key_value_store_manager::KeyValueStoreManager,
+use prost::bytes::Bytes;
+use rspace_plus_plus::rspace::{
+    history::Either,
+    shared::{
+        in_mem_store_manager::InMemoryStoreManager, key_value_store_manager::KeyValueStoreManager,
+    },
 };
 use shared::rust::store::key_value_typed_store_impl::KeyValueTypedStoreImpl;
 use std::{
@@ -31,6 +43,10 @@ struct TestFixture {
     dependencies: BlockProcessorDependencies<TransportLayerStub>,
     genesis: BlockMessage,
     test_block: BlockMessage,
+    /// Clone of the same `BlockDagKeyValueStorage` that lives inside
+    /// `dependencies`. Tests that need to pre-populate the dag (e.g. mark a
+    /// parent invalid before exercising the dependency gate) use this handle.
+    block_dag_storage_handle: BlockDagKeyValueStorage,
 }
 
 impl TestFixture {
@@ -113,6 +129,13 @@ impl TestFixture {
             None,
         );
 
+        // Clone the dag-storage handle before moving the original into
+        // BlockProcessorDependencies. Both handles point at the same
+        // underlying KV stores (BlockDagKeyValueStorage is `Clone` because
+        // its inner state is `Arc`/`Mutex`-shared). Tests use the cloned
+        // handle to pre-populate dag state observable by the dependencies.
+        let block_dag_storage_handle = block_dag_storage.clone();
+
         // Create unified dependencies
         let dependencies = BlockProcessorDependencies::new(
             block_store,
@@ -128,6 +151,7 @@ impl TestFixture {
             dependencies,
             genesis,
             test_block,
+            block_dag_storage_handle,
         }
     }
 
@@ -370,4 +394,144 @@ async fn block_processor_components_should_work_together() {
 
     // All operations should complete successfully
     assert!(true, "All components should work together");
+}
+
+// ── Cascading-invalidation gate (parent-child mergeable-entry race) ──
+//
+// A parent recorded as invalid in the local DAG never had its mergeable-
+// channels entry written (save_mergeable_channels runs inside compute_state
+// only on the success path). If a child of such a parent is allowed through
+// the dependency gate, its validation will fail with KvStoreError::KeyNotFound
+// looking up the parent's entry, and the resulting BlockException would be
+// mis-recorded as InvalidTransaction (slashable) — and the cascade would
+// continue down every descendant.
+//
+// `check_dependencies_with_effects` must instead detect the invalid parent
+// at the gate and cascade-invalidate the child as InvalidParent (non-
+// slashable), so validation never runs and the race never fires.
+
+struct CascadeMockCasper {
+    handle_invalid_block_calls: Arc<Mutex<Vec<InvalidBlock>>>,
+}
+
+impl CascadeMockCasper {
+    fn new() -> Self {
+        Self {
+            handle_invalid_block_calls: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+#[async_trait]
+impl Casper for CascadeMockCasper {
+    async fn get_snapshot(&self) -> Result<CasperSnapshot, CasperError> {
+        Ok(TestCasperWithSnapshot::create_empty_snapshot())
+    }
+    fn contains(&self, _h: &BlockHash) -> bool {
+        false
+    }
+    fn dag_contains(&self, _h: &BlockHash) -> bool {
+        // Not consulted on the InvalidParent path: get_non_validated_dependencies
+        // identifies invalid parents via the dag-storage invalid_blocks_map
+        // before any dag_contains lookup happens.
+        false
+    }
+    fn buffer_contains(&self, _h: &BlockHash) -> bool {
+        false
+    }
+    fn get_approved_block(&self) -> Result<&BlockMessage, CasperError> {
+        Err(CasperError::RuntimeError("not used in test".into()))
+    }
+    fn deploy(&self, _d: Signed<DeployData>) -> Result<Either<DeployError, DeployId>, CasperError> {
+        unimplemented!("not exercised on the cascade path")
+    }
+    async fn estimator(
+        &self,
+        _: &mut KeyValueDagRepresentation,
+    ) -> Result<Vec<BlockHash>, CasperError> {
+        Ok(Vec::new())
+    }
+    fn get_version(&self) -> i64 {
+        1
+    }
+    async fn validate(
+        &self,
+        _block: &BlockMessage,
+        _snapshot: &mut CasperSnapshot,
+    ) -> Result<Either<BlockError, ValidBlock>, CasperError> {
+        // Validation must NOT be reached when a parent is invalid. If the
+        // gate ever lets the block through, this method's invocation would
+        // be a regression — but the test asserts via the recorded
+        // handle_invalid_block calls, not via panicking here.
+        Ok(Either::Right(ValidBlock::Valid))
+    }
+    async fn validate_self_created(
+        &self,
+        _b: &BlockMessage,
+        _s: &mut CasperSnapshot,
+        _pre: Bytes,
+        _post: Bytes,
+    ) -> Result<Either<BlockError, ValidBlock>, CasperError> {
+        unimplemented!("not exercised on the cascade path")
+    }
+    async fn handle_valid_block(
+        &self,
+        _b: &BlockMessage,
+    ) -> Result<KeyValueDagRepresentation, CasperError> {
+        unimplemented!("not reached on the cascade path")
+    }
+    fn handle_invalid_block(
+        &self,
+        _b: &BlockMessage,
+        status: &InvalidBlock,
+        dag: &KeyValueDagRepresentation,
+    ) -> Result<KeyValueDagRepresentation, CasperError> {
+        self.handle_invalid_block_calls
+            .lock()
+            .unwrap()
+            .push(status.clone());
+        Ok(dag.clone())
+    }
+    fn get_dependency_free_from_buffer(&self) -> Result<Vec<BlockMessage>, CasperError> {
+        Ok(Vec::new())
+    }
+    fn get_all_from_buffer(&self) -> Result<Vec<BlockMessage>, CasperError> {
+        Ok(Vec::new())
+    }
+}
+
+#[tokio::test]
+async fn check_dependencies_must_cascade_invalidate_when_parent_is_invalid() {
+    let fixture = TestFixture::new().await;
+
+    // Pre-populate the dag with `genesis` marked invalid. The dependency gate
+    // reads invalid_blocks_map directly from this storage.
+    fixture
+        .block_dag_storage_handle
+        .insert(&fixture.genesis, true, false)
+        .expect("insert genesis as invalid");
+
+    let casper = Arc::new(CascadeMockCasper::new());
+    let block_processor = BlockProcessor::new(fixture.dependencies);
+
+    // test_block lists genesis as its parent (see TestFixture::new).
+    let ready = block_processor
+        .check_dependencies_with_effects(casper.clone(), &fixture.test_block)
+        .await
+        .expect("dependency check must not error");
+
+    assert!(
+        !ready,
+        "Block with an invalid parent must NOT be reported ready for validation"
+    );
+
+    let calls = casper.handle_invalid_block_calls.lock().unwrap().clone();
+    assert_eq!(
+        calls,
+        vec![InvalidBlock::InvalidParent],
+        "Block must be cascade-invalidated as InvalidParent (non-slashable). \
+         A bug here causes the parent-child mergeable-entry race to fire and \
+         spuriously record blocks as InvalidTransaction (slashable). Calls: {:?}",
+        calls
+    );
 }

--- a/docs/casper/CONSENSUS_PROTOCOL.md
+++ b/docs/casper/CONSENSUS_PROTOCOL.md
@@ -199,8 +199,10 @@ The block retriever (`block_retriever.rs`) handles missing dependencies:
 - Check field validity: hash length, timestamp within ±15s of local time, required fields present
 
 ### Step 3: Dependency Resolution
-- All parent blocks must be in the DAG
-- If missing: store block in **casper buffer** (max ~16K entries), request missing parents from peers
+- All parent blocks must be in the DAG **and recorded valid**
+- If a parent is in the DAG but flagged invalid (in `invalid_blocks_set` or the equivocation tracker): the block is **cascade-invalidated** as `InvalidBlock::InvalidParent` (non-slashable) immediately, without entering validation. Invalid parents have no mergeable-channels entry written, so allowing the child through would deterministically fail merge with `Missing mergeable entry` and mis-record the child as `InvalidTransaction` (slashable). The cascade closes that race at the gate.
+- If a parent is missing locally: store the block in the **casper buffer** (max ~16K entries) with the missing-parent dependencies, request missing parents from peers
+- Justifications can reference invalid blocks without triggering cascade — only *parents* are state dependencies (justifications are latest-message acknowledgments and don't require mergeable entries)
 - Casper buffer tracks retry attempts per dependency and quarantines blocks after budget exhaustion
 
 ### Step 4: Snapshot Computation


### PR DESCRIPTION
## Summary

Two block-validation correctness fixes surfaced during the bonding-bug investigation. Both close concrete failure modes that produced spurious `InvalidTransaction` cascades on joiners under load.

**Stacked on top of #507** ([feat(lfs): joiner-side coverage + orchestrator multi-root pagination fix for multi-bonded shards](https://github.com/F1R3FLY-io/f1r3node/pull/507)). This PR's diff shows ONLY the 2 commits below; auto-rebases onto `rust/staging` once #507 merges.

## Commits (2)

```
776fa361 fix(runtime-manager): ReplayCache mergeable-entry safety check
ad1627ac fix(block-processor): cascade-invalidate children of invalid parents
```

### `ad1627ac` — Cascade-invalidate children of invalid parents

**Problem.** When a block X is recorded invalid, its children sit in the buffer waiting on X. Each child eventually gets pulled out for validation, individually fails because its parent is missing a mergeable-channels entry (since invalid parents never wrote one — `save_mergeable_channels` only runs on the validation success path), and gets recorded as `InvalidTransaction` one-at-a-time. Slashable cascade for what was originally one parent's failure. Honest validators producing children of a block they didn't know was invalid in their view get punished.

**Fix.**
- New `InvalidBlock::InvalidParent` variant — **non-slashable** (the child's creator may not have known the parent was invalid in their view)
- New `Readiness` enum returned by `get_non_validated_dependencies`: `Ready / Waiting{deps_to_fetch, deps_in_buffer} / InvalidParents(parents)`
- Cascade fires only on invalid PARENTS — invalid justifications stay satisfied (justifications acknowledge a validator's latest message and don't require a mergeable entry)
- `effects_for_invalid_block` refactored to take `&KeyValueDagRepresentation` directly so the cascade path doesn't need to build a full snapshot
- `BlockException` arm in `validate_with_effects` escalated warn → error as a tripwire (should be unreachable post-fix)
- `handle_invalid_block` routes `InvalidParent` through `handle_invalid_block_effect` so descendants also cascade

New test: `check_dependencies_must_cascade_invalidate_when_parent_is_invalid`.

### `776fa361` — ReplayCache mergeable-entry safety check

**Problem.** ReplayCache is a per-node optimization — on a cache hit, return the cached post-state without re-running replay. But if the mergeable-channels entry for `(post_state, sender, seq_num)` isn't in the local store, returning the cached post-state lets the block enter the DAG with no mergeable entry. Subsequent children that need the entry hit "Missing mergeable entry" during merge — the exact failure mode the existing StateHashCache check (lines 624-643) was designed to prevent.

**Fix.** On ReplayCache hit, look up the mergeable key first. If present → fast-return as before. If absent → fall through to full replay so `save_mergeable_channels` runs. Mirrors the existing StateHashCache safety check pattern.

## Test plan

- [x] `cargo test --release --workspace` — **2183 passed, 0 failed** (across 70 test suites; +1 over PR #507's 2182, accounting for the new cascade-invalidate test)
- [x] `cargo build --release -p casper` — clean
- [x] No new files; cherry-picks rustfmt-clean

Co-Authored-By: Claude <noreply@anthropic.com>
