### PR TITLE
feat(bonding): MergeType::AdditiveSet + PoS bondsCh

### DIFF
--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -169,9 +169,14 @@ in {
           for (@initialActive     <- initialActiveCh;
                @(true, _) <- moveInitialBondCh) {
             new stateCh, pendingRewardsInitializedCh, rewardsInfo, calTotalActiveBonds, calTotalBonds,
-                accumulateSndNum, accumulateFstOfSndArg, accumulateItemInState in {
+                accumulateSndNum, accumulateFstOfSndArg, accumulateItemInState,
+                mutexTag(`rho:system:mutexStateMergeableTag`) in {
               // Initializes PoS state structure.
-              stateCh!({
+              // stateCh is wrapped with the MutexState tag so multi-parent
+              // merge over concurrent take-then-put writes collapses to a
+              // single deterministic winner instead of accumulating
+              // multi-Datum residue.
+              @(*mutexTag, *stateCh)!({
                 // Map[PublicKey, Int] - each validator stake
                 "allBonds"        : $$initialBonds$$,
                 // Set[PublicKey]     - the active validators
@@ -197,7 +202,7 @@ in {
                   accumulateItemInState!(*committedRewardsCh, "committedRewards", *accumulateSndNum) |
                   for (@posBalance <- posBalanceCh; @totalBond <- totalBondCh; @activeBonds <- totalActiveBondCh;
                        @totalWithdraw <- totalWithdrawCh; @totalCommittedRewards <- committedRewardsCh){
-                    for (@state <<- stateCh) {
+                    for (@state <<- @(*mutexTag, *stateCh)) {
                       retCh!((posBalance , totalBond , activeBonds, totalWithdraw, totalCommittedRewards, state.get("allBonds"), state.get("activeValidators")))
                     }
                   }
@@ -205,7 +210,7 @@ in {
               } |
               contract calTotalActiveBonds(returnCh) = {
                 new computeSum in {
-                  for (@state <<- stateCh){
+                  for (@state <<- @(*mutexTag, *stateCh)){
                     @ListOps!("fold", state.get("allBonds").toList(), 0, *computeSum, *returnCh) |
                     contract computeSum(@(pk, bondAmount), @acc, resultCh) = {
                       if (state.get("activeValidators").contains(pk)){
@@ -224,7 +229,7 @@ in {
                 resultCh!(acc + amount)
               } |
               contract accumulateItemInState(returnCh, @stateKey, accumulateAlgo) = {
-                for (@state <<- stateCh){
+                for (@state <<- @(*mutexTag, *stateCh)){
                   @ListOps!("fold", state.get(stateKey).toList(), 0, *accumulateAlgo, *returnCh)
                 }
               }|
@@ -246,7 +251,7 @@ in {
               } |
               contract PoS(@"getRewards", returnCh) = {
                 new currentEpochRewardCh, accumulateReward in {
-                  for (@state <<- stateCh) {
+                  for (@state <<- @(*mutexTag, *stateCh)) {
                     PoS!("getCurrentEpochRewards", *currentEpochRewardCh)|
                     for (@currentEpochReward <- currentEpochRewardCh) {
                       @ListOps!("fold", currentEpochReward.toList(), state.get("committedRewards"), *accumulateReward, *returnCh) |
@@ -259,24 +264,24 @@ in {
               } |
               // Peeks at bonds map.
               contract PoS(@"getBonds", returnCh) = {
-                for (@state <<- stateCh) {
+                for (@state <<- @(*mutexTag, *stateCh)) {
                   returnCh!(state.get("allBonds"))
                 }
               } |
               // Peeks at active validator list.
               contract PoS(@"getActiveValidators", returnCh) = {
-                for (@state <<- stateCh) {
+                for (@state <<- @(*mutexTag, *stateCh)) {
                   returnCh!(state.get("activeValidators"))
                 }
               } |
               // Peeks at active validator list.
               contract PoS(@"getWithdrawers", returnCh) = {
-                for (@state <<- stateCh) {
+                for (@state <<- @(*mutexTag, *stateCh)) {
                   returnCh!(state.get("withdrawers"))
                 }
               } |
               contract PoS(@"getPendingWithdrawer", returnCh) = {
-                for (@state <<- stateCh) {
+                for (@state <<- @(*mutexTag, *stateCh)) {
                   returnCh!(state.get("pendingWithdrawers"))
                 }
               } |
@@ -307,7 +312,7 @@ in {
                 new userCh, depositCh,
                     processCh
                 in {
-                  runMVar!(*stateCh, *processCh, *returnCh) |
+                  runMVar!(*@(*mutexTag, *stateCh), *processCh, *returnCh) |
                   getUser!(deployerId, *userCh) |
                   for (@state, resultCh <- processCh &
                        @userPk          <- userCh) {
@@ -342,7 +347,7 @@ in {
                     getBlockData(`rho:block:data`)
                 in {
                   // Consumes state and updates withdrawers map.
-                  runMVar!(*stateCh, *processCh, *returnCh) |
+                  runMVar!(*@(*mutexTag, *stateCh), *processCh, *returnCh) |
                   getBlockData!(*blockDataCh) |
                   getUser!(deployerId, *userCh) |
                   for (@state, resultCh   <- processCh &
@@ -442,7 +447,7 @@ in {
                         in {
                           getInvalidBlocks!(*invalidBlocksCh) |
                           getUser!(deployerId, *userCh) |
-                          runMVar!(*stateCh, *stateProcessCh, *returnCh) |
+                          runMVar!(*@(*mutexTag, *stateCh), *stateProcessCh, *returnCh) |
                           for (@invalidBlocks        <- invalidBlocksCh &
                                @userPk               <- userCh &
                                @state, stateUpdateCh <- stateProcessCh) {
@@ -515,7 +520,7 @@ in {
                               in {
                                 PoS!("getCurrentEpochRewards", * currentEpochRewardCh) |
                                 for (@currentRewards <- currentEpochRewardCh) {
-                                  runMVar!(*stateCh, *stateProcessCh, *ackCh) |
+                                  runMVar!(*@(*mutexTag, *stateCh), *stateProcessCh, *ackCh) |
                                   for (@state, stateUpdateCh <- stateProcessCh) {
                                     // 1. Calculate all the validator current epoch rewards based on active validator bonding proportion
                                     // 2. Accumulate `committedRewards` with the result of step 1
@@ -621,7 +626,7 @@ in {
               contract PoS(@"commitRandomImage", @deployerId, @hash, ackCh) = {
                 new userCh, mvarCh in {
                   getUser!(deployerId, *userCh) |
-                  runMVar!(*stateCh, *mvarCh, *ackCh) |
+                  runMVar!(*@(*mutexTag, *stateCh), *mvarCh, *ackCh) |
                   for (@validator       <- userCh &
                        @state, resultCh <- mvarCh) {
                     if (state.get("randomImages").contains(validator)) {
@@ -637,7 +642,7 @@ in {
               contract PoS(@"revealRandom", @deployerId, @random, ackCh) = {
                 new userCh, mvarCh, computeHash(`rho:crypto:keccak256Hash`), hashCh in {
                   getUser!(deployerId, *userCh) |
-                  runMVar!(*stateCh, *mvarCh, *ackCh) |
+                  runMVar!(*@(*mutexTag, *stateCh), *mvarCh, *ackCh) |
                   computeHash!(random, *hashCh) |
                   for (@validator       <- userCh &
                        @state, resultCh <- mvarCh &

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -168,9 +168,20 @@ in {
           pickActiveValidators!($$initialBonds$$.toList(), *initialActiveCh) |
           for (@initialActive     <- initialActiveCh;
                @(true, _) <- moveInitialBondCh) {
-            new stateCh, pendingRewardsInitializedCh, rewardsInfo, calTotalActiveBonds, calTotalBonds,
+            new stateCh, bondsCh, pendingRewardsInitializedCh, rewardsInfo, calTotalActiveBonds, calTotalBonds,
                 accumulateSndNum, accumulateFstOfSndArg, accumulateItemInState,
-                mutexTag(`rho:system:mutexStateMergeableTag`) in {
+                mutexTag(`rho:system:mutexStateMergeableTag`),
+                additiveSetTag(`rho:system:additiveSetMergeableTag`) in {
+              // bondsCh holds the canonical bonds map (Map[PublicKey, Int]).
+              // It is tagged with the AdditiveSet merge type so multi-parent
+              // merge takes the key-wise union of concurrent branches' bond
+              // writes instead of dropping all but one branch's contribution
+              // (which is what MutexState's lowest-hash LWW would do).
+              // `getBonds` and active-validator selection read this channel;
+              // `bond` writes to it. The `state.allBonds` field in stateCh
+              // remains as a legacy mirror for the slash/withdraw paths
+              // until those are migrated.
+              @(*additiveSetTag, *bondsCh)!($$initialBonds$$) |
               // Initializes PoS state structure.
               // stateCh is wrapped with the MutexState tag so multi-parent
               // merge over concurrent take-then-put writes collapses to a
@@ -262,10 +273,12 @@ in {
                   }
                 }
               } |
-              // Peeks at bonds map.
+              // Peeks at bonds map. Reads bondsCh (AdditiveSet) — the
+              // canonical bonds source whose multi-parent merge preserves
+              // every branch's contribution.
               contract PoS(@"getBonds", returnCh) = {
-                for (@state <<- @(*mutexTag, *stateCh)) {
-                  returnCh!(state.get("allBonds"))
+                for (@bonds <<- @(*additiveSetTag, *bondsCh)) {
+                  returnCh!(bonds)
                 }
               } |
               // Peeks at active validator list.
@@ -328,7 +341,12 @@ in {
                       for (@depositResult <- depositCh) {
                         match depositResult {
                           // If deposit is successful, the user becomes a bonded validator.
+                          // Dual-write: bondsCh (canonical, AdditiveSet-merged) and
+                          // stateCh.allBonds (legacy mirror for slash/withdraw).
                           (true, _) => {
+                            for (@bonds <- @(*additiveSetTag, *bondsCh)) {
+                              @(*additiveSetTag, *bondsCh)!(bonds.set(userPk, amount))
+                            } |
                             resultCh!(state.set("allBonds", state.get("allBonds").set(userPk, amount)), depositResult)
                           }
                           // If deposit is unsuccessful, the user is not bonded.
@@ -535,8 +553,15 @@ in {
                                         // 5. update `pendingWithdrawers` to empty Map {}.
                                         removeQuarantinedWithdrawers!(blockNumber, newMovedPendingState, *removeQuarantinedCh) |
                                         for (@newRemovedQuantinueState <- removeQuarantinedCh) {
-                                          // 6. Pick new `activeValidators`
-                                          pickActiveValidators!(newMovedPendingState.get("allBonds").toList(), *newValidatorsCh) |
+                                          // 6. Pick new `activeValidators` from the canonical bondsCh
+                                          //    (AdditiveSet-merged) so multi-parent merge of bond
+                                          //    writes is honoured here. Reading the legacy
+                                          //    `state.allBonds` would inherit MutexState's LWW
+                                          //    drop and exclude validators bonded on a sibling
+                                          //    branch.
+                                          for (@bondsForActive <<- @(*additiveSetTag, *bondsCh)) {
+                                            pickActiveValidators!(bondsForActive.toList(), *newValidatorsCh)
+                                          } |
                                           for (@newValidators <- newValidatorsCh) {
                                             stateUpdateCh!(newRemovedQuantinueState.set("activeValidators", newValidators), (true, Nil))
                                           }

--- a/casper/src/rust/engine/initializing.rs
+++ b/casper/src/rust/engine/initializing.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use dashmap::DashSet;
 use futures::stream::StreamExt;
 use std::{
-    collections::{BTreeMap, HashSet, VecDeque},
+    collections::{BTreeMap, HashMap, HashSet, VecDeque},
     future::Future,
     pin::Pin,
     sync::atomic::{AtomicUsize, Ordering},
@@ -692,15 +692,25 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
         // check in `validate::parents`.
         {
             let dag = self.block_dag_storage.get_representation();
-            let horizon_roots =
-                crate::rust::util::rspace_history_horizon::compute_forward_horizon_roots(
-                    &dag,
-                    &self.block_store,
-                    &approved_block.candidate.block,
-                    &self.casper_shard_conf,
-                )
-                .map_err(|e| CasperError::KvStoreError(e))?;
+            let horizon = crate::rust::util::rspace_history_horizon::compute_forward_horizon(
+                &dag,
+                &self.block_store,
+                &approved_block.candidate.block,
+                &self.casper_shard_conf,
+            )
+            .map_err(|e| CasperError::KvStoreError(e))?;
 
+            // Sync mergeable-channel entries for any horizon block whose
+            // entry is not already in the local mergeable_store. The
+            // per-block sync in `lfs_block_requester` only covers
+            // LFB-ancestor blocks; side-branch blocks within the horizon
+            // need their entries fetched here so subsequent multi-parent
+            // validation can reproduce the merge intermediates without
+            // hitting `RootRepositoryDivergence`.
+            self.sync_horizon_mergeable_entries(&horizon.block_hashes)
+                .await?;
+
+            let horizon_roots = horizon.roots;
             if !horizon_roots.is_empty() {
                 // Phase 1's tuple_space_message_receiver was consumed by
                 // lfs_tuple_space_requester::stream. Install a fresh
@@ -787,6 +797,133 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
             .await?;
         tracing::info!("request_approved_state: transition_to_running completed");
 
+        Ok(())
+    }
+
+    /// Fetch any mergeable-channel entries that are missing locally for the
+    /// given horizon block hashes. Side-branch blocks (those not on the
+    /// LFB-ancestor chain) don't have their entries synced by
+    /// `lfs_block_requester`'s per-block path; without this step,
+    /// multi-parent merge of an upcoming block whose parent is a side-branch
+    /// block hits `RootRepositoryDivergence` because the merge cannot
+    /// reproduce the intermediate root.
+    ///
+    /// Sends one `MergeableEntryRequest` per missing block (broadcast via
+    /// transport_layer), drains responses on a fresh `mergeable_message_rx`,
+    /// imports each via `RuntimeManager::put_mergeable_entry_bytes`, and
+    /// loud-fails if any entry can't be fetched within the timeout.
+    async fn sync_horizon_mergeable_entries(
+        &self,
+        horizon_block_hashes: &[BlockHash],
+    ) -> Result<(), CasperError> {
+        if horizon_block_hashes.is_empty() {
+            return Ok(());
+        }
+
+        let mut needed: Vec<(BlockHash, Vec<u8>)> = Vec::new();
+        for hash in horizon_block_hashes {
+            let block = match self
+                .block_store
+                .get(hash)
+                .map_err(CasperError::KvStoreError)?
+            {
+                Some(b) => b,
+                None => {
+                    tracing::warn!(
+                        "sync_horizon_mergeable_entries: block {} in DAG but missing from block_store",
+                        PrettyPrinter::build_string_bytes(hash),
+                    );
+                    continue;
+                }
+            };
+            let (key_bytes, value) = self.runtime_manager.get_mergeable_entry_bytes(&block)?;
+            if value.is_none() {
+                needed.push((hash.clone(), key_bytes));
+            }
+        }
+
+        if needed.is_empty() {
+            tracing::info!(
+                "LFS forward-horizon mergeable: all {} entries already present",
+                horizon_block_hashes.len(),
+            );
+            return Ok(());
+        }
+
+        let key_for_hash: HashMap<BlockHash, Vec<u8>> = needed.iter().cloned().collect();
+
+        let (mergeable_tx, mut mergeable_rx) = mpsc::channel::<MergeableEntryResponse>(50);
+        {
+            let mut sender_slot = self.mergeable_message_tx.lock().unwrap();
+            *sender_slot = Some(mergeable_tx);
+        }
+
+        for (hash, _) in &needed {
+            let req = MergeableEntryRequest {
+                block_hash: hash.clone(),
+            };
+            self.transport_layer
+                .send_message_to_peers(
+                    &self.connections_cell,
+                    &self.rp_conf_ask,
+                    Arc::new(req.to_proto()),
+                    None,
+                )
+                .await
+                .map_err(|e| CasperError::RuntimeError(e.to_string()))?;
+        }
+
+        tracing::info!(
+            "LFS forward-horizon mergeable: requesting {} missing entries (of {} horizon blocks)",
+            needed.len(),
+            horizon_block_hashes.len(),
+        );
+
+        let request_timeout = Duration::from_secs(30);
+        let deadline = Instant::now() + request_timeout;
+        let mut received: HashSet<BlockHash> = HashSet::new();
+        while received.len() < needed.len() {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match tokio::time::timeout(remaining, mergeable_rx.recv()).await {
+                Ok(Some(resp)) => {
+                    if received.contains(&resp.block_hash) {
+                        continue;
+                    }
+                    let key_bytes = match key_for_hash.get(&resp.block_hash) {
+                        Some(k) => k.clone(),
+                        None => continue,
+                    };
+                    self.runtime_manager
+                        .put_mergeable_entry_bytes(key_bytes, resp.serialized_entry.to_vec())?;
+                    received.insert(resp.block_hash);
+                }
+                Ok(None) => break,
+                Err(_) => break,
+            }
+        }
+
+        {
+            let mut sender_slot = self.mergeable_message_tx.lock().unwrap();
+            *sender_slot = None;
+        }
+
+        if received.len() < needed.len() {
+            let missing = needed.len() - received.len();
+            return Err(CasperError::RuntimeError(format!(
+                "LFS forward-horizon mergeable: incomplete sync; {} of {} entries unfetched after {:?}",
+                missing,
+                needed.len(),
+                request_timeout,
+            )));
+        }
+
+        tracing::info!(
+            "LFS forward-horizon mergeable: imported {} entries",
+            received.len(),
+        );
         Ok(())
     }
 

--- a/casper/src/rust/merging/block_index.rs
+++ b/casper/src/rust/merging/block_index.rs
@@ -10,7 +10,10 @@ use models::rust::{
 use rholang::rust::interpreter::rho_runtime::RhoHistoryRepository;
 use rspace_plus_plus::rspace::{
     hashing::blake2b256_hash::Blake2b256Hash,
-    merger::{event_log_index::EventLogIndex, merging_logic::NumberChannelsDiff},
+    merger::{
+        event_log_index::EventLogIndex,
+        merging_logic::{NumberChannelsDiff, StateChannelsDiff},
+    },
     trace::event::Produce,
 };
 
@@ -33,6 +36,7 @@ pub fn create_event_log_index(
     history_repository: RhoHistoryRepository,
     pre_state_hash: &Blake2b256Hash,
     mergeable_chs: NumberChannelsDiff,
+    state_chs: StateChannelsDiff,
 ) -> EventLogIndex {
     let pre_state_reader = history_repository
         .get_history_reader(&pre_state_hash)
@@ -58,6 +62,7 @@ pub fn create_event_log_index(
         produce_exists_in_pre_state,
         produce_touches_pre_state_join,
         mergeable_chs,
+        state_chs,
     )
 }
 
@@ -70,44 +75,55 @@ pub fn new(
     post_state_hash: &Blake2b256Hash,
     history_repository: &RhoHistoryRepository,
     mergeable_chs: &Vec<NumberChannelsDiff>,
+    state_chs: &Vec<StateChannelsDiff>,
 ) -> Result<BlockIndex, CasperError> {
     // Connect mergeable channels data with processed deploys by index
     let usr_count = usr_processed_deploys.len();
     let sys_count = sys_processed_deploys.len();
     let deploy_count = usr_count + sys_count;
     let mrg_count = mergeable_chs.len();
-    if mrg_count != deploy_count {
+    let state_count = state_chs.len();
+    if mrg_count != deploy_count || state_count != deploy_count {
         let msg = format!(
-            "Mergeable channel count mismatch for block {}: mergeable_maps={}, deploys={}",
+            "Mergeable channel count mismatch for block {}: \
+             mergeable_maps={}, state_maps={}, deploys={}",
             hex::encode(&block_hash[..std::cmp::min(10, block_hash.len())]),
             mrg_count,
-            deploy_count
+            state_count,
+            deploy_count,
         );
         tracing::error!("{}", msg);
         return Err(CasperError::RuntimeError(msg));
     }
     let aligned_mergeable_chs = mergeable_chs.clone();
+    let aligned_state_chs = state_chs.clone();
 
     // Connect deploy with corresponding mergeable channels map
     let (usr_mergeable_chs, sys_mergeable_chs) = aligned_mergeable_chs.split_at(usr_count);
+    let (usr_state_chs, sys_state_chs) = aligned_state_chs.split_at(usr_count);
     let usr_deploys_with_mergeable: Vec<_> = usr_processed_deploys
         .iter()
         .zip(usr_mergeable_chs.iter())
+        .zip(usr_state_chs.iter())
+        .map(|((d, n), s)| (d, n, s))
         .collect();
     let sys_deploys_with_mergeable: Vec<_> = sys_processed_deploys
         .iter()
         .zip(sys_mergeable_chs.iter())
+        .zip(sys_state_chs.iter())
+        .map(|((d, n), s)| (d, n, s))
         .collect();
 
     // Create user deploy indices - filter out failed deploys
     let mut usr_deploy_indices = Vec::new();
-    for (deploy, merge_chs) in usr_deploys_with_mergeable {
+    for (deploy, merge_chs, state_chs) in usr_deploys_with_mergeable {
         if !deploy.is_failed {
             let event_log_index = create_event_log_index(
                 &deploy.deploy_log,
                 history_repository.clone(),
                 pre_state_hash,
                 merge_chs.clone(),
+                state_chs.clone(),
             );
 
             let deploy_index = DeployIndex {
@@ -122,7 +138,7 @@ pub fn new(
 
     // Create system deploy indices - collect successful system deploys
     let mut sys_deploy_indices = Vec::new();
-    for (sys_deploy, merge_chs) in sys_deploys_with_mergeable {
+    for (sys_deploy, merge_chs, state_chs) in sys_deploys_with_mergeable {
         match sys_deploy {
             ProcessedSystemDeploy::Succeeded {
                 system_deploy,
@@ -151,6 +167,7 @@ pub fn new(
                     history_repository.clone(),
                     pre_state_hash,
                     merge_chs.clone(),
+                    state_chs.clone(),
                 );
 
                 let deploy_index = DeployIndex {

--- a/casper/src/rust/merging/conflict_set_merger.rs
+++ b/casper/src/rust/merging/conflict_set_merger.rs
@@ -8,7 +8,10 @@ use rspace_plus_plus::rspace::{
     hot_store_trie_action::HotStoreTrieAction,
     internal::Datum,
     merger::{
-        merging_logic::{combine_mergeable_value, MergeType, NumberChannelsDiff},
+        merging_logic::{
+        combine_mergeable_state_bytes, combine_mergeable_value, MergeType, NumberChannelsDiff,
+        StateChannelsDiff,
+    },
         state_change::StateChange,
     },
 };
@@ -284,9 +287,11 @@ pub fn compute_merged_state<R, C, P, A, K>(
     resolved: &ResolvedConflicts<R>,
     state_changes: &impl Fn(&R) -> Result<StateChange, HistoryError>,
     mergeable_channels: &impl Fn(&R) -> NumberChannelsDiff,
+    state_channels: &impl Fn(&R) -> StateChannelsDiff,
     compute_trie_actions: &impl Fn(
         StateChange,
         NumberChannelsDiff,
+        StateChannelsDiff,
     ) -> Result<Vec<HotStoreTrieAction<C, P, A, K>>, HistoryError>,
     apply_trie_actions: &impl Fn(
         Vec<HotStoreTrieAction<C, P, A, K>>,
@@ -359,9 +364,36 @@ where
         }
     }
 
+    // Combine all state channels via byte-level lowest-Blake2b256-of-bincode
+    // wins; equivalent to the typed `combine_mergeable_state` because the
+    // storage bytes are `bincode(Datum)`.
+    let mut all_state_channels = StateChannelsDiff::new();
+    for item in &to_merge_items {
+        let item_state_channels = state_channels(item);
+        for (key, value) in item_state_channels.iter() {
+            let (incoming_bytes, incoming_mt) = value;
+            all_state_channels
+                .entry(key.clone())
+                .and_modify(|existing| {
+                    assert_eq!(
+                        existing.1, *incoming_mt,
+                        "MergeType mismatch on state channel {:?}: {:?} vs {:?}",
+                        key, existing.1, incoming_mt,
+                    );
+                    existing.0 = combine_mergeable_state_bytes(&existing.0, incoming_bytes);
+                })
+                .or_insert_with(|| (incoming_bytes.clone(), *incoming_mt));
+        }
+    }
+
     // Compute and apply trie actions with timing
-    let (trie_actions, compute_actions_time) =
-        measure_result_time(|| compute_trie_actions(all_changes, all_mergeable_channels.clone()))?;
+    let (trie_actions, compute_actions_time) = measure_result_time(|| {
+        compute_trie_actions(
+            all_changes,
+            all_mergeable_channels.clone(),
+            all_state_channels.clone(),
+        )
+    })?;
 
     let (new_state, apply_actions_time) =
         measure_result_time(|| apply_trie_actions(trie_actions.clone()))?;
@@ -415,9 +447,11 @@ pub fn merge<
     cost: impl Fn(&R) -> u64,
     state_changes: impl Fn(&R) -> Result<StateChange, HistoryError>,
     mergeable_channels: impl Fn(&R) -> NumberChannelsDiff,
+    state_channels: impl Fn(&R) -> StateChannelsDiff,
     compute_trie_actions: impl Fn(
         StateChange,
         NumberChannelsDiff,
+        StateChannelsDiff,
     ) -> Result<Vec<HotStoreTrieAction<C, P, A, K>>, HistoryError>,
     apply_trie_actions: impl Fn(
         Vec<HotStoreTrieAction<C, P, A, K>>,
@@ -445,6 +479,7 @@ pub fn merge<
         &resolved,
         &state_changes,
         &mergeable_channels,
+        &state_channels,
         &compute_trie_actions,
         &apply_trie_actions,
     )?;
@@ -572,6 +607,10 @@ fn cal_merged_result<R: Clone + Eq + std::hash::Hash>(
                         ba.insert(channel.clone(), result);
                         Some(ba)
                     }
+                    MergeType::MutexState => unreachable!(
+                        "MutexState channels do not flow through the i64 conflict-merger \
+                         path; they use the parallel state-channel pipeline"
+                    ),
                 }
             })
         })
@@ -723,7 +762,10 @@ mod tests {
                 diff.insert(base_channel.clone(), (delta, MergeType::IntegerAdd));
                 diff
             },
-            |_state_change, _channels| Ok(Vec::<HotStoreTrieAction<i32, i32, i32, i32>>::new()),
+            |_r| StateChannelsDiff::new(), // no state-channel data in this test
+            |_state_change, _channels, _state_channels| {
+                Ok(Vec::<HotStoreTrieAction<i32, i32, i32, i32>>::new())
+            },
             |_actions: Vec<HotStoreTrieAction<i32, i32, i32, i32>>| {
                 Ok(Blake2b256Hash::from_bytes(vec![9u8; 32]))
             },

--- a/casper/src/rust/merging/conflict_set_merger.rs
+++ b/casper/src/rust/merging/conflict_set_merger.rs
@@ -9,9 +9,9 @@ use rspace_plus_plus::rspace::{
     internal::Datum,
     merger::{
         merging_logic::{
-        combine_mergeable_state_bytes, combine_mergeable_value, MergeType, NumberChannelsDiff,
-        StateChannelsDiff,
-    },
+            combine_mergeable_state_bytes, combine_mergeable_value, MergeType, NumberChannelsDiff,
+            StateChannelsDiff,
+        },
         state_change::StateChange,
     },
 };
@@ -609,6 +609,10 @@ fn cal_merged_result<R: Clone + Eq + std::hash::Hash>(
                     }
                     MergeType::MutexState => unreachable!(
                         "MutexState channels do not flow through the i64 conflict-merger \
+                         path; they use the parallel state-channel pipeline"
+                    ),
+                    MergeType::AdditiveSet => unreachable!(
+                        "AdditiveSet channels do not flow through the i64 conflict-merger \
                          path; they use the parallel state-channel pipeline"
                     ),
                 }

--- a/casper/src/rust/merging/dag_merger.rs
+++ b/casper/src/rust/merging/dag_merger.rs
@@ -404,7 +404,7 @@ pub fn merge(
         let reader = Arc::clone(&history_reader);
         move |changes, mergeable_chs, state_chs: StateChannelsDiff| {
             // Capture state_chs into the inner closure so dispatch can route
-            // either State (MutexState) or Number (IntegerAdd/BitmaskOr).
+            // either State (MutexState/AdditiveSet) or Number (IntegerAdd/BitmaskOr).
             let state_chs_inner = state_chs.clone();
             state_change_merger::compute_trie_actions(
                 &changes,
@@ -412,8 +412,8 @@ pub fn merge(
                 &mergeable_chs,
                 |hash: &Blake2b256Hash, channel_changes, number_chs: &NumberChannelsDiff| {
                     // State channels take precedence — if a hash is tagged as
-                    // MutexState, it must NOT also be in number_chs (enforced
-                    // upstream by tag-type unique mapping).
+                    // MutexState or AdditiveSet, it must NOT also be in
+                    // number_chs (enforced upstream by tag-type unique mapping).
                     if let Some((diff_bytes, merge_type)) = state_chs_inner.get(hash) {
                         let base_get_data = |h: &Blake2b256Hash| reader.get_data(h);
                         Ok(Some(RholangMergingLogic::calculate_state_channel_merge(

--- a/casper/src/rust/merging/dag_merger.rs
+++ b/casper/src/rust/merging/dag_merger.rs
@@ -13,7 +13,7 @@ use rholang::rust::interpreter::{
 use rspace_plus_plus::rspace::{
     hashing::blake2b256_hash::Blake2b256Hash,
     merger::{
-        merging_logic::{self, NumberChannelsDiff},
+        merging_logic::{self, NumberChannelsDiff, StateChannelsDiff},
         state_change_merger,
     },
 };
@@ -397,15 +397,33 @@ pub fn merge(
     let mergeable_channels_fn =
         |chain: &DeployChainIndex| chain.event_log_index.number_channels_data.clone();
 
+    let state_channels_fn =
+        |chain: &DeployChainIndex| chain.event_log_index.state_channels_data.clone();
+
     let compute_trie_actions_fn = {
         let reader = Arc::clone(&history_reader);
-        move |changes, mergeable_chs| {
+        move |changes, mergeable_chs, state_chs: StateChannelsDiff| {
+            // Capture state_chs into the inner closure so dispatch can route
+            // either State (MutexState) or Number (IntegerAdd/BitmaskOr).
+            let state_chs_inner = state_chs.clone();
             state_change_merger::compute_trie_actions(
                 &changes,
                 &*reader,
                 &mergeable_chs,
                 |hash: &Blake2b256Hash, channel_changes, number_chs: &NumberChannelsDiff| {
-                    if let Some(number_ch_val) = number_chs.get(hash) {
+                    // State channels take precedence — if a hash is tagged as
+                    // MutexState, it must NOT also be in number_chs (enforced
+                    // upstream by tag-type unique mapping).
+                    if let Some((diff_bytes, merge_type)) = state_chs_inner.get(hash) {
+                        let base_get_data = |h: &Blake2b256Hash| reader.get_data(h);
+                        Ok(Some(RholangMergingLogic::calculate_state_channel_merge(
+                            hash,
+                            diff_bytes.clone(),
+                            *merge_type,
+                            channel_changes,
+                            base_get_data,
+                        )))
+                    } else if let Some(number_ch_val) = number_chs.get(hash) {
                         let (diff, merge_type) = *number_ch_val;
                         let base_get_data = |h: &Blake2b256Hash| reader.get_data(h);
                         Ok(Some(RholangMergingLogic::calculate_number_channel_merge(
@@ -599,6 +617,7 @@ pub fn merge(
         &resolved,
         &state_changes_fn,
         &mergeable_channels_fn,
+        &state_channels_fn,
         &compute_trie_actions_fn,
         &apply_trie_actions_fn,
     )

--- a/casper/src/rust/multi_parent_casper_impl.rs
+++ b/casper/src/rust/multi_parent_casper_impl.rs
@@ -204,34 +204,11 @@ impl<T: TransportLayer + Send + Sync> Casper for MultiParentCasperImpl<T> {
             }
         });
 
-        // Filter to blocks with matching bond maps (required for merge compatibility)
-        // If no parent blocks exist (genesis case), use approved block as the parent
+        // If no parent blocks exist (genesis case), use approved block as the parent.
         let unfiltered_parents = if sorted_parents_list.is_empty() {
             vec![self.approved_block.clone()]
         } else {
-            // Use the newest block as the bond-reference baseline.
-            // Relying on the first (hash-sorted near-tip) block can select an older
-            // parent and regress snapshot max_block_num when a joiner/fresh bond-map
-            // divergence is present.
-            let reference_bonds = sorted_parents_list
-                .iter()
-                .max_by(|a, b| {
-                    a.body
-                        .state
-                        .block_number
-                        .cmp(&b.body.state.block_number)
-                        .then_with(|| a.block_hash.cmp(&b.block_hash))
-                })
-                .expect("sorted_parents_list is non-empty after is_empty() check")
-                .body
-                .state
-                .bonds
-                .clone();
-
             sorted_parents_list
-                .into_iter()
-                .filter(|block| block.body.state.bonds == reference_bonds)
-                .collect()
         };
 
         let unfiltered_parents_count = unfiltered_parents.len();
@@ -754,7 +731,7 @@ impl<T: TransportLayer + Send + Sync> Casper for MultiParentCasperImpl<T> {
                 );
 
                 match maybe_mergeable {
-                    Ok(mergeable_chs) => {
+                    Ok((mergeable_chs, state_chs)) => {
                         if let Err(err) = self.runtime_manager.get_or_compute_block_index(
                             &block.block_hash,
                             block.body.state.block_number,
@@ -763,6 +740,7 @@ impl<T: TransportLayer + Send + Sync> Casper for MultiParentCasperImpl<T> {
                             &Blake2b256Hash::from_bytes_prost(&block.body.state.pre_state_hash),
                             &Blake2b256Hash::from_bytes_prost(&block.body.state.post_state_hash),
                             &mergeable_chs,
+                            &state_chs,
                         ) {
                             tracing::warn!(
                                 "Skipping block index cache update for block {}: {}",
@@ -977,7 +955,7 @@ impl<T: TransportLayer + Send + Sync> Casper for MultiParentCasperImpl<T> {
                 );
 
                 match maybe_mergeable {
-                    Ok(mergeable_chs) => {
+                    Ok((mergeable_chs, state_chs)) => {
                         if let Err(err) = self.runtime_manager.get_or_compute_block_index(
                             &block.block_hash,
                             block.body.state.block_number,
@@ -986,6 +964,7 @@ impl<T: TransportLayer + Send + Sync> Casper for MultiParentCasperImpl<T> {
                             &Blake2b256Hash::from_bytes_prost(&block.body.state.pre_state_hash),
                             &Blake2b256Hash::from_bytes_prost(&block.body.state.post_state_hash),
                             &mergeable_chs,
+                            &state_chs,
                         ) {
                             tracing::warn!(
                                 "Skipping block index cache update for self-created block {}: {}",

--- a/casper/src/rust/rholang/replay_runtime.rs
+++ b/casper/src/rust/rholang/replay_runtime.rs
@@ -21,7 +21,7 @@ use rholang::rust::interpreter::{
 use rspace_plus_plus::rspace::{
     hashing::blake2b256_hash::Blake2b256Hash,
     history::Either,
-    merger::merging_logic::{MergeType, NumberChannelsEndVal},
+    merger::merging_logic::{MergeType, NumberChannelsEndVal, StateChannelsEndVal},
 };
 
 use crate::rust::{
@@ -99,7 +99,7 @@ impl ReplayRuntimeOps {
         block_data: &BlockData,
         invalid_blocks: Option<HashMap<BlockHash, Validator>>,
         is_genesis: bool, //FIXME have a better way of knowing this. Pass the replayDeploy function maybe? - OLD
-    ) -> Result<(Blake2b256Hash, Vec<NumberChannelsEndVal>), CasperError> {
+    ) -> Result<(Blake2b256Hash, Vec<NumberChannelsEndVal>, Vec<StateChannelsEndVal>), CasperError> {
         let invalid_blocks = invalid_blocks.unwrap_or_default();
 
         self.runtime_ops
@@ -127,7 +127,7 @@ impl ReplayRuntimeOps {
         system_deploys: Vec<ProcessedSystemDeploy>,
         with_cost_accounting: bool,
         block_data: &BlockData,
-    ) -> Result<(Blake2b256Hash, Vec<NumberChannelsEndVal>), CasperError> {
+    ) -> Result<(Blake2b256Hash, Vec<NumberChannelsEndVal>, Vec<StateChannelsEndVal>), CasperError> {
         // Time reset phase - Span[F].traceI("reset") from Scala
         let reset_start = Instant::now();
         self.runtime_ops
@@ -159,9 +159,14 @@ impl ReplayRuntimeOps {
         metrics::histogram!(BLOCK_REPLAY_PHASE_SYSTEM_DEPLOYS_TIME_METRIC, "source" => CASPER_METRICS_SOURCE)
             .record(system_deploys_start.elapsed().as_secs_f64());
 
-        let mut all_mergeable = Vec::new();
-        all_mergeable.extend(deploy_results);
-        all_mergeable.extend(system_deploy_results);
+        // Split (Number, State) tuples into parallel vectors aligned by deploy
+        // index, mirroring the play-side cascade.
+        let mut all_number = Vec::with_capacity(deploy_results.len() + system_deploy_results.len());
+        let mut all_state = Vec::with_capacity(deploy_results.len() + system_deploy_results.len());
+        for (number, state) in deploy_results.into_iter().chain(system_deploy_results.into_iter()) {
+            all_number.push(number);
+            all_state.push(state);
+        }
 
         // Time create-checkpoint phase - Span[F].traceI("create-checkpoint") from Scala
         let checkpoint_start = Instant::now();
@@ -171,7 +176,7 @@ impl ReplayRuntimeOps {
         metrics::histogram!(BLOCK_REPLAY_PHASE_CREATE_CHECKPOINT_TIME_METRIC, "source" => CASPER_METRICS_SOURCE)
             .record(checkpoint_start.elapsed().as_secs_f64());
 
-        Ok((checkpoint.root, all_mergeable))
+        Ok((checkpoint.root, all_number, all_state))
     }
 
     /**
@@ -200,7 +205,7 @@ impl ReplayRuntimeOps {
         &mut self,
         with_cost_accounting: bool,
         processed_deploy: &ProcessedDeploy,
-    ) -> Result<NumberChannelsEndVal, CasperError> {
+    ) -> Result<(NumberChannelsEndVal, StateChannelsEndVal), CasperError> {
         let mut mergeable_channels: HashMap<Par, MergeType> = HashMap::new();
 
         let rig_start = Instant::now();
@@ -227,10 +232,14 @@ impl ReplayRuntimeOps {
             .runtime_ops
             .get_number_channels_data(&mergeable_channels)
             .await?;
+        let state_channels_data = self
+            .runtime_ops
+            .get_state_channels_data(&mergeable_channels)
+            .await?;
         metrics::histogram!(BLOCK_REPLAY_SYSDEPLOY_CHECKPOINT_MERGEABLE_TIME_METRIC, "source" => CASPER_METRICS_SOURCE)
             .record(checkpoint_mergeable_start.elapsed().as_secs_f64());
 
-        Ok(channels_data)
+        Ok((channels_data, state_channels_data))
     }
 
     async fn process_deploy_with_cost_accounting(
@@ -402,7 +411,7 @@ impl ReplayRuntimeOps {
         &mut self,
         block_data: &BlockData,
         processed_system_deploy: &ProcessedSystemDeploy,
-    ) -> Result<NumberChannelsEndVal, CasperError> {
+    ) -> Result<(NumberChannelsEndVal, StateChannelsEndVal), CasperError> {
         let system_deploy = match processed_system_deploy {
             ProcessedSystemDeploy::Succeeded {
                 ref system_deploy, ..
@@ -438,12 +447,16 @@ impl ReplayRuntimeOps {
                     .runtime_ops
                     .get_number_channels_data(&eval_result.mergeable)
                     .await?;
+                let state_map = self
+                    .runtime_ops
+                    .get_state_channels_data(&eval_result.mergeable)
+                    .await?;
                 metrics::histogram!(BLOCK_REPLAY_SYSDEPLOY_CHECKPOINT_MERGEABLE_TIME_METRIC, "source" => CASPER_METRICS_SOURCE)
                     .record(checkpoint_mergeable_start.elapsed().as_secs_f64());
 
                 self.check_replay_data_with_fix(eval_result.errors.is_empty())
                     .await?;
-                Ok(map)
+                Ok((map, state_map))
             }
 
             SystemDeployData::CloseBlockSystemDeployData => {
@@ -470,12 +483,16 @@ impl ReplayRuntimeOps {
                     .runtime_ops
                     .get_number_channels_data(&eval_result.mergeable)
                     .await?;
+                let state_map = self
+                    .runtime_ops
+                    .get_state_channels_data(&eval_result.mergeable)
+                    .await?;
                 metrics::histogram!(BLOCK_REPLAY_SYSDEPLOY_CHECKPOINT_MERGEABLE_TIME_METRIC, "source" => CASPER_METRICS_SOURCE)
                     .record(checkpoint_mergeable_start.elapsed().as_secs_f64());
 
                 self.check_replay_data_with_fix(eval_result.errors.is_empty())
                     .await?;
-                Ok(map)
+                Ok((map, state_map))
             }
 
             SystemDeployData::Empty => Err(CasperError::ReplayFailure(

--- a/casper/src/rust/rholang/runtime.rs
+++ b/casper/src/rust/rholang/runtime.rs
@@ -48,7 +48,7 @@ use rholang::rust::interpreter::{
 use rspace_plus_plus::rspace::{
     hashing::{blake2b256_hash::Blake2b256Hash, stable_hash_provider},
     history::{instances::radix_history::RadixHistory, Either},
-    merger::merging_logic::{MergeType, NumberChannelsEndVal},
+    merger::merging_logic::{MergeType, NumberChannelsEndVal, StateChannelsEndVal},
 };
 
 use crate::rust::{
@@ -130,8 +130,8 @@ impl RuntimeOps {
     ) -> Result<
         (
             StateHash,
-            Vec<(ProcessedDeploy, NumberChannelsEndVal)>,
-            Vec<(ProcessedSystemDeploy, NumberChannelsEndVal)>,
+            Vec<(ProcessedDeploy, NumberChannelsEndVal, StateChannelsEndVal)>,
+            Vec<(ProcessedSystemDeploy, NumberChannelsEndVal, StateChannelsEndVal)>,
         ),
         CasperError,
     > {
@@ -211,9 +211,14 @@ impl RuntimeOps {
                     state_hash,
                     processed_system_deploy,
                     mergeable_channels,
+                    state_channels,
                     result: _,
                 } => {
-                    processed_system_deploys.push((processed_system_deploy, mergeable_channels));
+                    processed_system_deploys.push((
+                        processed_system_deploy,
+                        mergeable_channels,
+                        state_channels,
+                    ));
                     current_hash = state_hash;
                 }
                 SystemDeployResult::PlayFailed {
@@ -253,7 +258,7 @@ impl RuntimeOps {
         (
             StateHash,
             StateHash,
-            Vec<(ProcessedDeploy, NumberChannelsEndVal)>,
+            Vec<(ProcessedDeploy, NumberChannelsEndVal, StateChannelsEndVal)>,
         ),
         CasperError,
     > {
@@ -288,7 +293,7 @@ impl RuntimeOps {
         &mut self,
         start_hash: &StateHash,
         terms: Vec<Signed<DeployData>>,
-    ) -> Result<(StateHash, Vec<(ProcessedDeploy, NumberChannelsEndVal)>), CasperError> {
+    ) -> Result<(StateHash, Vec<(ProcessedDeploy, NumberChannelsEndVal, StateChannelsEndVal)>), CasperError> {
         let mem_profile_enabled = crate::rust::util::rholang::mem_profiler::mem_profile_enabled();
         let read_vm_rss_kb =
             || -> Option<usize> { crate::rust::util::rholang::mem_profiler::read_vm_rss_kb() };
@@ -358,7 +363,7 @@ impl RuntimeOps {
         &mut self,
         start_hash: &StateHash,
         terms: Vec<Signed<DeployData>>,
-    ) -> Result<(StateHash, Vec<(ProcessedDeploy, NumberChannelsEndVal)>), CasperError> {
+    ) -> Result<(StateHash, Vec<(ProcessedDeploy, NumberChannelsEndVal, StateChannelsEndVal)>), CasperError> {
         // Using tracing events for async - Span[F].withMarks("play-deploys") from Scala
         tracing::info!(target: "f1r3fly.casper.play-deploys-genesis", "play-deploys-genesis-started");
         self.runtime
@@ -380,7 +385,7 @@ impl RuntimeOps {
     pub async fn play_deploy_with_cost_accounting(
         &mut self,
         deploy: Signed<DeployData>,
-    ) -> Result<(ProcessedDeploy, NumberChannelsEndVal), CasperError> {
+    ) -> Result<(ProcessedDeploy, NumberChannelsEndVal, StateChannelsEndVal), CasperError> {
         let mem_profile_enabled = crate::rust::util::rholang::mem_profiler::mem_profile_enabled();
         let read_vm_rss_kb =
             || -> Option<usize> { crate::rust::util::rholang::mem_profiler::read_vm_rss_kb() };
@@ -489,6 +494,9 @@ impl RuntimeOps {
                         let mergeable_channels_data = self
                             .get_number_channels_data(&eval_collector_state.mergeable_channels)
                             .await?;
+                        let state_channels_data = self
+                            .get_state_channels_data(&eval_collector_state.mergeable_channels)
+                            .await?;
 
                         let deploy_log = mem::take(&mut eval_collector_state.event_log);
                         log_mem_step("after_collect_result");
@@ -496,6 +504,7 @@ impl RuntimeOps {
                         Ok((
                             ProcessedDeploy { deploy_log, ..pd },
                             mergeable_channels_data,
+                            state_channels_data,
                         ))
                     }
 
@@ -536,6 +545,9 @@ impl RuntimeOps {
                 let mergeable_channels_data = self
                     .get_number_channels_data(&eval_collector_state.mergeable_channels)
                     .await?;
+                let state_channels_data = self
+                    .get_state_channels_data(&eval_collector_state.mergeable_channels)
+                    .await?;
 
                 let deploy_log = mem::take(&mut eval_collector_state.event_log);
 
@@ -545,6 +557,7 @@ impl RuntimeOps {
                         ..empty_pd
                     },
                     mergeable_channels_data,
+                    state_channels_data,
                 ))
             }
         }
@@ -588,10 +601,11 @@ impl RuntimeOps {
     pub async fn process_deploy_with_mergeable_data(
         &mut self,
         deploy: Signed<DeployData>,
-    ) -> Result<(ProcessedDeploy, NumberChannelsEndVal), CasperError> {
+    ) -> Result<(ProcessedDeploy, NumberChannelsEndVal, StateChannelsEndVal), CasperError> {
         let (pd, merge_chs) = self.process_deploy(deploy).await?;
-        let data = self.get_number_channels_data(&merge_chs).await?;
-        Ok((pd, data))
+        let number_data = self.get_number_channels_data(&merge_chs).await?;
+        let state_data = self.get_state_channels_data(&merge_chs).await?;
+        Ok((pd, number_data, state_data))
     }
 
     pub async fn get_number_channels_data(
@@ -624,6 +638,10 @@ impl RuntimeOps {
             MergeType::BitmaskOr => values
                 .iter()
                 .fold(0i64, |acc, v| ((acc as u64) | (*v as u64)) as i64),
+            MergeType::MutexState => unreachable!(
+                "MutexState channels do not flow through the numeric \
+                 fold_multi_value path; they use the parallel state-channel pipeline"
+            ),
         };
         Some(folded)
     }
@@ -683,6 +701,69 @@ impl RuntimeOps {
         }
     }
 
+    /// Extract `StateChannelsEndVal` from the deploy's mergeable channel set.
+    /// Filters for `MutexState`-tagged channels and returns each channel's
+    /// bincode-serialized winner Datum.
+    pub async fn get_state_channels_data(
+        &self,
+        channels: &std::collections::HashMap<Par, MergeType>,
+    ) -> Result<StateChannelsEndVal, CasperError> {
+        let mut result = BTreeMap::new();
+        for (channel, merge_type) in channels {
+            if !matches!(merge_type, MergeType::MutexState) {
+                continue;
+            }
+            if let Some((hash, bytes)) = self.get_state_channel(channel).await? {
+                result.insert(hash, (bytes, *merge_type));
+            }
+        }
+        Ok(result)
+    }
+
+    /// Read a single MutexState-tagged channel's current Datum and return
+    /// its bincode-serialized bytes. If the channel currently holds multiple
+    /// Datums (residue from a sibling proposal that hasn't been merged yet),
+    /// pick the lowest-Blake2b256 winner — same determinism rule as
+    /// `combine_mergeable_state`.
+    pub async fn get_state_channel(
+        &self,
+        channel: &Par,
+    ) -> Result<Option<(Blake2b256Hash, Vec<u8>)>, CasperError> {
+        use rspace_plus_plus::rspace::serializers::serializers as rspace_serializers;
+
+        let ch_values = self.runtime.get_data(channel).await;
+        if ch_values.is_empty() {
+            return Ok(None);
+        }
+        let ch_hash = stable_hash_provider::hash(channel);
+
+        // Lowest-hash-of-bincode winner across all Datums currently on the
+        // channel. For a normal "exactly one Datum" channel, this is just
+        // the single Datum's bytes. For multi-Datum residue, it deterministi-
+        // cally collapses to one — same rule as combine_mergeable_state.
+        let chosen_bytes = ch_values
+            .iter()
+            .map(|d| rspace_serializers::encode_datum(d))
+            .min_by(|a, b| Blake2b256Hash::new(a).bytes().cmp(&Blake2b256Hash::new(b).bytes()))
+            .expect("get_state_channel: ch_values non-empty checked above");
+
+        if ch_values.len() > 1 {
+            tracing::warn!(
+                target: "f1r3fly.mergeable_channel.sanitize",
+                "StateChannel has {} values; collapsed to deterministic winner for channel {}",
+                ch_values.len(),
+                hex::encode(ch_hash.clone().bytes()),
+            );
+            metrics::counter!(
+                "mergeable_channel_state_sanitized_total",
+                "source" => "casper_runtime"
+            )
+            .increment(1);
+        }
+
+        Ok(Some((ch_hash, chosen_bytes)))
+    }
+
     /* System deploy evaluators */
 
     /**
@@ -708,6 +789,7 @@ impl RuntimeOps {
         match result {
             Either::Right(system_deploy_result) => {
                 let mcl = self.get_number_channels_data(&mergeable_channels).await?;
+                let scl = self.get_state_channels_data(&mergeable_channels).await?;
                 if let Some(SlashDeploy {
                     invalid_block_hash,
                     pk,
@@ -719,6 +801,7 @@ impl RuntimeOps {
                         event_log,
                         SystemDeployData::create_slash(invalid_block_hash.clone(), pk.clone()),
                         mcl,
+                        scl,
                         system_deploy_result,
                     ))
                 } else if let Some(CloseBlockDeploy { .. }) =
@@ -729,6 +812,7 @@ impl RuntimeOps {
                         event_log,
                         SystemDeployData::create_close(),
                         mcl,
+                        scl,
                         system_deploy_result,
                     ))
                 } else {
@@ -737,6 +821,7 @@ impl RuntimeOps {
                         event_log,
                         SystemDeployData::Empty,
                         mcl,
+                        scl,
                         system_deploy_result,
                     ))
                 }

--- a/casper/src/rust/rholang/runtime.rs
+++ b/casper/src/rust/rholang/runtime.rs
@@ -131,7 +131,11 @@ impl RuntimeOps {
         (
             StateHash,
             Vec<(ProcessedDeploy, NumberChannelsEndVal, StateChannelsEndVal)>,
-            Vec<(ProcessedSystemDeploy, NumberChannelsEndVal, StateChannelsEndVal)>,
+            Vec<(
+                ProcessedSystemDeploy,
+                NumberChannelsEndVal,
+                StateChannelsEndVal,
+            )>,
         ),
         CasperError,
     > {
@@ -293,7 +297,13 @@ impl RuntimeOps {
         &mut self,
         start_hash: &StateHash,
         terms: Vec<Signed<DeployData>>,
-    ) -> Result<(StateHash, Vec<(ProcessedDeploy, NumberChannelsEndVal, StateChannelsEndVal)>), CasperError> {
+    ) -> Result<
+        (
+            StateHash,
+            Vec<(ProcessedDeploy, NumberChannelsEndVal, StateChannelsEndVal)>,
+        ),
+        CasperError,
+    > {
         let mem_profile_enabled = crate::rust::util::rholang::mem_profiler::mem_profile_enabled();
         let read_vm_rss_kb =
             || -> Option<usize> { crate::rust::util::rholang::mem_profiler::read_vm_rss_kb() };
@@ -363,7 +373,13 @@ impl RuntimeOps {
         &mut self,
         start_hash: &StateHash,
         terms: Vec<Signed<DeployData>>,
-    ) -> Result<(StateHash, Vec<(ProcessedDeploy, NumberChannelsEndVal, StateChannelsEndVal)>), CasperError> {
+    ) -> Result<
+        (
+            StateHash,
+            Vec<(ProcessedDeploy, NumberChannelsEndVal, StateChannelsEndVal)>,
+        ),
+        CasperError,
+    > {
         // Using tracing events for async - Span[F].withMarks("play-deploys") from Scala
         tracing::info!(target: "f1r3fly.casper.play-deploys-genesis", "play-deploys-genesis-started");
         self.runtime
@@ -642,6 +658,10 @@ impl RuntimeOps {
                 "MutexState channels do not flow through the numeric \
                  fold_multi_value path; they use the parallel state-channel pipeline"
             ),
+            MergeType::AdditiveSet => unreachable!(
+                "AdditiveSet channels do not flow through the numeric \
+                 fold_multi_value path; they use the parallel state-channel pipeline"
+            ),
         };
         Some(folded)
     }
@@ -702,15 +722,15 @@ impl RuntimeOps {
     }
 
     /// Extract `StateChannelsEndVal` from the deploy's mergeable channel set.
-    /// Filters for `MutexState`-tagged channels and returns each channel's
-    /// bincode-serialized winner Datum.
+    /// Filters for state-channel merge types (`MutexState`, `AdditiveSet`)
+    /// and returns each channel's bincode-serialized current Datum.
     pub async fn get_state_channels_data(
         &self,
         channels: &std::collections::HashMap<Par, MergeType>,
     ) -> Result<StateChannelsEndVal, CasperError> {
         let mut result = BTreeMap::new();
         for (channel, merge_type) in channels {
-            if !matches!(merge_type, MergeType::MutexState) {
+            if !matches!(merge_type, MergeType::MutexState | MergeType::AdditiveSet) {
                 continue;
             }
             if let Some((hash, bytes)) = self.get_state_channel(channel).await? {
@@ -744,7 +764,11 @@ impl RuntimeOps {
         let chosen_bytes = ch_values
             .iter()
             .map(|d| rspace_serializers::encode_datum(d))
-            .min_by(|a, b| Blake2b256Hash::new(a).bytes().cmp(&Blake2b256Hash::new(b).bytes()))
+            .min_by(|a, b| {
+                Blake2b256Hash::new(a)
+                    .bytes()
+                    .cmp(&Blake2b256Hash::new(b).bytes())
+            })
             .expect("get_state_channel: ch_values non-empty checked above");
 
         if ch_values.len() > 1 {

--- a/casper/src/rust/util/rholang/interpreter_util.rs
+++ b/casper/src/rust/util/rholang/interpreter_util.rs
@@ -855,7 +855,7 @@ pub fn compute_parents_post_state(
                 let sender = b.sender.clone();
                 let seq_num = b.seq_num;
 
-                let mergeable_chs =
+                let (mergeable_chs, state_chs) =
                     runtime_manager.load_mergeable_channels(post_state, sender, seq_num)?;
 
                 let block_index = crate::rust::merging::block_index::new(
@@ -867,6 +867,7 @@ pub fn compute_parents_post_state(
                     &Blake2b256Hash::from_bytes_prost(post_state),
                     &runtime_manager.history_repo,
                     &mergeable_chs,
+                    &state_chs,
                 )?;
 
                 // Cache the result

--- a/casper/src/rust/util/rholang/runtime_manager.rs
+++ b/casper/src/rust/util/rholang/runtime_manager.rs
@@ -20,14 +20,16 @@ use models::rust::validator::Validator;
 use rholang::rust::interpreter::external_services::ExternalServices;
 use rholang::rust::interpreter::matcher::r#match::Matcher;
 use rholang::rust::interpreter::merging::rholang_merging_logic::{
-    DeployMergeableData, NumberChannel, RholangMergingLogic,
+    DeployMergeableData, NumberChannel, RholangMergingLogic, StateChannel,
 };
 use rholang::rust::interpreter::rho_runtime::{
     self, RhoHistoryRepository, RhoRuntime, RhoRuntimeImpl,
 };
 use rholang::rust::interpreter::system_processes::BlockData;
 use rspace_plus_plus::rspace::hashing::blake2b256_hash::Blake2b256Hash;
-use rspace_plus_plus::rspace::merger::merging_logic::{NumberChannelsDiff, NumberChannelsEndVal};
+use rspace_plus_plus::rspace::merger::merging_logic::{
+    NumberChannelsDiff, NumberChannelsEndVal, StateChannelsDiff, StateChannelsEndVal,
+};
 use rspace_plus_plus::rspace::replay_rspace::ReplayRSpace;
 use rspace_plus_plus::rspace::rspace::{RSpace, RSpaceStore};
 use rspace_plus_plus::rspace::shared::key_value_store_manager::KeyValueStoreManager;
@@ -329,19 +331,32 @@ impl RuntimeManager {
             )
             .await?;
 
-        let (usr_processed, usr_mergeable): (Vec<ProcessedDeploy>, Vec<NumberChannelsEndVal>) =
-            usr_deploy_res.into_iter().unzip();
-        let (sys_processed, sys_mergeable): (
-            Vec<ProcessedSystemDeploy>,
-            Vec<NumberChannelsEndVal>,
-        ) = sys_deploy_res.into_iter().unzip();
+        let mut usr_processed = Vec::with_capacity(usr_deploy_res.len());
+        let mut usr_mergeable = Vec::with_capacity(usr_deploy_res.len());
+        let mut usr_state = Vec::with_capacity(usr_deploy_res.len());
+        for (pd, m, s) in usr_deploy_res {
+            usr_processed.push(pd);
+            usr_mergeable.push(m);
+            usr_state.push(s);
+        }
+        let mut sys_processed = Vec::with_capacity(sys_deploy_res.len());
+        let mut sys_mergeable = Vec::with_capacity(sys_deploy_res.len());
+        let mut sys_state = Vec::with_capacity(sys_deploy_res.len());
+        for (psd, m, s) in sys_deploy_res {
+            sys_processed.push(psd);
+            sys_mergeable.push(m);
+            sys_state.push(s);
+        }
         let replay_cache_event_log_cap = Self::max_replay_cache_event_log_entries();
 
-        // Concat user and system deploys mergeable channel maps
-        let mergeable_chs = usr_mergeable
+        // Concat user and system deploys mergeable channel maps (per-deploy
+        // alignment preserved). Both pipelines are persisted side-by-side.
+        let mergeable_chs: Vec<NumberChannelsEndVal> = usr_mergeable
             .into_iter()
             .chain(sys_mergeable.into_iter())
             .collect();
+        let state_chs: Vec<StateChannelsEndVal> =
+            usr_state.into_iter().chain(sys_state.into_iter()).collect();
 
         // Convert from final to diff values and persist mergeable (number) channels for post-state hash
         let pre_state_hash = Blake2b256Hash::from_bytes_prost(&start_hash);
@@ -353,6 +368,7 @@ impl RuntimeManager {
             sender.bytes.clone(),
             seq_num,
             mergeable_chs,
+            state_chs,
             &pre_state_hash,
         )?;
 
@@ -460,19 +476,31 @@ impl RuntimeManager {
             .await?;
         log_mem_step("after_compute_state");
 
-        let (usr_processed, usr_mergeable): (Vec<ProcessedDeploy>, Vec<NumberChannelsEndVal>) =
-            usr_deploy_res.into_iter().unzip();
-        let (sys_processed, sys_mergeable): (
-            Vec<ProcessedSystemDeploy>,
-            Vec<NumberChannelsEndVal>,
-        ) = sys_deploy_res.into_iter().unzip();
+        let mut usr_processed = Vec::with_capacity(usr_deploy_res.len());
+        let mut usr_mergeable = Vec::with_capacity(usr_deploy_res.len());
+        let mut usr_state = Vec::with_capacity(usr_deploy_res.len());
+        for (pd, m, s) in usr_deploy_res {
+            usr_processed.push(pd);
+            usr_mergeable.push(m);
+            usr_state.push(s);
+        }
+        let mut sys_processed = Vec::with_capacity(sys_deploy_res.len());
+        let mut sys_mergeable = Vec::with_capacity(sys_deploy_res.len());
+        let mut sys_state = Vec::with_capacity(sys_deploy_res.len());
+        for (psd, m, s) in sys_deploy_res {
+            sys_processed.push(psd);
+            sys_mergeable.push(m);
+            sys_state.push(s);
+        }
         let replay_cache_event_log_cap = Self::max_replay_cache_event_log_entries();
 
         // Concat user and system deploys mergeable channel maps
-        let mergeable_chs = usr_mergeable
+        let mergeable_chs: Vec<NumberChannelsEndVal> = usr_mergeable
             .into_iter()
             .chain(sys_mergeable.into_iter())
             .collect();
+        let state_chs: Vec<StateChannelsEndVal> =
+            usr_state.into_iter().chain(sys_state.into_iter()).collect();
 
         // Convert from final to diff values and persist mergeable (number) channels for post-state hash
         let pre_state_hash = Blake2b256Hash::from_bytes_prost(start_hash);
@@ -484,6 +512,7 @@ impl RuntimeManager {
             sender.bytes.clone(),
             seq_num,
             mergeable_chs,
+            state_chs,
             &pre_state_hash,
         )?;
         log_mem_step("after_save_mergeable_channels");
@@ -544,7 +573,14 @@ impl RuntimeManager {
         let (pre_state, state_hash, processed) = runtime_ops
             .compute_genesis(terms, block_time, block_number)
             .await?;
-        let (processed_deploys, mergeable_chs) = processed.into_iter().unzip();
+        let mut processed_deploys = Vec::with_capacity(processed.len());
+        let mut mergeable_chs = Vec::with_capacity(processed.len());
+        let mut state_chs = Vec::with_capacity(processed.len());
+        for (pd, m, s) in processed {
+            processed_deploys.push(pd);
+            mergeable_chs.push(m);
+            state_chs.push(s);
+        }
 
         // Convert from final to diff values and persist mergeable (number) channels for post-state hash
         let pre_state_hash = Blake2b256Hash::from_bytes_prost(&pre_state);
@@ -556,6 +592,7 @@ impl RuntimeManager {
             prost::bytes::Bytes::new(),
             0,
             mergeable_chs,
+            state_chs,
             &pre_state_hash,
         )?;
 
@@ -623,6 +660,7 @@ impl RuntimeManager {
                             post_state_hash,
                             sender.bytes.clone(),
                             seq_num,
+                            Vec::new(),
                             Vec::new(),
                             &pre_state_hash,
                         )?;
@@ -700,7 +738,7 @@ impl RuntimeManager {
         let runtime_ops = RuntimeOps::new(replay_runtime);
         let mut replay_runtime_ops = ReplayRuntimeOps::new(runtime_ops);
 
-        let (state_hash, mergeable_chs) = replay_runtime_ops
+        let (state_hash, mergeable_chs, state_chs) = replay_runtime_ops
             .replay_compute_state(
                 start_hash,
                 terms,
@@ -720,6 +758,7 @@ impl RuntimeManager {
             sender.bytes,
             seq_num,
             mergeable_chs,
+            state_chs,
             &pre_state_hash,
         )
         .unwrap_or_else(|e| panic!("Failed to save mergeable channels: {:?}", e));
@@ -852,6 +891,7 @@ impl RuntimeManager {
         pre_state_hash: &Blake2b256Hash,
         post_state_hash: &Blake2b256Hash,
         mergeable_chs: &Vec<NumberChannelsDiff>,
+        state_chs: &Vec<StateChannelsDiff>,
     ) -> Result<BlockIndex, CasperError> {
         if let Some(cached) = self.block_index_cache.get(block_hash) {
             Self::touch_cache_key(&self.block_index_cache_order, block_hash);
@@ -870,6 +910,7 @@ impl RuntimeManager {
             post_state_hash,
             &self.history_repo,
             mergeable_chs,
+            state_chs,
         )?;
 
         // Keep index cache bounded for long-running validators.
@@ -926,15 +967,15 @@ impl RuntimeManager {
             .set(self.parents_post_state_cache.len() as f64);
     }
 
-    /**
-     * Load mergeable channels from store
-     */
+    /// Load mergeable channels from store. Returns both the
+    /// `NumberChannelsDiff` vec (IntegerAdd/BitmaskOr) and the
+    /// `StateChannelsDiff` vec (MutexState). Both vecs align by deploy index.
     pub fn load_mergeable_channels(
         &self,
         state_hash_bs: &StateHash,
         creator: prost::bytes::Bytes,
         seq_num: i32,
-    ) -> Result<Vec<NumberChannelsDiff>, CasperError> {
+    ) -> Result<(Vec<NumberChannelsDiff>, Vec<StateChannelsDiff>), CasperError> {
         let state_hash = Blake2b256Hash::from_bytes_prost(state_hash_bs);
         let mergeable_key = MergeableKey {
             state_hash: StateHashSerde(state_hash.to_bytes_prost()),
@@ -949,16 +990,23 @@ impl RuntimeManager {
 
         match res {
             Some(res) => {
-                let res_map = res
-                    .into_iter()
-                    .map(|x| {
+                let mut number_diffs = Vec::with_capacity(res.len());
+                let mut state_diffs = Vec::with_capacity(res.len());
+                for x in res {
+                    number_diffs.push(
                         x.channels
                             .into_iter()
                             .map(|y| (y.hash, (y.diff, y.merge_type)))
-                            .collect::<BTreeMap<_, _>>()
-                    })
-                    .collect::<Vec<_>>();
-                Ok(res_map)
+                            .collect::<BTreeMap<_, _>>(),
+                    );
+                    state_diffs.push(
+                        x.state_channels
+                            .into_iter()
+                            .map(|y| (y.hash, (y.bytes, y.merge_type)))
+                            .collect::<BTreeMap<_, _>>(),
+                    );
+                }
+                Ok((number_diffs, state_diffs))
             }
             None => {
                 let msg = format!(
@@ -1059,16 +1107,28 @@ impl RuntimeManager {
         creator: prost::bytes::Bytes,
         seq_num: i32,
         channels_data: Vec<NumberChannelsEndVal>,
+        state_channels_data: Vec<StateChannelsEndVal>,
         // Used to calculate value difference from final values
         pre_state_hash: &Blake2b256Hash,
     ) -> Result<(), CasperError> {
+        // Per-deploy alignment: number and state vecs must be the same length.
+        debug_assert_eq!(
+            channels_data.len(),
+            state_channels_data.len(),
+            "save_mergeable_channels: number ({}) and state ({}) per-deploy vecs must align",
+            channels_data.len(),
+            state_channels_data.len(),
+        );
+
         // Calculate difference values from final values on number channels
         let diffs = self.convert_number_channels_to_diff(channels_data, pre_state_hash)?;
 
-        // Convert to storage types
+        // Convert to storage types — combine each deploy's number diff with its
+        // state-channel data into a single DeployMergeableData record.
         let deploy_channels = diffs
             .into_iter()
-            .map(|data| {
+            .zip(state_channels_data.into_iter())
+            .map(|(data, state_data)| {
                 let channels: Vec<NumberChannel> = data
                     .into_iter()
                     .map(|(hash, (diff, merge_type))| NumberChannel {
@@ -1078,7 +1138,19 @@ impl RuntimeManager {
                     })
                     .collect::<Vec<_>>();
 
-                DeployMergeableData { channels }
+                let state_channels: Vec<StateChannel> = state_data
+                    .into_iter()
+                    .map(|(hash, (bytes, merge_type))| StateChannel {
+                        hash,
+                        bytes,
+                        merge_type,
+                    })
+                    .collect::<Vec<_>>();
+
+                DeployMergeableData {
+                    channels,
+                    state_channels,
+                }
             })
             .collect();
 

--- a/casper/src/rust/util/rholang/system_deploy_result.rs
+++ b/casper/src/rust/util/rholang/system_deploy_result.rs
@@ -4,7 +4,9 @@ use models::rust::{
     block::state_hash::StateHash,
     casper::protocol::casper_message::{Event, ProcessedSystemDeploy, SystemDeployData},
 };
-use rspace_plus_plus::rspace::merger::merging_logic::NumberChannelsEndVal;
+use rspace_plus_plus::rspace::merger::merging_logic::{
+    NumberChannelsEndVal, StateChannelsEndVal,
+};
 
 use super::system_deploy_user_error::SystemDeployUserError;
 
@@ -13,6 +15,7 @@ pub enum SystemDeployResult<A> {
         state_hash: StateHash,
         processed_system_deploy: ProcessedSystemDeploy,
         mergeable_channels: NumberChannelsEndVal,
+        state_channels: StateChannelsEndVal,
         result: A,
     },
     PlayFailed {
@@ -26,6 +29,7 @@ impl<A> SystemDeployResult<A> {
         log: Vec<Event>,
         system_deploy_data: SystemDeployData,
         mergeable_channels: NumberChannelsEndVal,
+        state_channels: StateChannelsEndVal,
         result: A,
     ) -> Self {
         Self::PlaySucceeded {
@@ -35,6 +39,7 @@ impl<A> SystemDeployResult<A> {
                 system_deploy: system_deploy_data,
             },
             mergeable_channels,
+            state_channels,
             result,
         }
     }

--- a/casper/src/rust/util/rspace_history_horizon.rs
+++ b/casper/src/rust/util/rspace_history_horizon.rs
@@ -40,12 +40,27 @@
 
 use block_storage::rust::dag::block_dag_key_value_storage::KeyValueDagRepresentation;
 use block_storage::rust::key_value_block_store::KeyValueBlockStore;
+use models::rust::block_hash::BlockHash;
 use models::rust::casper::protocol::casper_message::BlockMessage;
 use rspace_plus_plus::rspace::hashing::blake2b256_hash::Blake2b256Hash;
 use shared::rust::store::key_value_store::KvStoreError;
 use std::collections::HashSet;
 
 use crate::rust::casper::CasperShardConf;
+
+/// Result of walking the forward-horizon DAG window. Carries both the block
+/// hashes (for storage-layers keyed by block — mergeable entries, block
+/// metadata) and the rspace state roots (for the rspace history sync).
+/// Single walk; both projections in one pass.
+pub struct ForwardHorizon {
+    /// Every block hash in the horizon, ordered LFB-side first (highest
+    /// block_number first), deduped.
+    pub block_hashes: Vec<BlockHash>,
+    /// Every rspace state root referenced by horizon blocks (post-state and
+    /// pre-state hashes), ordered LFB-side first, deduped. Within a single
+    /// block the post-state precedes the pre-state — see module-level docs.
+    pub roots: Vec<Blake2b256Hash>,
+}
 
 /// Compute the set of rspace roots a joiner needs in its local roots store
 /// before transitioning to Running. Walks every block in the DAG with
@@ -70,11 +85,32 @@ pub fn compute_forward_horizon_roots(
     lfb: &BlockMessage,
     casper_shard_conf: &CasperShardConf,
 ) -> Result<Vec<Blake2b256Hash>, KvStoreError> {
+    Ok(compute_forward_horizon(dag, block_store, lfb, casper_shard_conf)?.roots)
+}
+
+/// Walk the forward-horizon DAG window and return both the block hashes
+/// (for storage layers keyed by block — mergeable entries, block metadata)
+/// and the rspace state roots (for rspace history sync) in a single pass.
+/// Both projections are deduped and ordered LFB-side first.
+///
+/// Returns an empty `ForwardHorizon` if the LFB is at depth 0 (genesis) or
+/// if the horizon would extend below genesis (clamped to height 0). Also
+/// returns empty when `max_parent_depth == i32::MAX` (depth check disabled
+/// — the unbounded horizon is a deliberate opt-out; operators can use
+/// `disable-lfs = true` for full replay instead).
+pub fn compute_forward_horizon(
+    dag: &KeyValueDagRepresentation,
+    block_store: &KeyValueBlockStore,
+    lfb: &BlockMessage,
+    casper_shard_conf: &CasperShardConf,
+) -> Result<ForwardHorizon, KvStoreError> {
+    let empty = ForwardHorizon {
+        block_hashes: Vec::new(),
+        roots: Vec::new(),
+    };
+
     if casper_shard_conf.max_parent_depth == i32::MAX {
-        // Depth check disabled — joiner can validate against any historical
-        // block. Fall back to no horizon sync; caller can opt into full
-        // replay (`disable-lfs = true`) instead.
-        return Ok(Vec::new());
+        return Ok(empty);
     }
 
     let lfb_height = lfb.body.state.block_number;
@@ -83,7 +119,7 @@ pub fn compute_forward_horizon_roots(
     let min_height = std::cmp::max(0, lfb_height - horizon_depth);
 
     if min_height > lfb_height {
-        return Ok(Vec::new());
+        return Ok(empty);
     }
 
     // topo_sort returns Vec<Vec<BlockHash>> — one inner vec per height,
@@ -91,15 +127,20 @@ pub fn compute_forward_horizon_roots(
     // Ordering: ascending by height. Reverse to get LFB-side first.
     let layers = dag.topo_sort(min_height, Some(lfb_height))?;
 
+    let mut block_hashes: Vec<BlockHash> = Vec::new();
+    let mut block_seen: HashSet<BlockHash> = HashSet::new();
     let mut roots: Vec<Blake2b256Hash> = Vec::new();
-    let mut seen: HashSet<Blake2b256Hash> = HashSet::new();
+    let mut root_seen: HashSet<Blake2b256Hash> = HashSet::new();
     for layer in layers.iter().rev() {
         for block_hash in layer {
+            if !block_seen.insert(block_hash.clone()) {
+                continue;
+            }
             let block = match block_store.get(block_hash)? {
                 Some(b) => b,
                 None => {
                     tracing::warn!(
-                        "compute_forward_horizon_roots: block {} in DAG but missing from block_store",
+                        "compute_forward_horizon: block {} in DAG but missing from block_store",
                         models::rust::casper::pretty_printer::PrettyPrinter::build_string_bytes(
                             block_hash
                         )
@@ -107,17 +148,21 @@ pub fn compute_forward_horizon_roots(
                     continue;
                 }
             };
+            block_hashes.push(block_hash.clone());
             let post = Blake2b256Hash::from_bytes_prost(&block.body.state.post_state_hash);
-            if seen.insert(post.clone()) {
+            if root_seen.insert(post.clone()) {
                 roots.push(post);
             }
             let pre = Blake2b256Hash::from_bytes_prost(&block.body.state.pre_state_hash);
-            if seen.insert(pre.clone()) {
+            if root_seen.insert(pre.clone()) {
                 roots.push(pre);
             }
         }
     }
-    Ok(roots)
+    Ok(ForwardHorizon {
+        block_hashes,
+        roots,
+    })
 }
 
 /// Compute the LFS lower-bound block number for joiner-side block download.

--- a/casper/tests/batch1/multi_parent_casper_reporting_spec.rs
+++ b/casper/tests/batch1/multi_parent_casper_reporting_spec.rs
@@ -1,20 +1,31 @@
 // See casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperReportingSpec.scala
 
-/*
- * THIS TEST CANNOT BE PORTED YET
- *
- * ReportingCasper trait and implementation are not ported to Rust.
- * Required Rust components missing: ReportingCasper trait, rho_reporter function, ReportingRuntime, and trace method.
- * ReportingRspace::get_report exists in Rust (rspace++/src/rspace/reporting_rspace.rs:187) but is not integrated with Casper.
- * This test is marked as ignored until ReportingCasper infrastructure is ported from Scala to Rust.
- */
+use crate::util::rholang::resources::mk_test_rnode_store_manager_shared;
+use casper::rust::reporting_casper::{rho_reporter, ReportingCasper};
+use casper::rust::util::construct_deploy;
+use models::rhoapi::{BindPattern, ListParWithRandom, Par, TaggedContinuation};
+use models::rust::casper::protocol::casper_message::Event;
+use rholang::rust::interpreter::external_services::ExternalServices;
+use rspace_plus_plus::rspace::hashing::blake2b256_hash::Blake2b256Hash;
+use rspace_plus_plus::rspace::history::history_repository::HistoryRepositoryInstances;
+use rspace_plus_plus::rspace::reporting_rspace::ReportingEvent;
+use rspace_plus_plus::rspace::shared::key_value_store_manager::KeyValueStoreManager;
+use rspace_plus_plus::rspace::state::exporters::rspace_exporter_items::RSpaceExporterItems;
 
 use crate::helper::test_node::TestNode;
 use crate::util::genesis_builder::GenesisBuilder;
-use casper::rust::util::construct_deploy;
 
+/// Mirrors `MultiParentCasperReportingSpec` from the Scala suite. The
+/// reporter must converge to the same post-state hash as production for
+/// every block, and its replayed COMM-event count for each deploy must
+/// equal what the production execution recorded in the deploy log.
+///
+/// Anything else means the reporter's replay diverges from the
+/// production-recorded execution — the bug class observed on
+/// LFS-synced READONLY observers where every block's precharge system
+/// deploy returns `ConsumeFailed` and `create_checkpoint` panics on
+/// unconsumed COMM events.
 #[tokio::test]
-#[ignore = "ReportingCasper not implemented for RSpace++ - see detailed comment above"]
 async fn reporting_casper_should_behave_the_same_way_as_multi_parent_casper() {
     let genesis = GenesisBuilder::new()
         .build_genesis_with_parameters(None)
@@ -33,16 +44,226 @@ async fn reporting_casper_should_behave_the_same_way_as_multi_parent_casper() {
     )
     .unwrap();
 
-    let _signed_block = node.add_block_from_deploys(&[deploy]).await.unwrap();
+    let signed_block = node.add_block_from_deploys(&[deploy]).await.unwrap();
 
-    // TODO: Once ReportingCasper is implemented for RSpace++:
-    // 1. Create ReportingCasper::rho_reporter(node.data_dir)
-    // 2. Call reporting_casper.trace(signed_block)
-    // 3. Verify trace.deploy_report_result[0].processed_deploy.deploy_log contains CommEvents
-    // 4. Count CommEvents in signed_block.body.deploys[0].deploy_log
-    // 5. Assert reporting_comm_events_num == deploy_comm_events_num
-    // 6. Assert trace.post_state_hash == signed_block.body.state.post_state_hash
+    let reporter: std::sync::Arc<dyn ReportingCasper> = rho_reporter(
+        &node.rspace_store,
+        &node.block_store,
+        &node.block_dag_storage,
+        ExternalServices::noop(),
+    );
 
-    // For now, just verify the block was created successfully (basic smoke test)
-    // Once reporting is implemented, uncomment and complete the assertions above
+    let trace = reporter
+        .trace(&signed_block)
+        .await
+        .expect("reporter.trace must succeed for a freshly-played block");
+
+    assert_eq!(
+        trace.deploy_report_result.len(),
+        signed_block.body.deploys.len(),
+        "reporter must produce one deploy report per processed deploy",
+    );
+
+    // COMM-event count: reporter's collected events for the first deploy
+    // must equal the production deploy_log's COMM count. (Persistent-mode
+    // produces / consumes can drift on non-COMM event kinds; only COMM
+    // events are required to match one-for-one.)
+    let production_comm_events = signed_block.body.deploys[0]
+        .deploy_log
+        .iter()
+        .filter(|event| matches!(event, Event::Comm(_)))
+        .count();
+    let reporter_comm_events = trace.deploy_report_result[0]
+        .events
+        .iter()
+        .flatten()
+        .filter(|event| matches!(event, ReportingEvent::ReportingComm(_)))
+        .count();
+    assert_eq!(
+        reporter_comm_events, production_comm_events,
+        "reporter must produce the same COMM event count as production for \
+         the same deploy. Mismatch means replay diverged from production.",
+    );
+
+    // Post-state hash is the strongest single check: it folds in every
+    // committed COMM event and channel write across all of the block's
+    // deploys + system deploys.
+    let production_post_state = signed_block.body.state.post_state_hash.clone();
+    let reporter_post_state: Vec<u8> = trace.post_state_hash.to_vec();
+    assert_eq!(
+        reporter_post_state,
+        production_post_state.to_vec(),
+        "reporter post_state_hash must match production for the same block",
+    );
+}
+
+/// Reproduces the observer-side reporter divergence at the unit-test
+/// level. Mirrors the production scenario:
+///
+///   1. Node A plays a deploy and produces a block (the "producer").
+///   2. A second, empty rspace store B is created (the "joiner").
+///   3. B is populated by exporting A's rspace via the rspace exporter
+///      and importing the items via the rspace importer — exactly the
+///      contract the LFS forward-horizon sync uses on a real joiner.
+///   4. A reporter is constructed against B's freshly-imported store
+///      and asked to trace the same block.
+///   5. The reporter MUST converge to the same post-state hash and the
+///      same COMM-event count as the producer.
+///
+/// In production this fails on every observer that LFS-syncs to a live
+/// shard: the reporter's per-block precharge replay returns
+/// `ConsumeFailed`, deploy replay produces zero events, and
+/// `create_checkpoint` panics on the unconsumed COMM events left in
+/// the rigged trace. The same reporter against a freshly-played rspace
+/// (the test above) works correctly, so the divergence is specific to
+/// LFS-imported state, not to the reporter logic.
+#[tokio::test]
+async fn reporting_casper_works_against_lfs_imported_rspace() {
+    let genesis = GenesisBuilder::new()
+        .build_genesis_with_parameters(None)
+        .await
+        .expect("Failed to build genesis");
+
+    let mut node_a = TestNode::standalone(genesis.clone()).await.unwrap();
+
+    let correct_rholang = r#" for(@a <- @"1"){ Nil } | @"1"!("x") "#;
+    let deploy = construct_deploy::source_deploy_now(
+        correct_rholang.to_string(),
+        None,
+        None,
+        Some(genesis.genesis_block.shard_id.clone()),
+    )
+    .unwrap();
+
+    let signed_block = node_a.add_block_from_deploys(&[deploy]).await.unwrap();
+    let pre_state = Blake2b256Hash::from_bytes_prost(&signed_block.body.state.pre_state_hash);
+    let post_state = Blake2b256Hash::from_bytes_prost(&signed_block.body.state.post_state_hash);
+
+    // Producer-side history repo (for the exporter). We construct a
+    // fresh typed view over A's underlying KV stores so the exporter
+    // walks the same trie production wrote into.
+    let history_repo_a = HistoryRepositoryInstances::<
+        Par,
+        BindPattern,
+        ListParWithRandom,
+        TaggedContinuation,
+    >::lmdb_repository(
+        node_a.rspace_store.history.clone(),
+        node_a.rspace_store.roots.clone(),
+        node_a.rspace_store.cold.clone(),
+    )
+    .expect("Failed to construct producer history repository");
+    let exporter_a = history_repo_a.exporter();
+
+    // Joiner-side: brand-new on-disk LMDB, brand-new rspace_store. Nothing
+    // in it yet — this is the state observer1 starts in before LFS sync.
+    let scope_id = format!(
+        "reporter-lfs-import-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let mut kvm_b = mk_test_rnode_store_manager_shared(scope_id);
+    let rspace_store_b = (&mut *kvm_b)
+        .r_space_stores()
+        .await
+        .expect("Failed to construct joiner rspace stores");
+    let history_repo_b = HistoryRepositoryInstances::<
+        Par,
+        BindPattern,
+        ListParWithRandom,
+        TaggedContinuation,
+    >::lmdb_repository(
+        rspace_store_b.history.clone(),
+        rspace_store_b.roots.clone(),
+        rspace_store_b.cold.clone(),
+    )
+    .expect("Failed to construct joiner history repository");
+    let importer_b = history_repo_b.importer();
+
+    // Mirror the LFS forward-horizon import for both pre_state and
+    // post_state: walk the trie via the exporter in chunks, and feed
+    // each chunk to the joiner's importer until pagination terminates.
+    // Bounded loop: any honest peer with finite trie depth must
+    // terminate well below this bound.
+    let max_chunks_per_root = 4096;
+    let page_size = 1024;
+    for root in [&pre_state, &post_state] {
+        let mut start_path = vec![(root.clone(), None)];
+        let mut chunks = 0;
+        loop {
+            assert!(
+                chunks < max_chunks_per_root,
+                "exporter did not terminate within {} chunks for root {}",
+                max_chunks_per_root,
+                root
+            );
+            let (history, data) = RSpaceExporterItems::get_history_and_data(
+                exporter_a.clone(),
+                start_path.clone(),
+                0,
+                page_size,
+            );
+            let next_start = history.last_path.clone();
+            importer_b.set_history_items(history.items);
+            importer_b.set_data_items(data.items);
+            chunks += 1;
+            if next_start == start_path {
+                // Terminal cursor: subtree exhausted at this start_path.
+                break;
+            }
+            start_path = next_start;
+        }
+        importer_b.set_root(root);
+    }
+
+    // Construct the reporter against the joiner's LFS-imported store.
+    // BlockStore + BlockDagStorage reuse A's instances so the reporter
+    // can resolve the block; only the rspace state is freshly imported.
+    let reporter: std::sync::Arc<dyn ReportingCasper> = rho_reporter(
+        &rspace_store_b,
+        &node_a.block_store,
+        &node_a.block_dag_storage,
+        ExternalServices::noop(),
+    );
+
+    let trace = reporter
+        .trace(&signed_block)
+        .await
+        .expect("reporter.trace must succeed against an LFS-imported rspace");
+
+    assert_eq!(
+        trace.deploy_report_result.len(),
+        signed_block.body.deploys.len(),
+        "reporter must produce one deploy report per processed deploy",
+    );
+
+    let production_comm_events = signed_block.body.deploys[0]
+        .deploy_log
+        .iter()
+        .filter(|event| matches!(event, Event::Comm(_)))
+        .count();
+    let reporter_comm_events = trace.deploy_report_result[0]
+        .events
+        .iter()
+        .flatten()
+        .filter(|event| matches!(event, ReportingEvent::ReportingComm(_)))
+        .count();
+    assert_eq!(
+        reporter_comm_events, production_comm_events,
+        "reporter against LFS-imported rspace must produce the same COMM event \
+         count as production. Mismatch is the divergence we observe on \
+         observer1: replay leaves rigged events unconsumed because the \
+         imported rspace is missing some state production had.",
+    );
+
+    let production_post_state = signed_block.body.state.post_state_hash.clone();
+    let reporter_post_state: Vec<u8> = trace.post_state_hash.to_vec();
+    assert_eq!(
+        reporter_post_state,
+        production_post_state.to_vec(),
+        "reporter post_state_hash against LFS-imported rspace must match production",
+    );
 }

--- a/casper/tests/batch1/multi_parent_casper_reporting_spec.rs
+++ b/casper/tests/batch1/multi_parent_casper_reporting_spec.rs
@@ -9,7 +9,6 @@ use rholang::rust::interpreter::external_services::ExternalServices;
 use rspace_plus_plus::rspace::hashing::blake2b256_hash::Blake2b256Hash;
 use rspace_plus_plus::rspace::history::history_repository::HistoryRepositoryInstances;
 use rspace_plus_plus::rspace::reporting_rspace::ReportingEvent;
-use rspace_plus_plus::rspace::shared::key_value_store_manager::KeyValueStoreManager;
 use rspace_plus_plus::rspace::state::exporters::rspace_exporter_items::RSpaceExporterItems;
 
 use crate::helper::test_node::TestNode;

--- a/casper/tests/batch2/multi_validator_recovery_spec.rs
+++ b/casper/tests/batch2/multi_validator_recovery_spec.rs
@@ -17,10 +17,10 @@
 // them. The dedup logic is then the only mechanism that can avoid
 // surfacing the shared sig as a conflict-rejected duplicate.
 //
-// TDD red-green: disabling the dedup retain logic at
-// dag_merger.rs:201-213 routes the shared sig through
-// `conflict_set_merger`'s `same_deploy` short-circuit, surfacing it
-// in `rejected_user_deploys` and failing the assertion.
+// Disabling the dedup retain logic at dag_merger.rs:201-213 routes
+// the shared sig through `conflict_set_merger`'s `same_deploy`
+// short-circuit, surfacing it in `rejected_user_deploys` and failing
+// the assertion.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};

--- a/casper/tests/helper/test_node.rs
+++ b/casper/tests/helper/test_node.rs
@@ -82,6 +82,7 @@ pub struct TestNode {
         Mutex<block_storage::rust::deploy::key_value_rejected_deploy_buffer::KeyValueRejectedDeployBuffer>,
     >,
     pub runtime_manager: RuntimeManager,
+    pub rspace_store: rspace_plus_plus::rspace::rspace::RSpaceStore,
     // Note: no log field, logging will come from log crate
     pub requested_blocks: RequestedBlocks,
     pub connections_cell: ConnectionsCell,
@@ -931,7 +932,7 @@ impl TestNode {
             .unwrap();
         // Use create_with_history to ensure tests can reset to genesis state root hash
         let (runtime_manager, _rho_history_repository) = RuntimeManager::create_with_history(
-            rspace_store,
+            rspace_store.clone(),
             mergeable_store,
             std::sync::Arc::new(Genesis::default_mergeable_tags()),
             rholang::rust::interpreter::external_services::ExternalServices::noop(),
@@ -1111,6 +1112,7 @@ impl TestNode {
             deploy_storage,
             rejected_deploy_buffer,
             runtime_manager,
+            rspace_store,
             requested_blocks,
             connections_cell,
             rp_conf,

--- a/casper/tests/merging/bond_merge_regression_spec.rs
+++ b/casper/tests/merging/bond_merge_regression_spec.rs
@@ -1,0 +1,142 @@
+// Regression coverage for the bonding-drift class.
+//
+// When one branch's deploy contributes a bonds-map write (additive: only
+// that branch has it) and sibling branches contain heartbeat-only
+// `closeBlock` writes (idempotent: every branch produces equivalent
+// state for its own writes), the merge primitive must keep the additive
+// branch's contribution. A lowest-Blake2b256-hash LWW combine does NOT —
+// it picks one Datum's full Map and discards the others, so roughly
+// N-1 / N of the time the bond contribution is lost.
+//
+// The fix is `MergeType::AdditiveSet` whose combine function unions the
+// two Datums' Maps with per-key Last-Writer-Wins by sequence number,
+// applied to a dedicated bonds channel in PoS.rhox.
+
+use std::collections::HashMap;
+
+use models::rhoapi::{ListParWithRandom, Par};
+use rholang::rust::interpreter::rho_type::{RhoByteArray, RhoMap, RhoNumber};
+use rspace_plus_plus::rspace::{
+    hashing::blake2b256_hash::Blake2b256Hash, internal::Datum, trace::event::Produce,
+};
+
+/// Build a Datum whose payload encodes the given bonds map.
+///
+/// Mirrors PoS.rhox's `getBonds` shape: `Map[GByteArray pubkey, GInt stake]`.
+/// The Datum's `source` is constructed deterministically from `marker` so
+/// different test scenarios produce different Blake2b256 hashes — this is
+/// what makes the LWW tiebreak deterministic for the regression assertion.
+fn bonds_datum(
+    bonds: &[(Vec<u8>, i64)],
+    marker: u8,
+    random_state: Vec<u8>,
+) -> Datum<ListParWithRandom> {
+    let mut hash_map: HashMap<Par, Par> = HashMap::new();
+    for (pk_bytes, stake) in bonds {
+        let key = RhoByteArray::create_par(pk_bytes.clone());
+        let value = RhoNumber::create_par(*stake);
+        hash_map.insert(key, value);
+    }
+    let map_par = RhoMap::create_par(hash_map);
+
+    Datum {
+        a: ListParWithRandom {
+            pars: vec![map_par],
+            random_state,
+        },
+        persist: false,
+        source: Produce {
+            channel_hash: Blake2b256Hash::new(&[marker; 32]),
+            hash: Blake2b256Hash::new(&[marker; 32]),
+            persistent: false,
+            is_deterministic: true,
+            output_value: vec![],
+            failed: false,
+        },
+    }
+}
+
+fn extract_bonds(datum: &Datum<ListParWithRandom>) -> HashMap<Vec<u8>, i64> {
+    assert_eq!(
+        datum.a.pars.len(),
+        1,
+        "bonds Datum must hold exactly one Par (the Map)"
+    );
+    let map = RhoMap::unapply(&datum.a.pars[0]).expect("Datum payload must be a Map Par");
+    map.into_iter()
+        .map(|(k_par, v_par)| {
+            let k =
+                RhoByteArray::unapply(&k_par).expect("bonds map key must be GByteArray (pubkey)");
+            let v = RhoNumber::unapply(&v_par).expect("bonds map value must be GInt (stake)");
+            (k, v)
+        })
+        .collect()
+}
+
+const V1: &[u8] = &[0x01; 32];
+const V2: &[u8] = &[0x02; 32];
+const V3: &[u8] = &[0x03; 32];
+const V4: &[u8] = &[0x04; 32];
+
+/// Bond write survives merge against a heartbeat-only sibling.
+///
+/// Two sibling branches at the same height:
+///   - Branch A processed V4's bond deploy. Its post-state `bondsCh`
+///     Datum carries `{V1, V2, V3, V4}`.
+///   - Branch B is a heartbeat-only sibling. Its `bondsCh` Datum carries
+///     `{V1, V2, V3}` (no V4 — V4's bond never touched this branch's
+///     local PoS state).
+///
+/// Multi-parent merge of these two `bondsCh` Datums must contain V4 in
+/// the merged Map. Under `MergeType::AdditiveSet`, the merge is
+/// set-union-with-per-key-LWW and V4 from branch A survives. Under
+/// `MergeType::MutexState`, the merge is byte-level lowest-Blake2b256
+/// LWW and branch B can win the tiebreak — V4 silently disappears from
+/// the merged bonds map.
+#[test]
+fn bond_write_survives_merge_against_heartbeat_only_sibling() {
+    let branch_a = bonds_datum(
+        &[
+            (V1.to_vec(), 100),
+            (V2.to_vec(), 100),
+            (V3.to_vec(), 100),
+            (V4.to_vec(), 100),
+        ],
+        0xAA,
+        vec![0x11; 64],
+    );
+    let branch_b = bonds_datum(
+        &[(V1.to_vec(), 100), (V2.to_vec(), 100), (V3.to_vec(), 100)],
+        0xBB,
+        vec![0x22; 64],
+    );
+
+    let merged = rholang::rust::interpreter::merging::rholang_merging_logic::combine_mergeable_state_additive(
+        &branch_a,
+        &branch_b,
+    );
+
+    let bonds = extract_bonds(&merged);
+    assert!(
+        bonds.contains_key(V1),
+        "V1 must survive merge: {:?}",
+        bonds.keys().collect::<Vec<_>>(),
+    );
+    assert!(
+        bonds.contains_key(V2),
+        "V2 must survive merge: {:?}",
+        bonds.keys().collect::<Vec<_>>(),
+    );
+    assert!(
+        bonds.contains_key(V3),
+        "V3 must survive merge: {:?}",
+        bonds.keys().collect::<Vec<_>>(),
+    );
+    assert!(
+        bonds.contains_key(V4),
+        "V4 must survive merge of branch-with-bond + heartbeat-only \
+         sibling. Merged bonds: {:?}",
+        bonds.keys().collect::<Vec<_>>(),
+    );
+    assert_eq!(bonds.get(V4), Some(&100), "V4 stake must round-trip merge");
+}

--- a/casper/tests/merging/merge_number_channel_spec.rs
+++ b/casper/tests/merging/merge_number_channel_spec.rs
@@ -318,20 +318,21 @@ async fn test_case(
             }
         };
 
-    let compute_trie_actions = |changes: StateChange,
-                                 mergeable_chs: NumberChannelsDiff,
-                                 _state_chs: rspace_plus_plus::rspace::merger::merging_logic::StateChannelsDiff| {
-        // This test only exercises the i64 number-channel path; state channels
-        // are validated separately by state_channel_pipeline_spec.
-        state_change_merger::compute_trie_actions(
-            &changes,
-            &base_reader,
-            &mergeable_chs,
-            |_hash, _changes, _number_channels| {
-                override_trie_action(_hash, _changes, _number_channels)
-            },
-        )
-    };
+    let compute_trie_actions =
+        |changes: StateChange,
+         mergeable_chs: NumberChannelsDiff,
+         _state_chs: rspace_plus_plus::rspace::merger::merging_logic::StateChannelsDiff| {
+            // This test only exercises the i64 number-channel path; state channels
+            // are validated separately by state_channel_pipeline_spec.
+            state_change_merger::compute_trie_actions(
+                &changes,
+                &base_reader,
+                &mergeable_chs,
+                |_hash, _changes, _number_channels| {
+                    override_trie_action(_hash, _changes, _number_channels)
+                },
+            )
+        };
 
     let apply_trie_actions = |actions: Vec<
         HotStoreTrieAction<Par, BindPattern, ListParWithRandom, TaggedContinuation>,

--- a/casper/tests/merging/merge_number_channel_spec.rs
+++ b/casper/tests/merging/merge_number_channel_spec.rs
@@ -190,6 +190,7 @@ async fn test_case(
                     rm.get_history_repo(),
                     &pre_state,
                     number_chan_diff,
+                    Default::default(),
                 );
 
                 let sig_bs = make_sig_pb(deploy.sig.as_str());
@@ -317,7 +318,11 @@ async fn test_case(
             }
         };
 
-    let compute_trie_actions = |changes: StateChange, mergeable_chs: NumberChannelsDiff| {
+    let compute_trie_actions = |changes: StateChange,
+                                 mergeable_chs: NumberChannelsDiff,
+                                 _state_chs: rspace_plus_plus::rspace::merger::merging_logic::StateChannelsDiff| {
+        // This test only exercises the i64 number-channel path; state channels
+        // are validated separately by state_channel_pipeline_spec.
         state_change_merger::compute_trie_actions(
             &changes,
             &base_reader,
@@ -353,6 +358,7 @@ async fn test_case(
         dag_merger::cost_optimal_rejection_alg(),
         |r| Ok(r.state_changes.clone()),
         |r| r.event_log_index.number_channels_data.clone(),
+        |r| r.event_log_index.state_channels_data.clone(),
         compute_trie_actions,
         apply_trie_actions,
         |x| base_reader.get_data(&x),

--- a/casper/tests/merging/merging_cases.rs
+++ b/casper/tests/merging/merging_cases.rs
@@ -82,7 +82,7 @@ async fn two_deploys_executed_inside_single_state_transition_should_be_dependent
 
         assert_eq!(processed_deploys.len(), 2);
 
-        let mergeable_channels = runtime_manager
+        let (mergeable_channels, state_channels) = runtime_manager
             .load_mergeable_channels(
                 &post_state_hash,
                 state_transition_creator.bytes.clone(),
@@ -95,16 +95,19 @@ async fn two_deploys_executed_inside_single_state_transition_should_be_dependent
             .to_vec()
             .into_iter()
             .zip(mergeable_channels)
+            .zip(state_channels)
+            .map(|((d, m), s)| (d, m, s))
             .collect::<Vec<_>>();
 
         let idxs = processed_deploys_with_mergeable
             .into_iter()
-            .map(|(d, merge_chs)| {
+            .map(|(d, merge_chs, state_chs)| {
                 block_index::create_event_log_index(
                     &d.deploy_log,
                     runtime_manager.get_history_repo(),
                     &Blake2b256Hash::from_bytes_prost(&base_state),
                     merge_chs,
+                    state_chs,
                 )
             })
             .collect::<Vec<_>>();

--- a/casper/tests/merging/mod.rs
+++ b/casper/tests/merging/mod.rs
@@ -1,3 +1,4 @@
 mod conflict_detection_perf_spec;
 mod merge_number_channel_spec;
 mod merging_cases;
+mod state_channel_pipeline_spec;

--- a/casper/tests/merging/mod.rs
+++ b/casper/tests/merging/mod.rs
@@ -1,3 +1,4 @@
+mod bond_merge_regression_spec;
 mod conflict_detection_perf_spec;
 mod merge_number_channel_spec;
 mod merging_cases;

--- a/casper/tests/merging/state_channel_pipeline_spec.rs
+++ b/casper/tests/merging/state_channel_pipeline_spec.rs
@@ -1,0 +1,307 @@
+// Parallel state-channel pipeline tests.
+//
+// Validates that the byte-erased storage strategy is sound for
+// `Datum<ListParWithRandom>` — the production payload type. If bincode
+// loses fields or changes byte representation across runs, the entire
+// merge layer would silently corrupt state.
+
+use models::rhoapi::{
+    g_unforgeable::UnfInstance, expr::ExprInstance, Expr, GPrivate, GUnforgeable,
+    ListParWithRandom, Par,
+};
+use rspace_plus_plus::rspace::{
+    hashing::blake2b256_hash::Blake2b256Hash,
+    internal::Datum,
+    serializers::serializers::{decode_datum, encode_datum},
+    trace::event::Produce,
+};
+
+/// Bincode round-trip stability for `Datum<ListParWithRandom>`. Byte-erased
+/// storage requires bincode to be a stable, reversible serialization for the
+/// production payload type. Constructs a non-trivial Datum, encodes it,
+/// decodes it, asserts equality, and asserts that encoding twice yields
+/// identical bytes (determinism).
+#[test]
+fn bincode_round_trip_for_datum_list_par_with_random() {
+    let payload = make_test_list_par_with_random();
+    let datum = Datum {
+        a: payload.clone(),
+        persist: false,
+        source: Produce {
+            channel_hash: Blake2b256Hash::new(&[0xAB; 32]),
+            hash: Blake2b256Hash::new(&[0xCD; 32]),
+            persistent: false,
+            is_deterministic: true,
+            output_value: vec![vec![0x01, 0x02, 0x03], vec![0x04, 0x05]],
+            failed: false,
+        },
+    };
+
+    let bytes_1 = encode_datum(&datum);
+    let bytes_2 = encode_datum(&datum);
+    assert_eq!(
+        bytes_1, bytes_2,
+        "bincode encoding must be deterministic — same input must yield same bytes"
+    );
+
+    let decoded: Datum<ListParWithRandom> = decode_datum(&bytes_1);
+    assert_eq!(
+        decoded, datum,
+        "bincode round-trip must preserve Datum<ListParWithRandom> exactly"
+    );
+
+    let bytes_3 = encode_datum(&decoded);
+    assert_eq!(
+        bytes_1, bytes_3,
+        "encoding the decoded value must yield identical bytes (full round-trip stability)"
+    );
+}
+
+/// Persist=true variant — bool field shouldn't behave differently from false
+/// under bincode but worth confirming explicitly.
+#[test]
+fn bincode_round_trip_for_persistent_datum() {
+    let datum = Datum {
+        a: make_test_list_par_with_random(),
+        persist: true,
+        source: Produce {
+            channel_hash: Blake2b256Hash::new(&[0x11; 32]),
+            hash: Blake2b256Hash::new(&[0x22; 32]),
+            persistent: true,
+            is_deterministic: true,
+            output_value: vec![],
+            failed: false,
+        },
+    };
+
+    let bytes = encode_datum(&datum);
+    let decoded: Datum<ListParWithRandom> = decode_datum(&bytes);
+    assert_eq!(decoded, datum);
+}
+
+/// Empty payload (no Pars, empty random_state) — confirms default-value
+/// encoding is stable.
+#[test]
+fn bincode_round_trip_for_empty_payload() {
+    let datum = Datum {
+        a: ListParWithRandom::default(),
+        persist: false,
+        source: Produce {
+            channel_hash: Blake2b256Hash::new(&[0x00; 32]),
+            hash: Blake2b256Hash::new(&[0x00; 32]),
+            persistent: false,
+            is_deterministic: true,
+            output_value: vec![],
+            failed: false,
+        },
+    };
+
+    let bytes = encode_datum(&datum);
+    let decoded: Datum<ListParWithRandom> = decode_datum(&bytes);
+    assert_eq!(decoded, datum);
+}
+
+fn make_test_list_par_with_random() -> ListParWithRandom {
+    let unforgeable_par = Par::default().with_unforgeables(vec![GUnforgeable {
+        unf_instance: Some(UnfInstance::GPrivateBody(GPrivate {
+            id: vec![0xDE, 0xAD, 0xBE, 0xEF],
+        })),
+    }]);
+    let int_par = Par::default().with_exprs(vec![Expr {
+        expr_instance: Some(ExprInstance::GInt(42)),
+    }]);
+
+    ListParWithRandom {
+        pars: vec![unforgeable_par, int_par],
+        random_state: vec![0x99; 64],
+    }
+}
+
+// Mid-level pipeline test: construct a `StateChannelsDiff` with
+// multi-Datum content directly (bypassing runtime extraction), route it
+// through `RholangMergingLogic::calculate_state_channel_merge`, and
+// assert the resulting trie action contains the lowest-Blake2b256-hash
+// winner. End-to-end coverage of the parallel state-channel pipeline.
+
+use rholang::rust::interpreter::merging::rholang_merging_logic::RholangMergingLogic;
+use rspace_plus_plus::rspace::{
+    errors::HistoryError,
+    hot_store_trie_action::{HotStoreTrieAction, TrieInsertAction},
+    merger::{
+        channel_change::ChannelChange,
+        merging_logic::{combine_mergeable_state, MergeType},
+    },
+};
+
+/// Builds a Datum with the given byte payload marker so its bincode bytes
+/// hash distinctly from siblings. Mirrors the L1-test pattern.
+fn make_state_datum(payload_marker: u8, payload_int: i64) -> Datum<ListParWithRandom> {
+    let payload = ListParWithRandom {
+        pars: vec![Par::default().with_exprs(vec![models::rhoapi::Expr {
+            expr_instance: Some(models::rhoapi::expr::ExprInstance::GInt(payload_int)),
+        }])],
+        random_state: vec![payload_marker; 64],
+    };
+    Datum {
+        a: payload,
+        persist: false,
+        source: Produce {
+            channel_hash: Blake2b256Hash::new(&[payload_marker; 32]),
+            hash: Blake2b256Hash::new(&[payload_marker; 32]),
+            persistent: false,
+            is_deterministic: true,
+            output_value: vec![],
+            failed: false,
+        },
+    }
+}
+
+/// Mid-level pipeline test: three sibling Datums on a state channel are
+/// merged via `calculate_state_channel_merge`. The emitted trie action
+/// must contain exactly one Datum — the lowest-hash winner.
+#[test]
+fn calculate_state_channel_merge_picks_lowest_hash_winner_with_empty_base() {
+    let channel_hash = Blake2b256Hash::new(&[0x42; 32]);
+    let datum_a = make_state_datum(0xAA, 100);
+    let datum_b = make_state_datum(0xBB, 200);
+    let datum_c = make_state_datum(0xCC, 300);
+
+    // Independently compute the expected winner using the typed combine.
+    let expected = combine_mergeable_state(
+        &combine_mergeable_state(&datum_a, &datum_b, MergeType::MutexState),
+        &datum_c,
+        MergeType::MutexState,
+    );
+
+    // Build the per-deploy "diff" (this branch's contribution) and the
+    // ChannelChange for sibling additions, mirroring how B5 plumbing will
+    // present them.
+    let diff_bytes = encode_datum(&datum_a);
+    let changes = ChannelChange {
+        added: vec![encode_datum(&datum_b), encode_datum(&datum_c)],
+        removed: vec![],
+    };
+
+    // Empty base — no prior state on this channel.
+    let get_base_data =
+        |_h: &Blake2b256Hash| -> Result<Vec<Datum<ListParWithRandom>>, HistoryError> { Ok(vec![]) };
+
+    let action = RholangMergingLogic::calculate_state_channel_merge(
+        &channel_hash,
+        diff_bytes,
+        MergeType::MutexState,
+        &changes,
+        get_base_data,
+    );
+
+    match action {
+        HotStoreTrieAction::TrieInsertAction(TrieInsertAction::TrieInsertBinaryProduce(insert)) => {
+            assert_eq!(insert.hash, channel_hash);
+            assert_eq!(
+                insert.data.len(),
+                1,
+                "MutexState merge must collapse to exactly one Datum, got {}",
+                insert.data.len(),
+            );
+            let written: Datum<ListParWithRandom> = decode_datum(&insert.data[0]);
+            assert_eq!(
+                written, expected,
+                "trie action's surviving Datum must match the typed combine_mergeable_state winner"
+            );
+        }
+        other => panic!("expected TrieInsertBinaryProduce, got {:?}", other),
+    }
+}
+
+/// Same as above but with a non-empty base — the merge must consider the
+/// base Datum as one of the candidates, so the winner is the lowest-hash
+/// across {base, diff, added...}.
+#[test]
+fn calculate_state_channel_merge_includes_base_in_candidates() {
+    let channel_hash = Blake2b256Hash::new(&[0x77; 32]);
+    let base_datum = make_state_datum(0x01, 0);
+    let datum_x = make_state_datum(0xFE, 1);
+    let datum_y = make_state_datum(0xFF, 2);
+
+    let expected = combine_mergeable_state(
+        &combine_mergeable_state(&base_datum, &datum_x, MergeType::MutexState),
+        &datum_y,
+        MergeType::MutexState,
+    );
+
+    let diff_bytes = encode_datum(&datum_x);
+    let changes = ChannelChange {
+        added: vec![encode_datum(&datum_y)],
+        removed: vec![],
+    };
+
+    let base_clone = base_datum.clone();
+    let get_base_data =
+        move |_h: &Blake2b256Hash| -> Result<Vec<Datum<ListParWithRandom>>, HistoryError> {
+            Ok(vec![base_clone.clone()])
+        };
+
+    let action = RholangMergingLogic::calculate_state_channel_merge(
+        &channel_hash,
+        diff_bytes,
+        MergeType::MutexState,
+        &changes,
+        get_base_data,
+    );
+
+    match action {
+        HotStoreTrieAction::TrieInsertAction(TrieInsertAction::TrieInsertBinaryProduce(insert)) => {
+            assert_eq!(insert.data.len(), 1);
+            let written: Datum<ListParWithRandom> = decode_datum(&insert.data[0]);
+            assert_eq!(
+                written, expected,
+                "winner must be lowest-hash across {{base, diff, added}}"
+            );
+        }
+        other => panic!("expected TrieInsertBinaryProduce, got {:?}", other),
+    }
+}
+
+/// EventLogIndex-level test: build two EventLogIndexes with conflicting
+/// state-channel data, combine them, and assert the combined
+/// `state_channels_data` carries the byte-level lowest-hash winner.
+/// This proves the parallel State pipeline survives the EventLogIndex
+/// combine path used during multi-parent merge.
+#[test]
+fn event_log_index_combine_picks_lowest_hash_winner_for_state_channel() {
+    use rspace_plus_plus::rspace::merger::event_log_index::EventLogIndex;
+
+    let channel_hash = Blake2b256Hash::new(&[0xAB; 32]);
+    let datum_left = make_state_datum(0x10, 111);
+    let datum_right = make_state_datum(0xF0, 222);
+
+    let left_bytes = encode_datum(&datum_left);
+    let right_bytes = encode_datum(&datum_right);
+
+    // Compute expected winner via the typed function (ground truth).
+    let expected_datum =
+        combine_mergeable_state(&datum_left, &datum_right, MergeType::MutexState);
+    let expected_bytes = encode_datum(&expected_datum);
+
+    // Construct two EventLogIndexes, each carrying one State Datum on the
+    // same channel.
+    let mut left = EventLogIndex::empty();
+    left.state_channels_data
+        .insert(channel_hash.clone(), (left_bytes.clone(), MergeType::MutexState));
+    let mut right = EventLogIndex::empty();
+    right
+        .state_channels_data
+        .insert(channel_hash.clone(), (right_bytes.clone(), MergeType::MutexState));
+
+    let combined = EventLogIndex::combine(&left, &right);
+
+    let (combined_bytes, combined_mt) = combined
+        .state_channels_data
+        .get(&channel_hash)
+        .expect("combined state_channels_data must contain the merged channel");
+    assert_eq!(*combined_mt, MergeType::MutexState);
+    assert_eq!(
+        combined_bytes, &expected_bytes,
+        "EventLogIndex::combine must pick the lowest-hash-of-bincode winner"
+    );
+}

--- a/casper/tests/merging/state_channel_pipeline_spec.rs
+++ b/casper/tests/merging/state_channel_pipeline_spec.rs
@@ -6,7 +6,7 @@
 // merge layer would silently corrupt state.
 
 use models::rhoapi::{
-    g_unforgeable::UnfInstance, expr::ExprInstance, Expr, GPrivate, GUnforgeable,
+    expr::ExprInstance, g_unforgeable::UnfInstance, Expr, GPrivate, GUnforgeable,
     ListParWithRandom, Par,
 };
 use rspace_plus_plus::rspace::{
@@ -279,21 +279,24 @@ fn event_log_index_combine_picks_lowest_hash_winner_for_state_channel() {
     let right_bytes = encode_datum(&datum_right);
 
     // Compute expected winner via the typed function (ground truth).
-    let expected_datum =
-        combine_mergeable_state(&datum_left, &datum_right, MergeType::MutexState);
+    let expected_datum = combine_mergeable_state(&datum_left, &datum_right, MergeType::MutexState);
     let expected_bytes = encode_datum(&expected_datum);
 
     // Construct two EventLogIndexes, each carrying one State Datum on the
     // same channel.
     let mut left = EventLogIndex::empty();
-    left.state_channels_data
-        .insert(channel_hash.clone(), (left_bytes.clone(), MergeType::MutexState));
+    left.state_channels_data.insert(
+        channel_hash.clone(),
+        (left_bytes.clone(), MergeType::MutexState),
+    );
     let mut right = EventLogIndex::empty();
-    right
-        .state_channels_data
-        .insert(channel_hash.clone(), (right_bytes.clone(), MergeType::MutexState));
+    right.state_channels_data.insert(
+        channel_hash.clone(),
+        (right_bytes.clone(), MergeType::MutexState),
+    );
 
-    let combined = EventLogIndex::combine(&left, &right);
+    let combined = EventLogIndex::combine(&left, &right)
+        .expect("EventLogIndex::combine must succeed for matching merge types");
 
     let (combined_bytes, combined_mt) = combined
         .state_channels_data

--- a/casper/tests/util/rholang/runtime_manager_test.rs
+++ b/casper/tests/util/rholang/runtime_manager_test.rs
@@ -189,6 +189,7 @@ where
             state_hash: final_play_state_hash,
             processed_system_deploy,
             mergeable_channels: _,
+            state_channels: _,
             result: play_result,
         } => {
             result_assertion(&play_result);
@@ -1780,9 +1781,6 @@ in {{
 /// Deploys bridge.rho on block A (from genesis), creates empty block B (from
 /// genesis, sibling branch), merges [A, B] via compute_parents_post_state,
 /// then queries getNonce from the merged state.
-///
-/// Reproduces: system-integration docs/TODO.md "Contract query deploy returns
-/// empty deployId after finalization (intermittent)"
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn bridge_query_survives_multi_parent_merge() {
     use crate::util::rholang::resources::{
@@ -2357,11 +2355,13 @@ async fn concurrent_registry_inserts_should_not_conflict() {
             history_repo.clone(),
             &genesis_hash_b256,
             std::collections::BTreeMap::new(),
+            std::collections::BTreeMap::new(),
         );
         let eli_b = create_event_log_index(
             &pd_b[0].deploy_log,
             history_repo.clone(),
             &genesis_hash_b256,
+            std::collections::BTreeMap::new(),
             std::collections::BTreeMap::new(),
         );
 

--- a/node/src/rust/configuration/commandline/config_mapper.rs
+++ b/node/src/rust/configuration/commandline/config_mapper.rs
@@ -99,10 +99,9 @@ impl ConfigMapper<Options> for NodeConf {
             );
 
             // API server fields
-            Self::try_override_bool(
-                &mut self.api_server.enable_reporting,
-                run.api_enable_reporting,
-            );
+            if let Some(enable_reporting) = run.api_enable_reporting {
+                self.api_server.enable_reporting = enable_reporting;
+            }
             Self::try_override_value(
                 &mut self.api_server.port_grpc_external,
                 run.api_port_grpc_external,
@@ -614,7 +613,7 @@ mod tests {
                 api_port_http: Some(11111),
                 api_port_admin_http: Some(11111),
                 api_max_blocks_limit: Some(111111),
-                api_enable_reporting: true,
+                api_enable_reporting: Some(true),
                 api_keep_alive_time: Some(Duration::from_secs(111111)),
                 api_keep_alive_timeout: Some(Duration::from_secs(111111)),
                 api_permit_keep_alive_time: Some(Duration::from_secs(111111)),

--- a/node/src/rust/configuration/commandline/options.rs
+++ b/node/src/rust/configuration/commandline/options.rs
@@ -259,9 +259,17 @@ pub struct RunOptions {
     #[arg(long = "api-max-blocks-limit")]
     pub api_max_blocks_limit: Option<u32>,
 
-    /// Use this flag to enable reporting endpoints
-    #[arg(long = "api-enable-reporting", action = ArgAction::SetTrue)]
-    pub api_enable_reporting: bool,
+    /// Override the api-server.enable-reporting config value. Bare
+    /// `--api-enable-reporting` enables reporting (kept for backwards
+    /// compatibility); `--api-enable-reporting=false` explicitly
+    /// disables it. Omit the flag to use the config-file default.
+    #[arg(
+        long = "api-enable-reporting",
+        num_args = 0..=1,
+        default_missing_value = "true",
+        value_parser = clap::value_parser!(bool),
+    )]
+    pub api_enable_reporting: Option<bool>,
 
     /// Sets a custom keepalive time
     #[arg(long = "api-keep-alive-time", value_parser = ValueParser::new(parse_duration))]

--- a/rholang/src/rust/interpreter/merging/mergeable_tags.rs
+++ b/rholang/src/rust/interpreter/merging/mergeable_tags.rs
@@ -46,6 +46,14 @@ pub const MUTEX_STATE_TAG_PK: &str =
     "d976a4490cbbf5733171a4549a28633d13fce6a65a29ce1f31a6d4f413b1bd67";
 pub const MUTEX_STATE_TAG_TIMESTAMP: i64 = 1762100000000;
 
+// Dedicated key for deriving the AdditiveSet mergeable tag's unforgeable
+// name. Generated fresh via `openssl rand -hex 32`. Same pattern as
+// MUTEX_STATE_TAG_PK — seeds the unforgeable-name RNG only; not used
+// to sign any deploy.
+pub const ADDITIVE_SET_TAG_PK: &str =
+    "a01f7c0f5fe70e31a6f9d45e5d6b6806fdfd1dc5019f427a1d45f0f512735cfc";
+pub const ADDITIVE_SET_TAG_TIMESTAMP: i64 = 1762200000000;
+
 pub fn pub_key_from_hex(priv_key_hex: &str) -> PublicKey {
     let private_key =
         PrivateKey::from_bytes(&hex::decode(priv_key_hex).expect("invalid private key hex"));
@@ -85,6 +93,10 @@ pub fn mutex_state_mergeable_tag_name() -> Par {
     tag_name(MUTEX_STATE_TAG_PK, MUTEX_STATE_TAG_TIMESTAMP)
 }
 
+pub fn additive_set_mergeable_tag_name() -> Par {
+    tag_name(ADDITIVE_SET_TAG_PK, ADDITIVE_SET_TAG_TIMESTAMP)
+}
+
 /// Standard mergeable-tag registry installed at runtime startup. Maps each
 /// genesis-defined tag `Par` to its merge strategy. Use this everywhere a
 /// mergeable-tag table is needed unless a test specifically wants a custom
@@ -94,6 +106,7 @@ pub fn default_mergeable_tags() -> HashMap<Par, MergeType> {
     tags.insert(non_negative_mergeable_tag_name(), MergeType::IntegerAdd);
     tags.insert(bitmask_or_mergeable_tag_name(), MergeType::BitmaskOr);
     tags.insert(mutex_state_mergeable_tag_name(), MergeType::MutexState);
+    tags.insert(additive_set_mergeable_tag_name(), MergeType::AdditiveSet);
     tags
 }
 
@@ -101,31 +114,44 @@ pub fn default_mergeable_tags() -> HashMap<Par, MergeType> {
 mod tests {
     use super::*;
 
-    /// Collision-check regression: the MutexState tag's `Par` must not
-    /// collide with the two existing tags. Catches a future regression
-    /// where someone reuses (PK, timestamp) by mistake.
+    /// All four mergeable-tag `Par`s must be pairwise distinct. Catches a
+    /// future regression where someone reuses (PK, timestamp) by mistake.
     #[test]
-    fn mutex_state_tag_does_not_collide_with_existing_tags() {
+    fn mergeable_tags_are_pairwise_distinct() {
         let nnn = non_negative_mergeable_tag_name();
         let bitmask = bitmask_or_mergeable_tag_name();
         let mutex_state = mutex_state_mergeable_tag_name();
+        let additive_set = additive_set_mergeable_tag_name();
 
-        assert_ne!(mutex_state, nnn, "MutexState tag must differ from NonNegativeNumber tag");
-        assert_ne!(mutex_state, bitmask, "MutexState tag must differ from BitmaskOr tag");
+        assert_ne!(mutex_state, nnn);
+        assert_ne!(mutex_state, bitmask);
+        assert_ne!(additive_set, nnn);
+        assert_ne!(additive_set, bitmask);
+        assert_ne!(additive_set, mutex_state);
     }
 
-    /// `default_mergeable_tags()` must contain exactly 3 distinct entries:
-    /// IntegerAdd, BitmaskOr, MutexState.
+    /// `default_mergeable_tags()` must contain exactly 4 distinct entries:
+    /// IntegerAdd, BitmaskOr, MutexState, AdditiveSet.
     #[test]
-    fn default_mergeable_tags_has_three_distinct_entries() {
+    fn default_mergeable_tags_has_four_distinct_entries() {
         let tags = default_mergeable_tags();
-        assert_eq!(tags.len(), 3, "expected 3 mergeable tags, got {}", tags.len());
+        assert_eq!(
+            tags.len(),
+            4,
+            "expected 4 mergeable tags, got {}",
+            tags.len()
+        );
 
         let mut merge_types: Vec<_> = tags.values().copied().collect();
         merge_types.sort();
         assert_eq!(
             merge_types,
-            vec![MergeType::IntegerAdd, MergeType::BitmaskOr, MergeType::MutexState],
+            vec![
+                MergeType::IntegerAdd,
+                MergeType::BitmaskOr,
+                MergeType::MutexState,
+                MergeType::AdditiveSet,
+            ],
         );
     }
 }

--- a/rholang/src/rust/interpreter/merging/mergeable_tags.rs
+++ b/rholang/src/rust/interpreter/merging/mergeable_tags.rs
@@ -38,6 +38,14 @@ pub const BITMASK_OR_TAG_PK: &str =
     "4d76b8e3f29a51c8d05e7b4f9a23c6e1d8b5f0a7c4e91b6d3a8f5c2e9b6d4a1c";
 pub const BITMASK_OR_TAG_TIMESTAMP: i64 = 1762000000000;
 
+// Dedicated key for deriving the MutexState mergeable tag's unforgeable
+// name. Generated fresh via `openssl rand -hex 32` (2026-05-02). Same
+// pattern as BITMASK_OR_TAG_PK — seeds the unforgeable-name RNG only;
+// not used to sign any deploy.
+pub const MUTEX_STATE_TAG_PK: &str =
+    "d976a4490cbbf5733171a4549a28633d13fce6a65a29ce1f31a6d4f413b1bd67";
+pub const MUTEX_STATE_TAG_TIMESTAMP: i64 = 1762100000000;
+
 pub fn pub_key_from_hex(priv_key_hex: &str) -> PublicKey {
     let private_key =
         PrivateKey::from_bytes(&hex::decode(priv_key_hex).expect("invalid private key hex"));
@@ -73,6 +81,10 @@ pub fn bitmask_or_mergeable_tag_name() -> Par {
     tag_name(BITMASK_OR_TAG_PK, BITMASK_OR_TAG_TIMESTAMP)
 }
 
+pub fn mutex_state_mergeable_tag_name() -> Par {
+    tag_name(MUTEX_STATE_TAG_PK, MUTEX_STATE_TAG_TIMESTAMP)
+}
+
 /// Standard mergeable-tag registry installed at runtime startup. Maps each
 /// genesis-defined tag `Par` to its merge strategy. Use this everywhere a
 /// mergeable-tag table is needed unless a test specifically wants a custom
@@ -81,5 +93,39 @@ pub fn default_mergeable_tags() -> HashMap<Par, MergeType> {
     let mut tags = HashMap::new();
     tags.insert(non_negative_mergeable_tag_name(), MergeType::IntegerAdd);
     tags.insert(bitmask_or_mergeable_tag_name(), MergeType::BitmaskOr);
+    tags.insert(mutex_state_mergeable_tag_name(), MergeType::MutexState);
     tags
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Collision-check regression: the MutexState tag's `Par` must not
+    /// collide with the two existing tags. Catches a future regression
+    /// where someone reuses (PK, timestamp) by mistake.
+    #[test]
+    fn mutex_state_tag_does_not_collide_with_existing_tags() {
+        let nnn = non_negative_mergeable_tag_name();
+        let bitmask = bitmask_or_mergeable_tag_name();
+        let mutex_state = mutex_state_mergeable_tag_name();
+
+        assert_ne!(mutex_state, nnn, "MutexState tag must differ from NonNegativeNumber tag");
+        assert_ne!(mutex_state, bitmask, "MutexState tag must differ from BitmaskOr tag");
+    }
+
+    /// `default_mergeable_tags()` must contain exactly 3 distinct entries:
+    /// IntegerAdd, BitmaskOr, MutexState.
+    #[test]
+    fn default_mergeable_tags_has_three_distinct_entries() {
+        let tags = default_mergeable_tags();
+        assert_eq!(tags.len(), 3, "expected 3 mergeable tags, got {}", tags.len());
+
+        let mut merge_types: Vec<_> = tags.values().copied().collect();
+        merge_types.sort();
+        assert_eq!(
+            merge_types,
+            vec![MergeType::IntegerAdd, MergeType::BitmaskOr, MergeType::MutexState],
+        );
+    }
 }

--- a/rholang/src/rust/interpreter/merging/rholang_merging_logic.rs
+++ b/rholang/src/rust/interpreter/merging/rholang_merging_logic.rs
@@ -13,7 +13,10 @@ use rspace_plus_plus::rspace::{
     hashing::{blake2b256_hash::Blake2b256Hash, stable_hash_provider},
     hot_store_trie_action::HotStoreTrieAction,
     internal::Datum,
-    merger::{channel_change::ChannelChange, merging_logic::MergeType},
+    merger::{
+        channel_change::ChannelChange,
+        merging_logic::{combine_mergeable_state, MergeType},
+    },
     serializers::serializers,
     trace::event::Produce,
 };
@@ -67,7 +70,14 @@ impl RholangMergingLogic {
                     if let Some(prev_val) = state.get(&ch) {
                         let diff = match merge_type {
                             MergeType::IntegerAdd => end_val.wrapping_sub(*prev_val),
-                            MergeType::BitmaskOr => ((end_val as u64) & !(*prev_val as u64)) as i64,
+                            MergeType::BitmaskOr => {
+                                ((end_val as u64) & !(*prev_val as u64)) as i64
+                            }
+                            MergeType::MutexState => unreachable!(
+                                "MutexState channels do not flow through the \
+                                 number-channel diff path; they use the parallel \
+                                 state-channel pipeline (StateChannelsDiff)"
+                            ),
                         };
                         diffs.insert(ch.clone(), (diff, merge_type));
                         state.insert(ch, end_val);
@@ -104,6 +114,10 @@ impl RholangMergingLogic {
         let new_val = match merge_type {
             MergeType::IntegerAdd => init_num.wrapping_add(diff),
             MergeType::BitmaskOr => ((init_num as u64) | (diff as u64)) as i64,
+            MergeType::MutexState => unreachable!(
+                "MutexState channels do not flow through calculate_number_channel_merge; \
+                 they use calculate_state_channel_merge in the parallel state pipeline"
+            ),
         };
 
         // Calculate merged random generator (use only unique changes as input)
@@ -141,6 +155,61 @@ impl RholangMergingLogic {
                 hash: channel_hash.clone(),
                 data: vec![datum_encoded],
             }),
+        ))
+    }
+
+    /// Merge a state-channel value across multiple parents under the
+    /// `MutexState` strategy. Reads base state, decodes incoming sibling
+    /// Datums, and folds via `combine_mergeable_state` (lowest-hash winner).
+    /// The winner's `random_state` is preserved as-is.
+    ///
+    /// Symmetric to `calculate_number_channel_merge` but for `Datum<P>`-valued
+    /// channels rather than `i64`-valued ones.
+    pub fn calculate_state_channel_merge(
+        channel_hash: &Blake2b256Hash,
+        diff_bytes: Vec<u8>,
+        merge_type: MergeType,
+        changes: &ChannelChange<Vec<u8>>,
+        get_base_data: impl Fn(&Blake2b256Hash) -> Result<Vec<Datum<ListParWithRandom>>, HistoryError>,
+    ) -> HotStoreTrieAction<Par, BindPattern, ListParWithRandom, TaggedContinuation> {
+        debug_assert!(
+            matches!(merge_type, MergeType::MutexState),
+            "calculate_state_channel_merge only supports MutexState; got {:?}",
+            merge_type,
+        );
+
+        // 1. Decode base state (current Datums on this channel, if any).
+        let base = get_base_data(channel_hash).unwrap_or_default();
+
+        // 2. Decode this branch's diff and the sibling-added bytes.
+        let diff_datum: Datum<ListParWithRandom> =
+            serializers::decode_datum(&diff_bytes);
+        let added_datums: Vec<Datum<ListParWithRandom>> = changes
+            .added
+            .iter()
+            .map(|b| serializers::decode_datum(&b.to_vec()))
+            .collect();
+
+        // 3. Reduce all candidates {base..., diff_datum, added...} via
+        //    combine_mergeable_state (lowest Blake2b256-of-bincode wins).
+        //    The reducer is associative+commutative+idempotent, so order is safe.
+        let candidates: Vec<Datum<ListParWithRandom>> = base
+            .into_iter()
+            .chain(std::iter::once(diff_datum))
+            .chain(added_datums)
+            .collect();
+        let winner = candidates
+            .into_iter()
+            .reduce(|a, b| combine_mergeable_state(&a, &b, MergeType::MutexState))
+            .expect("calculate_state_channel_merge: at least one candidate must exist");
+
+        // 4. Re-encode winner as the single surviving Datum on the channel.
+        let winner_bytes = serializers::encode_datum(&winner);
+        HotStoreTrieAction::TrieInsertAction(TrieInsertAction::TrieInsertBinaryProduce(
+            TrieInsertBinaryProduce {
+                hash: channel_hash.clone(),
+                data: vec![winner_bytes],
+            },
         ))
     }
 
@@ -246,12 +315,28 @@ impl RholangMergingLogic {
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct DeployMergeableData {
     pub channels: Vec<NumberChannel>,
+    /// State-channel diffs (parallel pipeline for `MutexState`-tagged
+    /// channels). Empty for deploys that touch no such channel.
+    /// Adding this field changed the on-disk bincode layout; chains
+    /// created with the older format must be re-genesised.
+    pub state_channels: Vec<StateChannel>,
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct NumberChannel {
     pub hash: Blake2b256Hash,
     pub diff: i64,
+    pub merge_type: MergeType,
+}
+
+/// Per-deploy state-channel record. Parallel to `NumberChannel` for the
+/// MutexState pipeline. `bytes` is the bincode-serialized
+/// `Datum<ListParWithRandom>` that won the lowest-hash pick at extraction
+/// time.
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct StateChannel {
+    pub hash: Blake2b256Hash,
+    pub bytes: Vec<u8>,
     pub merge_type: MergeType,
 }
 

--- a/rholang/src/rust/interpreter/merging/rholang_merging_logic.rs
+++ b/rholang/src/rust/interpreter/merging/rholang_merging_logic.rs
@@ -21,7 +21,7 @@ use rspace_plus_plus::rspace::{
     trace::event::Produce,
 };
 
-use crate::rust::interpreter::rho_type::RhoNumber;
+use crate::rust::interpreter::rho_type::{RhoMap, RhoNumber};
 
 pub struct RholangMergingLogic;
 
@@ -70,11 +70,14 @@ impl RholangMergingLogic {
                     if let Some(prev_val) = state.get(&ch) {
                         let diff = match merge_type {
                             MergeType::IntegerAdd => end_val.wrapping_sub(*prev_val),
-                            MergeType::BitmaskOr => {
-                                ((end_val as u64) & !(*prev_val as u64)) as i64
-                            }
+                            MergeType::BitmaskOr => ((end_val as u64) & !(*prev_val as u64)) as i64,
                             MergeType::MutexState => unreachable!(
                                 "MutexState channels do not flow through the \
+                                 number-channel diff path; they use the parallel \
+                                 state-channel pipeline (StateChannelsDiff)"
+                            ),
+                            MergeType::AdditiveSet => unreachable!(
+                                "AdditiveSet channels do not flow through the \
                                  number-channel diff path; they use the parallel \
                                  state-channel pipeline (StateChannelsDiff)"
                             ),
@@ -118,6 +121,10 @@ impl RholangMergingLogic {
                 "MutexState channels do not flow through calculate_number_channel_merge; \
                  they use calculate_state_channel_merge in the parallel state pipeline"
             ),
+            MergeType::AdditiveSet => unreachable!(
+                "AdditiveSet channels do not flow through calculate_number_channel_merge; \
+                 they use calculate_state_channel_merge in the parallel state pipeline"
+            ),
         };
 
         // Calculate merged random generator (use only unique changes as input)
@@ -158,13 +165,18 @@ impl RholangMergingLogic {
         ))
     }
 
-    /// Merge a state-channel value across multiple parents under the
-    /// `MutexState` strategy. Reads base state, decodes incoming sibling
-    /// Datums, and folds via `combine_mergeable_state` (lowest-hash winner).
-    /// The winner's `random_state` is preserved as-is.
+    /// Merge a state-channel value across multiple parents. Dispatches by
+    /// `MergeType`:
+    ///   - `MutexState`: fold via `combine_mergeable_state` (lowest-bincode
+    ///     -hash winner; the winner's `random_state` is preserved as-is).
+    ///   - `AdditiveSet`: fold via `combine_mergeable_state_additive`
+    ///     (key-wise union of Map-bearing payloads with per-key bincode
+    ///     tiebreak; `random_state` merged across all inputs).
     ///
     /// Symmetric to `calculate_number_channel_merge` but for `Datum<P>`-valued
-    /// channels rather than `i64`-valued ones.
+    /// channels rather than `i64`-valued ones. The reducer is
+    /// associative+commutative+idempotent in both cases, so input order is
+    /// safe.
     pub fn calculate_state_channel_merge(
         channel_hash: &Blake2b256Hash,
         diff_bytes: Vec<u8>,
@@ -173,35 +185,39 @@ impl RholangMergingLogic {
         get_base_data: impl Fn(&Blake2b256Hash) -> Result<Vec<Datum<ListParWithRandom>>, HistoryError>,
     ) -> HotStoreTrieAction<Par, BindPattern, ListParWithRandom, TaggedContinuation> {
         debug_assert!(
-            matches!(merge_type, MergeType::MutexState),
-            "calculate_state_channel_merge only supports MutexState; got {:?}",
+            matches!(merge_type, MergeType::MutexState | MergeType::AdditiveSet),
+            "calculate_state_channel_merge supports MutexState and AdditiveSet; got {:?}",
             merge_type,
         );
 
-        // 1. Decode base state (current Datums on this channel, if any).
         let base = get_base_data(channel_hash).unwrap_or_default();
 
-        // 2. Decode this branch's diff and the sibling-added bytes.
-        let diff_datum: Datum<ListParWithRandom> =
-            serializers::decode_datum(&diff_bytes);
+        let diff_datum: Datum<ListParWithRandom> = serializers::decode_datum(&diff_bytes);
         let added_datums: Vec<Datum<ListParWithRandom>> = changes
             .added
             .iter()
             .map(|b| serializers::decode_datum(&b.to_vec()))
             .collect();
 
-        // 3. Reduce all candidates {base..., diff_datum, added...} via
-        //    combine_mergeable_state (lowest Blake2b256-of-bincode wins).
-        //    The reducer is associative+commutative+idempotent, so order is safe.
         let candidates: Vec<Datum<ListParWithRandom>> = base
             .into_iter()
             .chain(std::iter::once(diff_datum))
             .chain(added_datums)
             .collect();
-        let winner = candidates
-            .into_iter()
-            .reduce(|a, b| combine_mergeable_state(&a, &b, MergeType::MutexState))
-            .expect("calculate_state_channel_merge: at least one candidate must exist");
+        let winner = match merge_type {
+            MergeType::MutexState => candidates
+                .into_iter()
+                .reduce(|a, b| combine_mergeable_state(&a, &b, MergeType::MutexState))
+                .expect("calculate_state_channel_merge: at least one candidate must exist"),
+            MergeType::AdditiveSet => candidates
+                .into_iter()
+                .reduce(|a, b| combine_mergeable_state_additive(&a, &b))
+                .expect("calculate_state_channel_merge: at least one candidate must exist"),
+            other => unreachable!(
+                "calculate_state_channel_merge cannot dispatch on {:?}",
+                other
+            ),
+        };
 
         // 4. Re-encode winner as the single surviving Datum on the channel.
         let winner_bytes = serializers::encode_datum(&winner);
@@ -310,6 +326,99 @@ impl RholangMergingLogic {
             }
         }
     }
+}
+
+/// Combine two `Datum<ListParWithRandom>` whose payloads each encode a
+/// single Rholang `Map[K, V]`, producing one `Datum<ListParWithRandom>`
+/// whose payload is the key-wise union of the two Maps.
+///
+/// Conflict resolution: when both inputs contain the same key with
+/// differing values, the value with the lexicographically lower
+/// bincode encoding wins. This is deterministic across validators and
+/// matches the tiebreak shape used by `combine_mergeable_state` for the
+/// MutexState path.
+///
+/// Persistence: result `persist` is the logical OR of the two inputs.
+/// Source: taken from the lower-hash input Datum (same determinism rule).
+/// `random_state`: merged across both inputs via
+/// `Blake2b512Random::merge` over the deduplicated, byte-sorted RNGs —
+/// same construction as the IntegerAdd / BitmaskOr number-channel merge.
+///
+/// Both inputs must hold a single Par whose only expression is an EMap;
+/// an empty `pars` vec is treated as an empty Map.
+pub fn combine_mergeable_state_additive(
+    a: &Datum<ListParWithRandom>,
+    b: &Datum<ListParWithRandom>,
+) -> Datum<ListParWithRandom> {
+    let map_a = extract_payload_map(&a.a);
+    let map_b = extract_payload_map(&b.a);
+
+    let mut merged: std::collections::HashMap<Par, Par> = map_a;
+    for (k, v_b) in map_b {
+        match merged.get(&k) {
+            None => {
+                merged.insert(k, v_b);
+            }
+            Some(v_a) if *v_a == v_b => {}
+            Some(v_a) => {
+                let bytes_a = bincode::serialize(v_a).unwrap_or_default();
+                let bytes_b = bincode::serialize(&v_b).unwrap_or_default();
+                if bytes_b < bytes_a {
+                    merged.insert(k, v_b);
+                }
+            }
+        }
+    }
+
+    let merged_par = RhoMap::create_par(merged);
+
+    let mut rnd_pairs: Vec<(Blake2b512Random, Vec<u8>)> = [&a.a.random_state, &b.a.random_state]
+        .into_iter()
+        .map(|bytes| {
+            let rnd = Blake2b512Random::from_bytes(bytes);
+            let key = rnd.to_bytes();
+            (rnd, key)
+        })
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    rnd_pairs.sort_by(|x, y| x.1.cmp(&y.1));
+    let sorted_rnds: Vec<Blake2b512Random> = rnd_pairs.into_iter().map(|(rnd, _)| rnd).collect();
+    let merged_rnd = match sorted_rnds.len() {
+        0 => Blake2b512Random::from_bytes(&[]),
+        1 => sorted_rnds.into_iter().next().unwrap(),
+        _ => Blake2b512Random::merge(sorted_rnds),
+    };
+
+    let bytes_a = bincode::serialize(a).unwrap_or_default();
+    let bytes_b = bincode::serialize(b).unwrap_or_default();
+    let source_winner =
+        if Blake2b256Hash::new(&bytes_a).bytes() <= Blake2b256Hash::new(&bytes_b).bytes() {
+            a.source.clone()
+        } else {
+            b.source.clone()
+        };
+
+    Datum {
+        a: ListParWithRandom {
+            pars: vec![merged_par],
+            random_state: merged_rnd.to_bytes(),
+        },
+        persist: a.persist || b.persist,
+        source: source_winner,
+    }
+}
+
+fn extract_payload_map(payload: &ListParWithRandom) -> std::collections::HashMap<Par, Par> {
+    if payload.pars.is_empty() {
+        return std::collections::HashMap::new();
+    }
+    debug_assert_eq!(
+        payload.pars.len(),
+        1,
+        "AdditiveSet payload must hold exactly one Par (the Map)"
+    );
+    RhoMap::unapply(&payload.pars[0]).unwrap_or_default()
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]

--- a/rholang/src/rust/interpreter/rho_runtime.rs
+++ b/rholang/src/rust/interpreter/rho_runtime.rs
@@ -1204,24 +1204,47 @@ where
     let maps_and_refs = setup_maps_and_refs(&extra_system_processes);
     let (block_data_ref, invalid_blocks, deploy_data_ref, mut urn_map, proc_defs) = maps_and_refs;
 
-    // Expose the bitmask-OR mergeable tag to system contracts (Registry.rho)
-    // via a URI binding. Genesis-defined tags are unforgeable names; they must
-    // be created at runtime startup and threaded into both the merge engine's
-    // tag registry and the URN map so contracts can bind them via
-    // `bootstrapName(`rho:system:...`)`.
+    // Expose mergeable tags to system contracts via URI bindings. Genesis-
+    // defined tags are unforgeable names; they must be created at runtime
+    // startup and threaded into both the merge engine's tag registry and the
+    // URN map so contracts can bind them via `bootstrapName(`rho:system:...`)`.
+    //
+    // - `rho:system:bitmaskMergeableTag` — used by Registry.rho's TreeHashMap
+    //   interior-node bitmaps (BitmaskOr merge).
+    // - `rho:system:mutexStateMergeableTag` — used by PoS.rhox's `stateCh`
+    //   (MutexState merge).
+    //
+    // The IntegerAdd tag (NonNegativeNumber) is bound via the
+    // NonNegativeNumber.rho contract import path, not via URI.
     for (tag_par, merge_type) in mergeable_tags.iter() {
-        if let MergeType::BitmaskOr = merge_type {
-            tracing::info!(
-                target: "f1r3fly.merge.tag_check",
-                "URI binding inserted: rho:system:bitmaskMergeableTag -> Par(unforgeables={}, exprs={}, bundles={})",
-                tag_par.unforgeables.len(),
-                tag_par.exprs.len(),
-                tag_par.bundles.len(),
-            );
-            urn_map.insert(
-                "rho:system:bitmaskMergeableTag".to_string(),
-                tag_par.clone(),
-            );
+        match merge_type {
+            MergeType::BitmaskOr => {
+                tracing::info!(
+                    target: "f1r3fly.merge.tag_check",
+                    "URI binding inserted: rho:system:bitmaskMergeableTag -> Par(unforgeables={}, exprs={}, bundles={})",
+                    tag_par.unforgeables.len(),
+                    tag_par.exprs.len(),
+                    tag_par.bundles.len(),
+                );
+                urn_map.insert(
+                    "rho:system:bitmaskMergeableTag".to_string(),
+                    tag_par.clone(),
+                );
+            }
+            MergeType::MutexState => {
+                tracing::info!(
+                    target: "f1r3fly.merge.tag_check",
+                    "URI binding inserted: rho:system:mutexStateMergeableTag -> Par(unforgeables={}, exprs={}, bundles={})",
+                    tag_par.unforgeables.len(),
+                    tag_par.exprs.len(),
+                    tag_par.bundles.len(),
+                );
+                urn_map.insert(
+                    "rho:system:mutexStateMergeableTag".to_string(),
+                    tag_par.clone(),
+                );
+            }
+            MergeType::IntegerAdd => { /* bound via NonNegativeNumber.rho */ }
         }
     }
 

--- a/rholang/src/rust/interpreter/rho_runtime.rs
+++ b/rholang/src/rust/interpreter/rho_runtime.rs
@@ -13,9 +13,9 @@ use models::rust::utils::new_freevar_par;
 use models::rust::validator::Validator;
 use rspace_plus_plus::rspace::checkpoint::{Checkpoint, SoftCheckpoint};
 use rspace_plus_plus::rspace::hashing::blake2b256_hash::Blake2b256Hash;
-use rspace_plus_plus::rspace::merger::merging_logic::MergeType;
 use rspace_plus_plus::rspace::history::history_repository::HistoryRepository;
 use rspace_plus_plus::rspace::internal::{Datum, Row, WaitingContinuation};
+use rspace_plus_plus::rspace::merger::merging_logic::MergeType;
 use rspace_plus_plus::rspace::r#match::Match;
 use rspace_plus_plus::rspace::replay_rspace_interface::IReplayRSpace;
 use rspace_plus_plus::rspace::rspace::RSpace;
@@ -326,11 +326,7 @@ impl RhoRuntime for RhoRuntimeImpl {
         &mut self,
     ) -> SoftCheckpoint<Par, BindPattern, ListParWithRandom, TaggedContinuation> {
         let start = Instant::now();
-        let checkpoint = self
-            .reducer
-            .space
-            .create_soft_checkpoint()
-            .await;
+        let checkpoint = self.reducer.space.create_soft_checkpoint().await;
         metrics::histogram!(CREATE_SOFT_CHECKPOINT_TIME_METRIC, "source" => RUNTIME_METRICS_SOURCE)
             .record(start.elapsed().as_secs_f64());
         metrics::counter!(RUNTIME_SOFT_CHECKPOINT_TOTAL_METRIC, "source" => RUNTIME_METRICS_SOURCE)
@@ -378,12 +374,7 @@ impl RhoRuntime for RhoRuntimeImpl {
 
     async fn create_checkpoint(&mut self) -> Checkpoint {
         let start = Instant::now();
-        let checkpoint = self
-            .reducer
-            .space
-            .create_checkpoint()
-            .await
-            .unwrap();
+        let checkpoint = self.reducer.space.create_checkpoint().await.unwrap();
         metrics::histogram!(CREATE_CHECKPOINT_TIME_METRIC, "source" => RUNTIME_METRICS_SOURCE)
             .record(start.elapsed().as_secs_f64());
         metrics::counter!(RUNTIME_CHECKPOINT_TOTAL_METRIC, "source" => RUNTIME_METRICS_SOURCE)
@@ -401,11 +392,7 @@ impl RhoRuntime for RhoRuntimeImpl {
         channel: Vec<Par>,
         pattern: Vec<BindPattern>,
     ) -> Result<Option<(TaggedContinuation, Vec<ListParWithRandom>)>, InterpreterError> {
-        Ok(self
-            .reducer
-            .space
-            .consume_result(channel, pattern)
-            .await?)
+        Ok(self.reducer.space.consume_result(channel, pattern).await?)
     }
 
     async fn get_data(&self, channel: &Par) -> Vec<Datum<ListParWithRandom>> {
@@ -420,10 +407,7 @@ impl RhoRuntime for RhoRuntimeImpl {
         &self,
         channels: Vec<Par>,
     ) -> Vec<WaitingContinuation<BindPattern, TaggedContinuation>> {
-        self.reducer
-            .space
-            .get_waiting_continuations(channels)
-            .await
+        self.reducer.space.get_waiting_continuations(channels).await
     }
 
     async fn set_block_data(&self, block_data: BlockData) -> () {
@@ -483,20 +467,14 @@ impl HasCost for RhoRuntimeImpl {
     }
 }
 
-pub type RhoTuplespace = Arc<
-    Box<dyn Tuplespace<Par, BindPattern, ListParWithRandom, TaggedContinuation> + Send + Sync>,
->;
+pub type RhoTuplespace =
+    Arc<Box<dyn Tuplespace<Par, BindPattern, ListParWithRandom, TaggedContinuation> + Send + Sync>>;
 
-pub type RhoISpace = Arc<
-    Box<dyn ISpace<Par, BindPattern, ListParWithRandom, TaggedContinuation> + Send + Sync>,
->;
+pub type RhoISpace =
+    Arc<Box<dyn ISpace<Par, BindPattern, ListParWithRandom, TaggedContinuation> + Send + Sync>>;
 
 pub type RhoReplayISpace = Arc<
-    Box<
-        dyn IReplayRSpace<Par, BindPattern, ListParWithRandom, TaggedContinuation>
-            + Send
-            + Sync,
-    >,
+    Box<dyn IReplayRSpace<Par, BindPattern, ListParWithRandom, TaggedContinuation> + Send + Sync>,
 >;
 
 pub type RhoHistoryRepository = Arc<
@@ -532,7 +510,9 @@ where
         };
 
         for space in &mut spaces {
-            let result = space.install(channels.clone(), patterns.clone(), continuation.clone()).await;
+            let result = space
+                .install(channels.clone(), patterns.clone(), continuation.clone())
+                .await;
             results.push(result.map_err(|err| panic!("{}", err)).unwrap());
         }
     }
@@ -1213,6 +1193,8 @@ where
     //   interior-node bitmaps (BitmaskOr merge).
     // - `rho:system:mutexStateMergeableTag` — used by PoS.rhox's `stateCh`
     //   (MutexState merge).
+    // - `rho:system:additiveSetMergeableTag` — used by PoS.rhox's `bondsCh`
+    //   (AdditiveSet merge: key-wise union of Map payloads).
     //
     // The IntegerAdd tag (NonNegativeNumber) is bound via the
     // NonNegativeNumber.rho contract import path, not via URI.
@@ -1244,6 +1226,19 @@ where
                     tag_par.clone(),
                 );
             }
+            MergeType::AdditiveSet => {
+                tracing::info!(
+                    target: "f1r3fly.merge.tag_check",
+                    "URI binding inserted: rho:system:additiveSetMergeableTag -> Par(unforgeables={}, exprs={}, bundles={})",
+                    tag_par.unforgeables.len(),
+                    tag_par.exprs.len(),
+                    tag_par.bundles.len(),
+                );
+                urn_map.insert(
+                    "rho:system:additiveSetMergeableTag".to_string(),
+                    tag_par.clone(),
+                );
+            }
             MergeType::IntegerAdd => { /* bound via NonNegativeNumber.rho */ }
         }
     }
@@ -1251,9 +1246,10 @@ where
     let res = introduce_system_process(vec![&mut rspace], proc_defs).await;
     assert!(res.iter().all(|s| s.is_none()));
 
-    let charging_rspace: RhoISpace = Arc::new(Box::new(
-        ChargingRSpace::charging_rspace(rspace, cost.clone()),
-    ));
+    let charging_rspace: RhoISpace = Arc::new(Box::new(ChargingRSpace::charging_rspace(
+        rspace,
+        cost.clone(),
+    )));
 
     // Use services from ExternalServices
     let openai_service = external_services.openai.clone();

--- a/rspace++/src/rspace/merger/event_log_index.rs
+++ b/rspace++/src/rspace/merger/event_log_index.rs
@@ -7,7 +7,8 @@ use rayon::prelude::*;
 use shared::rust::hashable_set::HashableSet;
 
 use super::merging_logic::{
-    NumberChannelsDiff, combine_mergeable_value, combine_produces_copied_by_peek,
+    combine_mergeable_state_bytes, combine_mergeable_value, combine_produces_copied_by_peek,
+    NumberChannelsDiff, StateChannelsDiff,
 };
 use crate::rspace::errors::HistoryError;
 use crate::rspace::trace::event::{Consume, Event, IOEvent, Produce};
@@ -26,6 +27,10 @@ pub struct EventLogIndex {
     pub produces_mergeable: HashableSet<Produce>,
     pub consumes_mergeable: HashableSet<Consume>,
     pub number_channels_data: NumberChannelsDiff,
+    /// Parallel State-channel pipeline. Byte-erased storage — bytes are
+    /// bincode-serialized `Datum<ListParWithRandom>`. See
+    /// `merging_logic::combine_mergeable_state_bytes` for the merge rule.
+    pub state_channels_data: StateChannelsDiff,
 }
 
 // Ordering for deterministic processing in merge operations.
@@ -52,6 +57,25 @@ impl Ord for EventLogIndex {
         // Compare entries lexicographically: first by key (Blake2b256Hash), then by
         // value (i64)
         for ((ak, av), (bk, bv)) in a_entries.iter().zip(b_entries.iter()) {
+            let key_cmp = ak.cmp(bk);
+            if key_cmp != std::cmp::Ordering::Equal {
+                return key_cmp;
+            }
+            let val_cmp = av.cmp(bv);
+            if val_cmp != std::cmp::Ordering::Equal {
+                return val_cmp;
+            }
+        }
+
+        // Compare state_channels_data (BTreeMap, key-sorted) entries
+        // lexicographically by (key, byte payload).
+        let a_state: Vec<_> = self.state_channels_data.iter().collect();
+        let b_state: Vec<_> = other.state_channels_data.iter().collect();
+        let state_len_cmp = a_state.len().cmp(&b_state.len());
+        if state_len_cmp != std::cmp::Ordering::Equal {
+            return state_len_cmp;
+        }
+        for ((ak, av), (bk, bv)) in a_state.iter().zip(b_state.iter()) {
             let key_cmp = ak.cmp(bk);
             if key_cmp != std::cmp::Ordering::Equal {
                 return key_cmp;
@@ -90,6 +114,7 @@ impl EventLogIndex {
         produce_exists_in_pre_state: impl Fn(&Produce) -> bool,
         produce_touch_pre_state_join: impl Fn(&Produce) -> bool,
         mergeable_chs: NumberChannelsDiff,
+        state_chs: StateChannelsDiff,
     ) -> Self {
         // Use Arc<Mutex<>> for thread-safe collections that will be updated in parallel
         let produces_linear = Arc::new(Mutex::new(HashSet::new()));
@@ -230,11 +255,16 @@ impl EventLogIndex {
             .cloned()
             .collect();
 
-        // Then filter and clone only once for the final set
+        // Then filter and clone only once for the final set.
+        // A produce/consume is "mergeable" if it touched ANY mergeable channel
+        // (number-tagged OR state-tagged).
         let produces_mergeable = HashableSet(
             all_produces
                 .into_iter()
-                .filter(|p| mergeable_chs.contains_key(&p.channel_hash))
+                .filter(|p| {
+                    mergeable_chs.contains_key(&p.channel_hash)
+                        || state_chs.contains_key(&p.channel_hash)
+                })
                 .collect(),
         );
 
@@ -251,9 +281,9 @@ impl EventLogIndex {
             all_consumes
                 .into_iter()
                 .filter(|c| {
-                    c.channel_hashes
-                        .iter()
-                        .any(|hash| mergeable_chs.contains_key(hash))
+                    c.channel_hashes.iter().any(|hash| {
+                        mergeable_chs.contains_key(hash) || state_chs.contains_key(hash)
+                    })
                 })
                 .collect(),
         );
@@ -271,6 +301,7 @@ impl EventLogIndex {
             produces_mergeable,
             consumes_mergeable,
             number_channels_data: mergeable_chs,
+            state_channels_data: state_chs,
         }
     }
 
@@ -288,6 +319,7 @@ impl EventLogIndex {
             produces_mergeable: HashableSet(HashSet::new()),
             consumes_mergeable: HashableSet(HashSet::new()),
             number_channels_data: NumberChannelsDiff::new(),
+            state_channels_data: StateChannelsDiff::new(),
         }
     }
 
@@ -316,6 +348,29 @@ impl EventLogIndex {
                 }
                 None => {
                     number_channels_data.insert(key.clone(), (incoming_diff, incoming_mt));
+                }
+            }
+        }
+
+        let mut state_channels_data = StateChannelsDiff::new();
+        for (key, value) in x
+            .state_channels_data
+            .iter()
+            .chain(y.state_channels_data.iter())
+        {
+            let (incoming_bytes, incoming_mt) = value;
+            match state_channels_data.get_mut(key) {
+                Some(existing) => {
+                    if existing.1 != *incoming_mt {
+                        return Err(HistoryError::MergeError(format!(
+                            "MergeType mismatch on state channel {:?}: {:?} vs {:?}",
+                            key, existing.1, incoming_mt,
+                        )));
+                    }
+                    existing.0 = combine_mergeable_state_bytes(&existing.0, incoming_bytes);
+                }
+                None => {
+                    state_channels_data.insert(key.clone(), (incoming_bytes.clone(), *incoming_mt));
                 }
             }
         }
@@ -396,6 +451,7 @@ impl EventLogIndex {
                     .collect(),
             ),
             number_channels_data,
+            state_channels_data,
         })
     }
 }

--- a/rspace++/src/rspace/merger/merging_logic.rs
+++ b/rspace++/src/rspace/merger/merging_logic.rs
@@ -29,6 +29,7 @@ pub enum MergeType {
     IntegerAdd,
     BitmaskOr,
     MutexState,
+    AdditiveSet,
 }
 
 // === Number-channel pipeline (existing — i64-valued) =======================
@@ -49,8 +50,12 @@ pub fn combine_mergeable_value(a: i64, b: i64, merge_type: MergeType) -> i64 {
         MergeType::IntegerAdd => a.wrapping_add(b),
         MergeType::BitmaskOr => ((a as u64) | (b as u64)) as i64,
         MergeType::MutexState => unreachable!(
-            "combine_mergeable_value (i64 path) cannot handle MutexState; \
-             route MutexState channels through combine_mergeable_state instead"
+            "combine_mergeable_value (i64 path) cannot handle MutexState; route MutexState \
+             channels through combine_mergeable_state instead"
+        ),
+        MergeType::AdditiveSet => unreachable!(
+            "combine_mergeable_value (i64 path) cannot handle AdditiveSet; route AdditiveSet \
+             channels through combine_mergeable_state_additive instead"
         ),
     }
 }
@@ -106,14 +111,8 @@ pub fn combine_mergeable_state_bytes(a: &[u8], b: &[u8]) -> Vec<u8> {
 ///
 /// `merge_type` is accepted for API symmetry with `combine_mergeable_value`
 /// and asserted internally — only `MergeType::MutexState` is valid here.
-pub fn combine_mergeable_state<P>(
-    a: &Datum<P>,
-    b: &Datum<P>,
-    merge_type: MergeType,
-) -> Datum<P>
-where
-    P: Clone + serde::Serialize,
-{
+pub fn combine_mergeable_state<P>(a: &Datum<P>, b: &Datum<P>, merge_type: MergeType) -> Datum<P>
+where P: Clone + serde::Serialize {
     debug_assert!(
         matches!(merge_type, MergeType::MutexState),
         "combine_mergeable_state only supports MergeType::MutexState, got {:?}",
@@ -1891,12 +1890,9 @@ mod tests {
     fn mutex_state_combine_n_parents_returns_one_winner() {
         let datums: Vec<_> = (0..4u8).map(|i| make_test_datum(i)).collect();
 
-        let result = datums
-            .iter()
-            .skip(1)
-            .fold(datums[0].clone(), |acc, d| {
-                combine_mergeable_state(&acc, d, MergeType::MutexState)
-            });
+        let result = datums.iter().skip(1).fold(datums[0].clone(), |acc, d| {
+            combine_mergeable_state(&acc, d, MergeType::MutexState)
+        });
 
         assert!(datums.contains(&result));
     }

--- a/rspace++/src/rspace/merger/merging_logic.rs
+++ b/rspace++/src/rspace/merger/merging_logic.rs
@@ -7,6 +7,7 @@ use shared::rust::hashable_set::HashableSet;
 
 use super::event_log_index::EventLogIndex;
 use crate::rspace::hashing::blake2b256_hash::Blake2b256Hash;
+use crate::rspace::internal::Datum;
 use crate::rspace::trace::event::{Consume, Produce};
 
 /// Merge strategy for a mergeable channel. Mirrors
@@ -27,7 +28,13 @@ use crate::rspace::trace::event::{Consume, Produce};
 pub enum MergeType {
     IntegerAdd,
     BitmaskOr,
+    MutexState,
 }
+
+// === Number-channel pipeline (existing — i64-valued) =======================
+//
+// IntegerAdd / BitmaskOr strategies operate on `i64` values. See the parallel
+// state-channel pipeline below for `MutexState` (`Datum<P>`-valued).
 
 pub type NumberChannelsEndVal = BTreeMap<Blake2b256Hash, (i64, MergeType)>;
 
@@ -41,6 +48,85 @@ pub fn combine_mergeable_value(a: i64, b: i64, merge_type: MergeType) -> i64 {
     match merge_type {
         MergeType::IntegerAdd => a.wrapping_add(b),
         MergeType::BitmaskOr => ((a as u64) | (b as u64)) as i64,
+        MergeType::MutexState => unreachable!(
+            "combine_mergeable_value (i64 path) cannot handle MutexState; \
+             route MutexState channels through combine_mergeable_state instead"
+        ),
+    }
+}
+
+// === State-channel pipeline (`Datum<P>`-valued) ============================
+//
+// The `MutexState` strategy operates on opaque `Datum<P>` payloads
+// (e.g. PoS `stateCh`). Stored as serialized bytes here to avoid making
+// `EventLogIndex` and downstream consumers generic over the payload
+// type — rspace++ cannot depend on the `models` crate (which provides
+// `ListParWithRandom`) because `models` already depends on rspace++.
+//
+// The typed `combine_mergeable_state` function operates on `Datum<P>` for
+// clean unit testing; the dispatch layer decodes bytes from
+// `StateChannelsDiff` into `Datum<ListParWithRandom>` before invoking it,
+// then re-encodes the winner.
+
+pub type StateChannelsEndVal = BTreeMap<Blake2b256Hash, (Vec<u8>, MergeType)>;
+
+pub type StateChannelsDiff = BTreeMap<Blake2b256Hash, (Vec<u8>, MergeType)>;
+
+/// Byte-level equivalent of `combine_mergeable_state` for the byte-erased
+/// storage layer (e.g. `EventLogIndex.state_channels_data`).
+///
+/// Since storage bytes ARE `bincode::serialize(datum)`, hashing them with
+/// `Blake2b256Hash::new` produces the exact same hash as the typed
+/// `combine_mergeable_state` would compute. This avoids the decode → combine
+/// → re-encode round-trip when we only need to pick the winner's bytes.
+///
+/// Used by `EventLogIndex::combine` and `conflict_set_merger` at the rspace++
+/// layer where the typed `Datum<P>` payload type isn't available.
+pub fn combine_mergeable_state_bytes(a: &[u8], b: &[u8]) -> Vec<u8> {
+    let a_hash = Blake2b256Hash::new(a);
+    let b_hash = Blake2b256Hash::new(b);
+    if a_hash.bytes() <= b_hash.bytes() {
+        a.to_vec()
+    } else {
+        b.to_vec()
+    }
+}
+
+/// Combine two state-channel `Datum`s under the `MutexState` strategy.
+///
+/// Determinism rule: the Datum with the lexicographically lower
+/// `Blake2b256Hash` of its bincode-serialized bytes wins. Hashing the full
+/// Datum (payload + persist + source) — not the payload alone — gives a
+/// total order even when two siblings produce equal payloads, because the
+/// `Produce` source carries lineage that distinguishes them.
+///
+/// This is the LWW-Register CRDT specialization for opaque Rholang state
+/// channels (PoS `stateCh`, etc.). The function is associative, commutative,
+/// and idempotent.
+///
+/// `merge_type` is accepted for API symmetry with `combine_mergeable_value`
+/// and asserted internally — only `MergeType::MutexState` is valid here.
+pub fn combine_mergeable_state<P>(
+    a: &Datum<P>,
+    b: &Datum<P>,
+    merge_type: MergeType,
+) -> Datum<P>
+where
+    P: Clone + serde::Serialize,
+{
+    debug_assert!(
+        matches!(merge_type, MergeType::MutexState),
+        "combine_mergeable_state only supports MergeType::MutexState, got {:?}",
+        merge_type,
+    );
+    let a_bytes = bincode::serialize(a).unwrap_or_default();
+    let b_bytes = bincode::serialize(b).unwrap_or_default();
+    let a_hash = Blake2b256Hash::new(&a_bytes);
+    let b_hash = Blake2b256Hash::new(&b_bytes);
+    if a_hash.bytes() <= b_hash.bytes() {
+        a.clone()
+    } else {
+        b.clone()
     }
 }
 
@@ -1720,5 +1806,98 @@ mod tests {
             let a_bc = combine_mergeable_value(a, bc, MergeType::IntegerAdd);
             proptest::prop_assert_eq!(ab_c, a_bc);
         }
+    }
+
+    use crate::rspace::hashing::blake2b256_hash::Blake2b256Hash;
+    use crate::rspace::internal::Datum;
+    use crate::rspace::trace::event::Produce;
+
+    // Test payload is `i64` to keep the test inside rspace++. The merge
+    // function is generic over A and depends only on the serialized Datum
+    // hash, so i64 is behaviourally equivalent to ListParWithRandom here.
+    fn make_test_datum(payload_marker: u8) -> Datum<i64> {
+        let payload: i64 = payload_marker as i64;
+        let produce = Produce {
+            channel_hash: Blake2b256Hash::new(&[payload_marker]),
+            hash: Blake2b256Hash::new(&[payload_marker; 8]),
+            persistent: false,
+            is_deterministic: true,
+            output_value: vec![],
+            failed: false,
+        };
+        Datum {
+            a: payload,
+            persist: false,
+            source: produce,
+        }
+    }
+
+    #[test]
+    fn mutex_state_combine_picks_lowest_hash_winner() {
+        let datum_a = make_test_datum(0xAA);
+        let datum_b = make_test_datum(0xBB);
+        let datum_c = make_test_datum(0xCC);
+
+        let r1 = combine_mergeable_state(&datum_a, &datum_b, MergeType::MutexState);
+        let r2 = combine_mergeable_state(&r1, &datum_c, MergeType::MutexState);
+
+        let candidates = vec![datum_a.clone(), datum_b.clone(), datum_c.clone()];
+        let expected = candidates
+            .iter()
+            .min_by_key(|d| {
+                let bytes = bincode::serialize(d).unwrap_or_default();
+                Blake2b256Hash::new(&bytes).bytes()
+            })
+            .unwrap();
+        assert_eq!(&r2, expected);
+    }
+
+    #[test]
+    fn mutex_state_combine_is_commutative() {
+        let datum_a = make_test_datum(0x01);
+        let datum_b = make_test_datum(0x02);
+
+        let ab = combine_mergeable_state(&datum_a, &datum_b, MergeType::MutexState);
+        let ba = combine_mergeable_state(&datum_b, &datum_a, MergeType::MutexState);
+
+        assert_eq!(ab, ba);
+    }
+
+    #[test]
+    fn mutex_state_combine_is_associative() {
+        let datum_a = make_test_datum(0xA1);
+        let datum_b = make_test_datum(0xB2);
+        let datum_c = make_test_datum(0xC3);
+
+        let ab = combine_mergeable_state(&datum_a, &datum_b, MergeType::MutexState);
+        let abc_left = combine_mergeable_state(&ab, &datum_c, MergeType::MutexState);
+
+        let bc = combine_mergeable_state(&datum_b, &datum_c, MergeType::MutexState);
+        let abc_right = combine_mergeable_state(&datum_a, &bc, MergeType::MutexState);
+
+        assert_eq!(abc_left, abc_right);
+    }
+
+    #[test]
+    fn mutex_state_combine_is_idempotent() {
+        let datum_a = make_test_datum(0x42);
+
+        let aa = combine_mergeable_state(&datum_a, &datum_a, MergeType::MutexState);
+
+        assert_eq!(aa, datum_a);
+    }
+
+    #[test]
+    fn mutex_state_combine_n_parents_returns_one_winner() {
+        let datums: Vec<_> = (0..4u8).map(|i| make_test_datum(i)).collect();
+
+        let result = datums
+            .iter()
+            .skip(1)
+            .fold(datums[0].clone(), |acc, d| {
+                combine_mergeable_state(&acc, d, MergeType::MutexState)
+            });
+
+        assert!(datums.contains(&result));
     }
 }


### PR DESCRIPTION
## Summary

Fixes the joiner-dropped-from-bonds-map bonding bug:

**Joiner silently dropped from bonds map after first proposed block.** Multi-parent merge of a branch carrying a bond write against sibling branches that don't (heartbeat-only `closeBlock` writes elsewhere) was using the `MutexState` merge primitive's lowest-Blake2b256-hash LWW combine, which picks one Datum's full Map and discards the others — roughly N-1 / N of the time the bond contribution is dropped. New `MergeType::AdditiveSet` primitive does key-wise Map union with per-key tiebreak, applied to a dedicated `bondsCh` channel in PoS.rhox. Verified end-to-end: integration B5 5/5 stable, mean 379s, with cross-node bonds-map consistency at every bond block (4 entries after V4 bond, 5 entries after V5 bond, observer LFS-syncs to LFB#52-#56 with drift=0).

Stacked on PR #508 (`feat/lfs-validation`) which is itself stacked on PR #507 (`feat/lfs-coverage`). Reviewer sees only this PR's commits.

The orchestrator multi-root pagination fix that earlier rode on this PR has been moved to PR #507 where it belongs scope-wise (the orchestrator file is introduced by #507). This PR is now purely the bonding-merge fix plus its scaffolding (AdditiveSet primitive, horizon-mergeable defensive phase, reporter CLI flag + tests).

## Commits

- **`feat(merge): MergeType::AdditiveSet primitive + tag identity + dispatch`** — third state-channel merge type alongside MutexState and the number-channel BitmaskOr/IntegerAdd. Combine function unions two Datums' Maps key-wise with lowest-bincode per-key tiebreak; `random_state` merged via `Blake2b512Random::merge` across deduped sorted-bytes input. Wires through dispatch (variant in `merging_logic.rs`, `calculate_state_channel_merge`, conflict-set merger, fold_multi_value, `get_state_channels_data` filter), URI binding `rho:system:additiveSetMergeableTag`, and a new mergeable tag identity (PK + timestamp + 4-way pairwise-distinct test). Bond-merge regression test pins the contract: branch carrying `{V1,V2,V3,V4}` merges with heartbeat-only sibling carrying `{V1,V2,V3}` to `{V1,V2,V3,V4}`, not LWW-pick of one branch.

- **`feat(pos): bondsCh + AdditiveSet routing for bond writes`** — adds dedicated `bondsCh` state channel tagged with `additiveSetTag`, holding the canonical `Map[PublicKey, Int]` bonds map. The `bond` handler dual-writes to both `state.allBonds` (legacy mirror for slash/withdraw, until those migrate) and `bondsCh`. `getBonds` and `closeBlock`'s active-validator selection read `bondsCh`. Multi-parent merge of concurrent bond writes now key-unions through AdditiveSet instead of LWW-dropping all but one branch's contribution. Slash and withdraw continue to read `state.allBonds` and are not in scope; their bonded-state reads will see stale views post-merge until those handlers are migrated.

- **`fix(lfs): horizon-mergeable phase + ForwardHorizon block-hash projection`** — refactors `compute_forward_horizon_roots` into a new `ForwardHorizon` struct that carries both `block_hashes` and `roots` from a single DAG walk. Adds a defensive horizon-mergeable phase to `request_approved_state` that scans the horizon block set for any block whose mergeable-channels store entry is locally absent and broadcasts requests to fill the gap, draining responses with a 30s deadline. In practice the per-block sync from `lfs_block_requester` already covers every horizon block, so this phase is a no-op on a well-behaved peer set; the phase exists to close the gap deterministically rather than depend on serendipitous coverage.

- **`feat(cli): --api-enable-reporting accepts true|false (backwards-compatible)`** — converts the `clap` `SetTrue` switch to a value-taking `Option<bool>` with `default_missing_value = "true"`. Bare `--api-enable-reporting` keeps backwards-compatibility as `true`; new `--api-enable-reporting=false` explicitly disables. Apply via inline `if let Some(...)` override instead of `try_override_bool` (which can only flip false → true). Unblocks per-node opt-out of the reporter, used by integration tests that need to attach a node with reporting explicitly off — see [#509](https://github.com/F1R3FLY-io/f1r3node/issues/509) for the reporter divergence on LFS-synced READONLY observers that motivated the addition.

- **`test(reporting): unit coverage for reporter on single-node + LFS-imported rspace`** — two reporter tests aligned with the Scala `MultiParentCasperReportingSpec` contract (`casper/tests/batch1/multi_parent_casper_reporting_spec.rs`). Single-node freshly-played PASSES; basic LFS-import roundtrip (play one trivial deploy, export trie, import to fresh rspace, run reporter against fresh rspace) PASSES — narrowing the production reporter divergence ([#509](https://github.com/F1R3FLY-io/f1r3node/issues/509)) to factors not captured by a unit-level repro. Supporting change: `TestNode` exposes `pub rspace_store: RSpaceStore` so tests can construct ancillary runtimes over the same KV stores without re-deriving them from the data dir.

## Test plan

- [x] Casper unit tests: `cargo test --release -p casper` — 495+ passed (includes the two new reporter tests and the bond-merge regression)
- [x] Integration B5 (`test_bonding_validators` against `feat/bonding-additiveset` binary): 5/5 individual stability runs passed (391s, 381s, 381s, 367s, 375s; mean 379s). Phase A bonds V4 with cross-node bonds map consistency (4 entries); Phase B bonds V5 with cross-node bonds map consistency (5 entries); Phase C observer LFS-syncs to LFB #52-#56 with drift=0. Zero panics, zero forbidden patterns, zero deploy replay failures.
- [x] CLI option tests: `cargo test --release -p node --lib -- configuration::commandline` — 10/10 passed (includes existing `test_cli_options_override_defaults` updated for the new `Option<bool>` field).

Co-Authored-By: Claude <noreply@anthropic.com>
