### PR TITLE
ci: wire integration baseline + env-var defaults.conf resolution

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -281,7 +281,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: F1R3FLY-io/system-integration
-          ref: 2ace29f4f45b26418749edb9477ec2a310be9c6c
+          ref: refactor/integration-test-framework
           path: system-integration
 
       - uses: actions/setup-python@v5
@@ -337,6 +337,7 @@ jobs:
         shell: bash -ex {0}
         env:
           DEFAULT_IMAGE: f1r3flyindustries/f1r3fly-rust-node
+          F1R3FLY_NODE_DEFAULTS_CONF: ${{ github.workspace }}/node/src/main/resources/defaults.conf
         run: |
           cd system-integration
           SCALE_FLAG=""
@@ -344,29 +345,18 @@ jobs:
             SCALE_FLAG="--timeout-scale=1.5"
           fi
           poetry run pytest \
-            integration-tests/test/test_web_api.py \
-            integration-tests/test/test_wallets.py \
-            integration-tests/test/test_heartbeat.py \
-            integration-tests/test/test_deployment.py \
-            integration-tests/test/test_storage.py \
-            integration-tests/test/test_genesis_ceremony.py \
-            integration-tests/test/test_dag_correctness.py \
-            integration-tests/test/test_finalization.py \
-            integration-tests/test/test_propose.py \
-            integration-tests/test/test_replay_correctness.py \
-            integration-tests/test/test_convergence.py \
-            integration-tests/test/test_bridge_admin.py \
-            integration-tests/test/test_shard_degradation.py \
-            integration-tests/test/test_consensus_health.py \
-            integration-tests/test/test_websocket.py \
-            integration-tests/test/test_synchrony_constraint.py \
-            integration-tests/test/test_asymmetric_bonds.py \
-            integration-tests/test/test_bonding_validators.py \
-            integration-tests/test/test_trim_state.py \
-            -v --tb=short --log-cli-level=WARNING \
-            -n 3 --dist=loadgroup \
-            --deselect=integration-tests/test/test_convergence.py::test_network_converges_after_slow_deploy \
-            --startup-timeout=600 --command-timeout=300 --timeout=1200 $SCALE_FLAG
+            integration-tests/test/tests/shared/ \
+            integration-tests/test/tests/custom/ \
+            integration-tests/test/tests/standalone/ \
+            --deselect integration-tests/test/tests/custom/test_load.py \
+            --deselect integration-tests/test/tests/shared/test_convergence.py::test_network_converges_after_slow_deploy \
+            --deselect integration-tests/test/tests/custom/test_asymmetric_bonds.py::test_finalization_asymmetric_bonds \
+            --deselect integration-tests/test/tests/shared/test_convergence.py::test_ft_convergence \
+            --deselect integration-tests/test/tests/shared/test_bonding_validators.py \
+            --deselect integration-tests/test/tests/custom/test_joiner_self_proposes_at_epoch_boundary.py \
+            --deselect integration-tests/test/tests/shared/test_observer_lfs_sync.py \
+            -v --tb=short --instafail --maxfail=10 \
+            -n auto --dist=loadgroup --timeout=1200 $SCALE_FLAG
 
       - name: Upload Integration Test Logs
         if: always()


### PR DESCRIPTION
## Summary

Updates the integration-tests CI step on \`rust/staging\` to:

1. **Track system-integration's \`refactor/integration-test-framework\` branch tip** instead of the stale pinned commit \`2ace29f4\` (from before the v2 test framework refactor).
2. **Run the canonical baseline** that's the source of truth in [\`system-integration/docs/TODO.md\` §1](https://github.com/F1R3FLY-io/system-integration/blob/refactor/integration-test-framework/docs/TODO.md): walk \`tests/{shared,custom,standalone}/\` with the current deselect list (7 entries), xdist \`-n auto --dist=loadgroup\`, \`--instafail --maxfail=10\`.
3. **Set \`F1R3FLY_NODE_DEFAULTS_CONF\`** so \`NodeConf.resolve()\` finds the node's \`defaults.conf\` at the CI checkout location, where f1r3node is the outer checkout and system-integration is nested under it. (Without this, ~12 tests/arch ERROR at setup with \`FileNotFoundError: services/f1r3node-rust/node/...defaults.conf\`. The system-integration side has a corresponding three-tier resolver in [\`integration-tests/test/infra/config.py\`](https://github.com/F1R3FLY-io/system-integration/blob/refactor/integration-test-framework/integration-tests/test/infra/config.py): env-var override → local-dev fallback → CI fallback.)

## Why this PR, not edits on #507 / #508

#507 and #508 already had similar CI-wiring commits applied directly. But the right place to fix this is \`rust/staging\` — once this lands, both PRs (and any future PR off staging) inherit the fix on rebase, and the duplicated wiring commits can be dropped.

## Pairs with

- system-integration commit \`bad7fdc\` on \`refactor/integration-test-framework\` — introduces \`resolve_node_defaults_conf()\` with env-var + 2 fallback paths.

## Test plan

- [ ] CI on this PR runs green against \`rust/staging\` (\`bf6a03d2\`) with no infra ERRORs.
- [ ] Verify the \`F1R3FLY_NODE_DEFAULTS_CONF\` env var appears in CI logs as \`/opt/actions-runner/_work/f1r3node/f1r3node/node/src/main/resources/defaults.conf\` (or equivalent runner path).
- [ ] Deselected tests stay deselected (matches TODO.md §1).
- [ ] No regression vs. the 91/0 subprocess baseline / 93/0-target Docker baseline.

Co-Authored-By: Claude <noreply@anthropic.com>