### PR TITLE
fix(conf): production heartbeat defaults — closes test_shard_degradation inclusion floor

### DIFF
--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -343,15 +343,21 @@ casper {
   # boundary itself.
   fork-choice-check-if-stale-interval = 11 minutes
 
-  # Cross-validator coordination gate. Each block must be justified by
-  # peer blocks; before proposing, the node checks whether the stake
-  # behind those justifications meets
-  # `synchrony-constraint-threshold * total-stake-of-other-validators`.
-  # 0 disables the check (every validator may propose any time —
-  # maximises liveness, increases sibling rate). > 0 forces validators
-  # to wait for peer progress before proposing — reduces siblings and
-  # tightens DAG width but can stall when peers are slow. 0.67 is the
-  # production safety value for honest-majority assumptions.
+  # Cross-validator coordination gate, a linear-chain artifact that does NOT
+  # apply to multi-parent DAG consensus. In a multi-parent DAG, sibling
+  # blocks at the same height are not wasteful forks — they get merged into
+  # the next block via the DAG merger, and their deploy effects reach
+  # canonical state via merge / re-inclusion.
+  #
+  # Keep this at 0 for any multi-parent deployment. With > 0, validators
+  # block on each other's latest message before proposing — under wide DAGs
+  # or slow peer gossip this deadlocks (see f1r3node#437) and the only
+  # recovery is the `synchrony-recovery-*` bypass machinery below, which
+  # adds complexity without correctness benefit.
+  #
+  # Setting > 0 is reserved for single-parent / linear-chain consensus
+  # mechanisms and for tests that specifically exercise the constraint
+  # path (e.g. `test_synchrony_constraint`).
   synchrony-constraint-threshold = 0
 
   # Duration before synchrony recovery bypass becomes eligible.
@@ -529,16 +535,25 @@ casper {
     # If no block has been finalized in this duration, propose an empty block
     max-lfb-age = 5 seconds
 
-    # Minimum time between heartbeat self-proposals.
-    # Controls proposal rate to prevent flooding the network.
-    self-propose-cooldown = 15 seconds
+    # Minimum time between heartbeat self-proposals. In a multi-parent DAG,
+    # siblings at the same height are an expected, merged-by-design outcome
+    # (not a fork), so cooldown's job is CPU/bandwidth budget plus a soft
+    # finalization-gap throttle — not sibling-rate control. The latter is
+    # handled by the DAG merger. 3 seconds gives deploy queues at production
+    # cadence (up to ~10 d/s) headroom to drain without piling on inclusion
+    # latency floors; raise for clusters with much slower per-block compute
+    # or much wider DAGs where finalization can't keep up.
+    self-propose-cooldown = 3 seconds
 
     # Minimum age of LFB/frontier before stale-recovery, leader-recovery,
     # and pending-deploy backstop are allowed to fire. Debounces empty-block
     # churn when the cluster is healthy. Lower → more responsive recovery
     # but more empty heartbeat blocks; higher → slower recovery, fewer
-    # blocks per minute.
-    stale-recovery-min-interval = 12 seconds
+    # blocks per minute. Paired with `self-propose-cooldown = 3 seconds`:
+    # keeps recovery responsive on the same timescale, so a transient stall
+    # under load is detected and worked around within one propose window
+    # instead of accumulating queue depth for 12+ seconds.
+    stale-recovery-min-interval = 3 seconds
 
     # When pending deploys land, opens a grace window during which lag caps
     # relax (advanced.deploy-recovery-max-lag instead of advanced.pending-
@@ -552,10 +567,16 @@ casper {
     # Treat as unstable API.
     advanced {
       # When this validator is already ahead of LFB, how many blocks of
-      # lag tolerate before "frontier-follow" proposing is throttled.
-      # 0 = never frontier-chase while ahead unless deploy recovery is
-      # active (which raises this dynamically).
-      frontier-chase-max-lag = 0
+      # lag to tolerate before "frontier-follow" proposing is throttled.
+      # With `self-propose-cooldown = 3 seconds`, finalization typically
+      # lags propose cadence — validators are routinely "ahead of LFB" in
+      # normal operation. 0 (the prior default) caused validators to stop
+      # contributing under sustained load; 20 keeps them participating up
+      # to a bounded gap, which the DAG merger handles via multi-parent
+      # inclusion. Raise if your shard's finalizer is much slower than
+      # propose cadence; the cost is wider DAGs and more merge work per
+      # block.
+      frontier-chase-max-lag = 20
 
       # If the validator has pending deploys but is already > N blocks
       # ahead of LFB, suppress pending-deploy proposing. Prevents lag

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -373,8 +373,13 @@ casper {
   # Larger values allow recovery on busier networks.
   synchrony-finalized-baseline-max-distance = 2048
 
-  # Hard cap on user deploys per block. Adaptive deploy cap adjusts within this ceiling.
-  max-user-deploys-per-block = 32
+  # Hard cap on user deploys per block. Adaptive deploy cap adjusts within
+  # this ceiling. Higher values let a single block absorb more concurrent
+  # deploys (lower propose-per-deploy ratio under sustained load); lower
+  # values force more frequent proposes which raises DAG width and merge
+  # cost. 128 sized to comfortably absorb a 1-second burst across a
+  # 3-validator shard at production cadence.
+  max-user-deploys-per-block = 128
 
   # Hard cap on (latest_block_number - last_finalized_block_number) for
   # this validator. If the gap exceeds this, propose is refused until
@@ -509,8 +514,13 @@ casper {
 
   # Heartbeat configuration for maintaining liveness during periods of no user activity
   heartbeat {
-    # Enable heartbeat block proposing
-    enabled = false
+    # Enable heartbeat block proposing. The heartbeat loop is the
+    # cross-validator coordination mechanism that drives consistent
+    # block / finalization cadence on multi-validator deployments. Single-
+    # node dev shards can override this to `false` and rely on `autopropose`
+    # or operator-triggered proposes; multi-validator production should
+    # leave this on.
+    enabled = true
 
     # Check interval - how often to check if heartbeat is needed
     check-interval = 5 seconds
@@ -591,7 +601,10 @@ casper {
 metrics {
   # Expose Prometheus scrape endpoint at /metrics on the admin HTTP
   # port. Required for Grafana / alerting workflows; cheap when idle.
-  prometheus = false
+  # Bound to the admin HTTP port (operator-restricted by network ACL), so
+  # enabling by default provides observability without widening attack
+  # surface beyond what the admin HTTP listener already exposes.
+  prometheus = true
 
   # Enable the InfluxDB HTTP push reporter (epoch-seconds timestamps).
   # Use UDP variant below for sub-second sampling — at 500ms intervals


### PR DESCRIPTION
## Summary

Two-commit branch promoting heartbeat configuration from "test-shard override"
to "production default" so the deploy-inclusion floor stops being limited by
the 15-second self-propose-cooldown.

### Commit 1 — `c1c59b2c feat(conf): production defaults`

- `casper.heartbeat.enabled` = true (was false)
- `casper.max-user-deploys-per-block` = 128 (was 32)
- `metrics.prometheus` = true (was false)

Heartbeat is the cross-validator coordination mechanism for multi-validator
deployments; making it the default removes the need for every shard to flip
the flag in their override config. 128 max-deploys lets a single block absorb
a 1-second burst across a 3-validator shard at production cadence (affects
block size, not propose cadence — single-deploy realistic workloads are
unchanged). Prometheus binds to the admin HTTP port (operator-restricted),
so enabling by default provides observability without widening exposed surface.

### Commit 2 — `8f4a45f7 feat(conf): production heartbeat cadence`

- `self-propose-cooldown` = 3 seconds (was 15s)
- `stale-recovery-min-interval` = 3 seconds (was 12s)
- `advanced.frontier-chase-max-lag` = 20 (was 0)
- `synchrony-constraint-threshold` **comment rewritten** to reflect that 0
  is the correct value for multi-parent DAGs. The previous "0.67 is the
  production safety value" guidance was a linear-chain artifact that
  deadlocks here (f1r3node#437). The default value (0) is unchanged.

The cooldown change is the inclusion-floor unlock. In a multi-parent DAG,
sibling blocks at the same height are an expected, merged-by-design outcome
— not a wasteful fork. The DAG merger handles sibling-rate; cooldown's
actual job is CPU / bandwidth budget plus a soft finalization-gap throttle.
The previous 15s value left the deploy-inclusion floor at 15+ seconds under
any sustained load; 3s gives production-cadence deploy queues headroom to
drain.

The companion `stale-recovery` and `frontier-chase` tunings are paired
with the new cooldown — see commit message for detail.

## Companion system-integration changes

A companion test-helper migration (in the system-integration repo) moves
the existing `wait_for_finalized(blockNumber) + assert_block_finalized
_on_all_nodes(blockHash)` test pattern to sig-based deploy-finalization
tracking via `deploy_finalization_status::resolve` (this repo's PR #504).
The prior pattern asserts an invariant that's eventually-true rather than
immediately-true under multi-parent indirect-finalization timing; without
the migration, transfer / web-api tests would fail under the new cooldown
because the deploy's specific blockHash takes a few extra seconds to
converge to canonical state (deploy effects are canonical immediately via
merge; only the blockHash's per-block `isFinalized` field lags).

## Test plan

- [x] `cargo test --release --workspace --no-fail-fast` — **2147 passed / 0 failed**
- [x] integration suite against this binary (subprocess provider, full
  canonical command) — **94 passed / 0 failed in 22:45**
- [x] focused integration: `test_wallets` + `test_web_api` against this
  binary with the companion test-helper migration — **28 / 0**

Co-Authored-By: Claude <noreply@anthropic.com>