### PR TITLE
ci: fix baseline integration-test flakes

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -17,12 +17,12 @@ on:
       - rust/staging
       - "feature/**"
 
-# Prevent interleaving of integration test jobs on single-runner-per-arch
-# self-hosted runners. A second workflow run for the same ref queues until
-# the first completes rather than cancelling it.
+# Queue concurrent workflow runs for the same ref behind the active one
+# rather than cancelling. Each run gets its own pool of ephemeral runners,
+# so the only reason to serialize is to keep CI signal readable.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   # Enable AES/SSE2 CPU features for gxhash dependency (required by PathMap crate)

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -310,6 +310,8 @@ jobs:
           # admin-on-repo scope. RELEASE_PAT is already provisioned with the
           # repo scope (used by the release job) so reuse it here.
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          # Register ephemeral runners on the repo that queued this workflow.
+          GH_REPO: ${{ github.repository }}
           SUPPRESS_LABEL_WARNING: "True"
         run: |
           cd system-integration/ci/oci-runners

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -428,7 +428,7 @@ jobs:
             --deselect integration-tests/test/tests/shared/test_observer_lfs_sync.py \
             --provider=${{ matrix.provider }} \
             -v --tb=short --instafail --maxfail=10 \
-            -n auto --dist=loadgroup --timeout=1200 $SCALE_FLAG
+            -n 8 --dist=loadgroup --timeout=1200 $SCALE_FLAG
 
       - name: Upload Integration Test Logs
         if: always()


### PR DESCRIPTION
## Summary

Rolling branch for fixes that reduce baseline flake rate on the ephemeral OCI integration matrix. Will accumulate small, orthogonal fixes here rather than spinning up a new PR per fix.

This first commit caps pytest-xdist workers at 8. The companion framework changes that this CI exercises (via `refactor/integration-test-framework` of system-integration) are also pulled in by the same workflow run.

Co-Authored-By: Claude <noreply@anthropic.com>